### PR TITLE
Fix using Mock.Of on objects having properties with private setters

### DIFF
--- a/Source/Linq/MockSetupsBuilder.cs
+++ b/Source/Linq/MockSetupsBuilder.cs
@@ -189,7 +189,7 @@ namespace Moq.Linq
 			// where Mock.Get(foo).SetupProperty(mock => mock.Name, "bar") != null
 
 			// if the property is readonly, we can only do a Setup(...) which is the same as a method setup.
-			if (!propertyInfo.CanWrite)
+			if (!propertyInfo.CanWrite || propertyInfo.GetSetMethod(true).IsPrivate)
 				return ConvertToSetup(targetObject, left, right);
 
 			// This will get up to and including the Mock.Get(foo).Setup(mock => mock.Name) call.

--- a/UnitTests/Linq/QueryableMocksFixture.cs
+++ b/UnitTests/Linq/QueryableMocksFixture.cs
@@ -216,4 +216,38 @@ namespace Moq.Tests
 			bool HasElements(string key1);
 		}
 	}
+
+    public class Foo
+    {
+        protected Foo()
+        {
+        }
+
+        public virtual string Value { get; private set; }
+    }
+
+    public class FooFixture
+    {
+        [Fact]
+        public void Test()
+        {
+            var remote = Mock.Of<Foo>(rt => rt.Value == "foo");
+            Assert.Equal("foo", remote.Value);
+        }
+    }
+
+    public interface IBar
+    {
+        Foo Foo { get; set; }
+    }
+
+    public class BarFixture
+    {
+        [Fact]
+        public void Test()
+        {
+            var remote = Mock.Of<IBar>(rt => rt.Foo.Value == "foo");
+            Assert.Equal("foo", remote.Foo.Value);
+        }
+    }
 }


### PR DESCRIPTION
Fixes #14

I _think_ my fix is valid (I'm basically converting to SetupGet when the setter is private).

@danielkzu the problem was that in MockSetupsBuilder, the `property.DeclaringType` is the _real type_ (`Moq.Tests.Foo`), whereas in `SetupPropery`, the type on which we work is the `FooProxy`. I think there is something going on in DynamicProxy2 (something like: when the setter of a property is private, it's not proxied in the proxy class).
