### PR TITLE
Feature request: It.IsIn(..), It.IsNotIn(...)

### DIFF
--- a/Source/It.cs
+++ b/Source/It.cs
@@ -39,6 +39,8 @@
 // http://www.opensource.org/licenses/bsd-license.php]
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Text.RegularExpressions;
 using System.Diagnostics.CodeAnalysis;
@@ -85,6 +87,30 @@ namespace Moq
 			},
 			() => It.IsInRange(from, to, rangeKind));
 		}
+
+        /// <include file='It.xdoc' path='docs/doc[@for="It.IsIn(enumerable)"]/*'/>
+        public static TValue IsIn<TValue>(IEnumerable<TValue> items)
+        {
+            return Match<TValue>.Create(value => items.Contains(value), () => It.IsIn(items)); 
+        }
+
+        /// <include file='It.xdoc' path='docs/doc[@for="It.IsIn(params)"]/*'/>
+        public static TValue IsIn<TValue>(params TValue[] items)
+        {
+            return Match<TValue>.Create(value => items.Contains(value), () => It.IsIn(items)); 
+        }
+
+        /// <include file='It.xdoc' path='docs/doc[@for="It.IsNotIn(enumerable)"]/*'/>
+        public static TValue IsNotIn<TValue>(IEnumerable<TValue> items)
+        {
+            return Match<TValue>.Create(value => !items.Contains(value), () => It.IsNotIn(items));
+        }
+
+        /// <include file='It.xdoc' path='docs/doc[@for="It.IsNotIn(params)"]/*'/>
+        public static TValue IsNotIn<TValue>(params TValue[] items)
+        {
+            return Match<TValue>.Create(value => !items.Contains(value), () => It.IsNotIn(items));
+        }
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsRegex(regex)"]/*'/>
 		public static string IsRegex(string regex)

--- a/Source/It.xdoc
+++ b/Source/It.xdoc
@@ -74,6 +74,78 @@
 			</code>
 		</example>
 	</doc>
+	<doc for="It.IsIn(enumerable)">
+		<summary>
+			Matches any value that is present in the sequence specified.
+		</summary>
+		<typeparam name="TValue">Type of the argument to check.</typeparam>
+		<param name="items">The sequence of possible values.</param>
+		<example>
+			The following example shows how to expect a method call
+			with an integer argument with value from a list.
+			<code>
+				var values = new List&lt;int&gt; { 1, 2, 3 };
+			
+				mock.Setup(x =&gt; x.HasInventory(
+				It.IsAny&lt;string&gt;(),
+				It.IsIn(values)))
+				.Returns(false);
+			</code>
+		</example>
+	</doc>
+	<doc for="It.IsIn(params)">
+		<summary>
+			Matches any value that is present in the sequence specified.
+		</summary>
+		<typeparam name="TValue">Type of the argument to check.</typeparam>
+		<param name="items">The sequence of possible values.</param>
+		<example>
+			The following example shows how to expect a method call
+			with an integer argument with a value of 1, 2, or 3.
+			<code>
+				mock.Setup(x =&gt; x.HasInventory(
+				It.IsAny&lt;string&gt;(),
+				It.IsIn(1, 2, 3)))
+				.Returns(false);
+			</code>
+		</example>
+	</doc>
+    <doc for="It.IsNotIn(enumerable)">
+		<summary>
+			Matches any value that is not found in the sequence specified.
+		</summary>
+		<typeparam name="TValue">Type of the argument to check.</typeparam>
+		<param name="items">The sequence of disallowed values.</param>
+		<example>
+			The following example shows how to expect a method call
+			with an integer argument with value not found from a list.
+			<code>
+				var values = new List&lt;int&gt; { 1, 2, 3 };
+				
+				mock.Setup(x =&gt; x.HasInventory(
+				It.IsAny&lt;string&gt;(),
+				It.IsNotIn(values)))
+				.Returns(false);
+			</code>
+		</example>
+	</doc>
+	<doc for="It.IsNotIn(params)">
+		<summary>
+			Matches any value that is not found in the sequence specified.
+		</summary>
+		<typeparam name="TValue">Type of the argument to check.</typeparam>
+		<param name="items">The sequence of disallowed values.</param>
+		<example>
+			The following example shows how to expect a method call
+			with an integer argument of any value except 1, 2, or 3.
+			<code>
+				mock.Setup(x =&gt; x.HasInventory(
+				It.IsAny&lt;string&gt;(),
+				It.IsNotIn(1, 2, 3)))
+				.Returns(false);
+			</code>
+		</example>
+	</doc>
 	<doc for="It.IsRegex(regex)">
 		<summary>
 			Matches a string argument if it matches the given regular expression pattern.

