### PR TITLE
Fixed collection modified exception thrown as result of more methods bei...

### DIFF
--- a/Source/Interceptor.cs
+++ b/Source/Interceptor.cs
@@ -70,7 +70,13 @@ namespace Moq
 
 		internal IEnumerable<ICallContext> ActualCalls
 		{
-			get { return this.actualInvocations; }
+			get
+			{
+			    lock (actualInvocations)
+			    {
+                    return this.actualInvocations.ToArray();
+			    }
+			}
 		}
 
 		internal Mock Mock { get; private set; }
@@ -204,7 +210,10 @@ namespace Moq
 					// mode we use to evaluate delegates by actually running them, 
 					// we don't want to count the invocation, or actually run 
 					// previous setups.
-					actualInvocations.Add(invocation);
+				    lock (actualInvocations)
+				    {
+				        actualInvocations.Add(invocation);
+				    }
 				}
 
 				var call = FluentMockContext.IsActive ? (IProxyCall)null : orderedCalls.LastOrDefault(c => c.Matches(invocation));

--- a/UnitTests/VerifyFixture.cs
+++ b/UnitTests/VerifyFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Moq;
 using Xunit;
+using System.Threading.Tasks;
 
 namespace Moq.Tests
 {
@@ -874,6 +875,17 @@ namespace Moq.Tests
             mock.Object.Call(new BazParam2());
 
             mock.Verify(foo => foo.Call(It.IsAny<IBazParam>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public void DoesNotThrowCollectionModifiedWhenMoreInvocationsInterceptedDuringVerfication()
+        {
+            var mock = new Mock<IFoo>();
+            Parallel.For(0, 100, (i) =>
+                {
+                    mock.Object.Submit();
+                    mock.Verify(foo => foo.Submit());
+                });
         }
 
 		public interface IBar


### PR DESCRIPTION
...ng called on a mock while verifying method calls

This issue is caused when you call verify on a mock and another thread calls any method on that mock while verify is still executing.
