### PR TITLE
Fix issue #325

### DIFF
--- a/Source/Interceptor.cs
+++ b/Source/Interceptor.cs
@@ -169,7 +169,7 @@ namespace Moq
 					// TODO: validate we can get the event?
 					var eventInfo = this.GetEventFromName(invocation.Method.Name.Substring(4));
 
-					if (this.Mock.CallBase)
+					if (this.Mock.CallBase && !eventInfo.DeclaringType.IsInterface)
 					{
 						invocation.InvokeBase();
 					}
@@ -186,7 +186,7 @@ namespace Moq
 					// TODO: validate we can get the event?
 					var eventInfo = this.GetEventFromName(invocation.Method.Name.Substring(7));
 
-					if (this.Mock.CallBase)
+					if (this.Mock.CallBase && !eventInfo.DeclaringType.IsInterface)
 					{
 						invocation.InvokeBase();
 					}

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -1564,6 +1564,55 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region #325
+
+		public class _325
+		{
+			[Fact]
+			public void SubscribingWorks()
+			{
+				var target = new Mock<Foo> { CallBase = true };
+				target.As<IBar>();
+
+				var bar = (IBar)target.Object;
+				var raised = false;
+				bar.SomeEvent += (sender, e) => raised = true;
+
+				target.As<IBar>().Raise(b => b.SomeEvent += null, EventArgs.Empty);
+
+				Assert.True(raised);
+			}
+
+			[Fact]
+			public void UnsubscribingWorks()
+			{
+				var target = new Mock<Foo> { CallBase = true };
+				target.As<IBar>();
+
+				var bar = (IBar)target.Object;
+				var raised = false;
+				EventHandler handler = (sender, e) => raised = true;
+				bar.SomeEvent += handler;
+				bar.SomeEvent -= handler;
+
+				target.As<IBar>().Raise(b => b.SomeEvent += null, EventArgs.Empty);
+
+				Assert.False(raised);
+			}
+
+			public class Foo
+			{
+			}
+
+			public interface IBar
+			{
+				event EventHandler SomeEvent;
+			}
+
+		}
+
+		#endregion
+
 		#region Recursive issue
 
 		public class RecursiveFixture


### PR DESCRIPTION
Adding (and removing) handlers for events declared on interfaces works
when CallBase = true.