--- a/UnitTests/MatchersFixture.cs
+++ b/UnitTests/MatchersFixture.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Text.RegularExpressions;
 using Moq.Matchers;
@@ -56,6 +57,70 @@ namespace Moq.Tests
 			Assert.Equal(2, mock.Object.Echo(7));
 			Assert.Equal(2, mock.Object.Echo(9));
 		}
+
+        [Fact]
+        public void MatchesIsInEnumerable()
+        {
+            var mock = new Mock<IFoo>();
+
+            mock.Setup(x => x.Echo(It.IsIn(Enumerable.Range(1, 5)))).Returns(1);
+            mock.Setup(x => x.Echo(It.IsIn(Enumerable.Range(6, 10)))).Returns(2);
+
+            Assert.Equal(1, mock.Object.Echo(1));
+            Assert.Equal(1, mock.Object.Echo(2));
+            Assert.Equal(1, mock.Object.Echo(5));
+
+            Assert.Equal(2, mock.Object.Echo(7));
+            Assert.Equal(2, mock.Object.Echo(9));
+        }
+
+        [Fact]
+        public void MatchesIsInVariadicParameters()
+        {
+            var mock = new Mock<IFoo>();
+
+            mock.Setup(x => x.Echo(It.IsIn(1, 2, 3, 4, 5))).Returns(1);
+            mock.Setup(x => x.Echo(It.IsIn(6, 7, 8, 9, 10))).Returns(2);
+
+            Assert.Equal(1, mock.Object.Echo(1));
+            Assert.Equal(1, mock.Object.Echo(2));
+            Assert.Equal(1, mock.Object.Echo(5));
+
+            Assert.Equal(2, mock.Object.Echo(7));
+            Assert.Equal(2, mock.Object.Echo(9));
+        }
+
+        [Fact]
+        public void MatchesIsNotInEnumerable()
+        {
+            var mock = new Mock<IFoo>();
+
+            mock.Setup(x => x.Echo(It.IsNotIn(Enumerable.Range(1, 5)))).Returns(1);
+            mock.Setup(x => x.Echo(It.IsNotIn(Enumerable.Range(6, 10)))).Returns(2);
+
+            Assert.Equal(2, mock.Object.Echo(1));
+            Assert.Equal(2, mock.Object.Echo(2));
+            Assert.Equal(2, mock.Object.Echo(5));
+
+            Assert.Equal(1, mock.Object.Echo(7));
+            Assert.Equal(1, mock.Object.Echo(9));
+        }
+
+        [Fact]
+        public void MatchesIsNotInVariadicParameters()
+        {
+            var mock = new Mock<IFoo>();
+
+            mock.Setup(x => x.Echo(It.IsNotIn(1, 2, 3, 4, 5))).Returns(1);
+            mock.Setup(x => x.Echo(It.IsNotIn(6, 7, 8, 9, 10))).Returns(2);
+
+            Assert.Equal(2, mock.Object.Echo(1));
+            Assert.Equal(2, mock.Object.Echo(2));
+            Assert.Equal(2, mock.Object.Echo(5));
+
+            Assert.Equal(1, mock.Object.Echo(7));
+            Assert.Equal(1, mock.Object.Echo(9));
+        }
 
 		[Fact]
 		public void DoesNotMatchOutOfRange()


### PR DESCRIPTION
Hi, I would like to request a Rhino Mocks feature be ported to Moq that allows parameter matching from a collection when setting up calls.

``` csharp
// IEnumerable<TValue>
mock.Setup(x => x.Echo(It.IsIn(Enumerable.Range(1, 5)))).Returns(1);

// Variadic params
mock.Setup(x => x.Echo(It.IsIn(1, 2, 3, 4, 5))).Returns(1);

// As well as the inverses
mock.Setup(x => x.Echo(It.IsNotIn(Enumerable.Range(1, 5)))).Returns(1);
mock.Setup(x => x.Echo(It.IsNotIn(1, 2, 3, 4, 5))).Returns(1);
```

At work I have done this by hand more times than I can remember so I figured I may as well submit a patch and make it official!

Here it is as a pull request as requested (I originally raised it [here](http://code.google.com/p/moq/issues/detail?id=338) as a patch on Google code).
