### PR TITLE
CallBase() Solution fixes

### DIFF
--- a/Source/Language/IReturns.cs
+++ b/Source/Language/IReturns.cs
@@ -103,5 +103,11 @@ namespace Moq.Language
 		/// </code>
 		/// </example>
 		IReturnsResult<TMock> Returns<T>(Func<T, TResult> valueFunction);
+
+		/// <summary>
+		/// Calls the real method of the object and returns its return value.
+		/// </summary>
+		/// <returns>The value calculated by the real method of the object.</returns>
+		IReturnsResult<TMock> CallBase();
 	}
 }

--- a/Source/Language/IReturnsGetter.cs
+++ b/Source/Language/IReturnsGetter.cs
@@ -82,5 +82,11 @@ namespace Moq.Language
 		/// that moment.
 		/// </example>
 		IReturnsResult<TMock> Returns(Func<TProperty> valueFunction);
+
+		/// <summary>
+		/// Calls the real property of the object and returns its return value.
+		/// </summary>
+		/// <returns>The value calculated by the real property of the object.</returns>
+		IReturnsResult<TMock> CallBase();
 	}
 }

--- a/Source/Language/ISetupSequentialResult.cs
+++ b/Source/Language/ISetupSequentialResult.cs
@@ -26,5 +26,10 @@ namespace Moq.Language
 		/// </summary>
 		[SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "By Design")]
 		void Throws<TException>() where TException : Exception, new();
+
+		/// <summary>
+		/// Calls original method
+		/// </summary>
+		ISetupSequentialResult<TResult> CallBase();
 	}
 }

--- a/Source/MethodCallReturn.cs
+++ b/Source/MethodCallReturn.cs
@@ -67,6 +67,7 @@ namespace Moq
 	{
 		private Delegate valueDel = (Func<TResult>)(() => default(TResult));
 		private Action<object[]> afterReturnCallback;
+		private bool callBase;
 
 		public MethodCallReturn(Mock mock, Func<bool> condition, Expression originalExpression, MethodInfo method, params Expression[] arguments)
 			: base(mock, condition, originalExpression, method, arguments)
@@ -98,6 +99,12 @@ namespace Moq
 		public IReturnsResult<TMock> Returns(TResult value)
 		{
 			Returns(() => value);
+			return this;
+		}
+
+		public IReturnsResult<TMock> CallBase()
+		{
+			callBase = true;
 			return this;
 		}
 
@@ -155,7 +162,9 @@ namespace Moq
 		{
 			base.Execute(call);
 
-			if (valueDel.Method.GetParameters().Length != 0)
+			if (callBase)
+				call.InvokeBase();
+			else if (valueDel.Method.GetParameters().Length != 0)
 				call.ReturnValue = valueDel.InvokePreserveStack(call.Arguments); //will throw if parameters mismatch
 			else
 				call.ReturnValue = valueDel.InvokePreserveStack(); //we need this, for the user to be able to use parameterless methods

--- a/Source/SetupSequentialContext.cs
+++ b/Source/SetupSequentialContext.cs
@@ -21,6 +21,12 @@ namespace Moq
 			this.expression = expression;
 		}
 
+		public ISetupSequentialResult<TResult> CallBase()
+		{
+			this.EndSetup(GetSetup().CallBase());
+			return this;
+		}
+
 		private ISetup<TMock, TResult> GetSetup()
 		{
 			var expectationStep = this.expectationsCount;

--- a/UnitTests/ReturnsFixture.cs
+++ b/UnitTests/ReturnsFixture.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+
 using Xunit;
 using System.Collections.Generic;
 
@@ -211,6 +212,24 @@ namespace Moq.Tests
 			Assert.Equal(int.MinValue, mock.Object.Value);
 		}
 
+		[Fact]
+		public void ReturnsValueFromBaseMethod()
+		{
+			var mock = new Mock<Foo>();
+			mock.Setup(foo => foo.Execute()).CallBase();
+
+			Assert.Equal("Ok", mock.Object.Execute());
+		}
+
+		[Fact]
+		public void ReturnsValueFromBaseProperty()
+		{
+			var mock = new Mock<Foo>();
+			mock.SetupGet(foo => foo.StringProperty).CallBase();
+
+			Assert.Equal("Text", mock.Object.StringProperty);
+		}
+
 		public interface IFoo
 		{
 			void Execute();
@@ -226,6 +245,19 @@ namespace Moq.Tests
 			IList<int> ReturnIntList();
 
 			int Value { get; set; }
+		}
+
+		public class Foo
+		{
+			public virtual string Execute()
+			{
+				return "Ok";
+			}
+
+			public virtual string StringProperty
+			{
+				get { return "Text"; }
+			}
 		}
 	}
 }

--- a/UnitTests/SequenceExtensionsFixture.cs
+++ b/UnitTests/SequenceExtensionsFixture.cs
@@ -36,10 +36,33 @@ namespace Moq.Tests
 			Assert.Throws<SystemException>(() => temp = mock.Object.Value);
 		}
 
+		[Fact]
+		public void PerformSequenceWithCallBase()
+		{
+			var mock = new Mock<Foo>();
+
+			mock.SetupSequence(x => x.Do())
+				.Returns("Good")
+				.CallBase()
+				.Throws<InvalidOperationException>();
+
+			Assert.Equal("Good", mock.Object.Do());
+			Assert.Equal("Ok", mock.Object.Do());
+			Assert.Throws<InvalidOperationException>(() => mock.Object.Do());
+		}
+
 		public interface IFoo
 		{
 			string Value { get; set; }
 			int Do();
+		}
+
+		public class Foo
+		{
+			public virtual string Do()
+			{
+				return "Ok";
+			}
 		}
 	}
 }


### PR DESCRIPTION
Hello

I have implemented two features and fixed a couple of (minor) bugs:

First I added the option to be able to call the base (original) method for a specific setup – here’s a link where someone else has discussed this request: http://code.google.com/p/moq/issues/detail?id=293

Second I added the option that either Throw() or CallBase() is available within a setup sequence chain – again here’s a link where someone else has discussed this request: http://code.google.com/p/moq/issues/detail?id=319

Finally I adjusted the references in the UnitTest project to match those of the Moq project (I had compiler errors without that fix). I also adjusted the command line for merging the castle library into the moq library because the way it is specified now it will always compile for .NET runtime  4.0 even when the project is set to 3.5 and the 2.0 runtime should be used. And I added a .gitignore because I got tired of all the temp files being listed in my Commit dialogue.

I think the changeset is rather small and self explinatory but I admit that I’m not sure whether all my changes are implemented the best way (kind of tricky to keep the overview over all the interfaces) so maybe improvements are possible? Just get back to me if I can be of any help.

Thanks & kind regards
Sandro
