### PR TITLE
Add support to change the default behavior

### DIFF
--- a/Source/Mock.Generic.cs
+++ b/Source/Mock.Generic.cs
@@ -75,14 +75,14 @@ namespace Moq
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.ctor()"]/*'/>
 		[SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors")]
 		public Mock()
-			: this(MockBehavior.Default)
+			: this(Mock.DefaultBehavior)
 		{
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.ctor(object[])"]/*'/>
 		[SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors")]
 		public Mock(params object[] args)
-			: this(MockBehavior.Default, args)
+            : this(Mock.DefaultBehavior, args)
 		{
 		}
 

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -65,6 +65,13 @@ namespace Moq
 			this.ImplementedInterfaces = new List<Type>();
 			this.InnerMocks = new Dictionary<MethodInfo, Mock>();
 		}
+        /// <summary>
+        /// Initializes the plumbing common for every instance of <see cref="Mock"/> or <see cref="Mock{T}"/>.
+        /// </summary>
+	    static Mock()
+	    {
+	        DefaultBehavior = MockBehavior.Default;    
+	    }
 
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.Get"]/*'/>
 		public static Mock<T> Get<T>(T mocked) where T : class
@@ -199,7 +206,15 @@ namespace Moq
 		/// </summary>
 		internal List<Type> ImplementedInterfaces { get; private set; }
 
-		#region Verify
+        /// <summary>
+        /// Exposes the default behavior for every subsequent mocks created without specifying the behavior explicitly.
+        /// </summary>
+        /// <remarks>
+        /// Default value is <see cref="MockBehavior.Default"/>.
+        /// </remarks>
+	    public static MockBehavior DefaultBehavior { get; set; }
+
+	    #region Verify
 
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.Verify"]/*'/>
 		[SuppressMessage("Microsoft.Usage", "CA2200:RethrowToPreserveStackDetails", Justification = "We want to explicitly reset the stack trace here.")]

--- a/UnitTests/MockFixture.cs
+++ b/UnitTests/MockFixture.cs
@@ -6,6 +6,76 @@ namespace Moq.Tests
 {
 	public class MockFixture
 	{
+        [Fact]
+        public void CreatesLooseMockWithDefaultCtor()
+        {
+            var disposableMock = new Mock<IDisposable>();
+            Assert.DoesNotThrow(              
+                () =>
+                    {
+                        disposableMock.Object.Dispose();
+                    });
+        }
+
+        [Fact]
+        public void CreatesLooseMockWithLooseBehaviorInjectedInCtor()
+        {
+            var disposableMock = new Mock<IDisposable>(MockBehavior.Loose);
+            Assert.DoesNotThrow(
+                () =>
+                {
+                    disposableMock.Object.Dispose();
+                });
+        }
+
+        [Fact]
+        public void CreatesLooseMockWithLooseBehaviorInjectedInCtorAfterSettingStrictDefaultBehavior()
+        {
+            Mock.DefaultBehavior = MockBehavior.Strict;
+            var disposableMock = new Mock<IDisposable>(MockBehavior.Loose);            
+            Assert.DoesNotThrow(
+                () =>
+                {
+                    disposableMock.Object.Dispose();
+                });
+        }
+
+        [Fact]
+        public void CreatesStrictMockWithDefaultCtorAfterSettingStrictDefaultBehavior()
+        {
+            Mock.DefaultBehavior = MockBehavior.Strict;
+            var disposableMock = new Mock<IDisposable>();
+            Assert.Throws<MockException>(
+                () =>
+                {
+                    disposableMock.Object.Dispose();
+                });
+        }
+
+        [Fact]
+        public void CreatesStrictMockWithStrictBehaviorInjectedInCtorAfterSettingStrictDefaultBehavior()
+        {
+            Mock.DefaultBehavior = MockBehavior.Strict;
+            var disposableMock = new Mock<IDisposable>(MockBehavior.Strict);
+            Assert.Throws<MockException>(
+                () =>
+                {
+                    disposableMock.Object.Dispose();
+                });
+        }
+
+        [Fact]
+        public void CreatesStrictMockWithStrictBehaviorInjectedInCtorAfterSettingLooseDefaultBehavior()
+        {
+            Mock.DefaultBehavior = MockBehavior.Loose;
+            var disposableMock = new Mock<IDisposable>(MockBehavior.Strict);
+            Assert.Throws<MockException>(
+                () =>
+                {
+                    disposableMock.Object.Dispose();
+                });
+        }
+
 		[Fact]
 		public void CreatesMockAndExposesInterface()
 		{


### PR DESCRIPTION
Right now, the default behavior cannot be changed. Instead, it must be specified for every single mock instantiation.

When a team chooses to work only with Strict behavior, it has no other options than explicitly calling the constructor by specifying that the behavior to use is Strict.

Since this can be error prone and time consuming, it would be ideal to set once and for all the default behavior to use for every subsequent mock instantiation.

This pull request contains a fix which will address this issue, while still retaining the current behavior.

The pull request also contains the tests defining the new specifications for the mechanism introduced.
