### PR TITLE
differentiate verification error from mock crash

### DIFF
--- a/Source/MockException.cs
+++ b/Source/MockException.cs
@@ -114,6 +114,14 @@ namespace Moq
 			get { return reason; }
 		}
 
+        /// <summary>
+        /// Indicates whether this exception is a verification fault raised by Verify()
+        /// </summary>
+        public bool IsVerificationError
+        {
+            get { return reason == ExceptionReason.VerificationFailed; }
+        }
+
 		private static string GetMessage(
 			MockBehavior behavior,
 			ICallContext invocation,


### PR DESCRIPTION
When a verification error occurs, the library throws MockException with a proper message. It is OK, but for some corner cases, it would be nicer, if the user code that catches that exception were able to discover whether it is a real error (like mocking nonvirtual method), or just verification failure.

I suppose the best way would be to expose a subclass - VerificationError : MockException to report them, but for the sake of simplicity, I've currently added a trivial MockException.IsVerificationError boolean property
