### PR TITLE
Matcher should always work with the whole expression, including Convert

### DIFF
--- a/Source/MatcherFactory.cs
+++ b/Source/MatcherFactory.cs
@@ -99,19 +99,19 @@ namespace Moq
 				if (attr != null)
 				{
 					var matcher = attr.CreateMatcher();
-					matcher.Initialize(expression);
+					matcher.Initialize(originalExpression);
 					return matcher;
 				}
 				else if (staticMatcherMethodAttr != null)
 				{
 					var matcher = new MatcherAttributeMatcher();
-					matcher.Initialize(expression);
+					matcher.Initialize(originalExpression);
 					return matcher;
 				}
 				else
 				{
 					var matcher = new LazyEvalMatcher();
-					matcher.Initialize(expression);
+					matcher.Initialize(originalExpression);
 					return matcher;
 				}
 			}

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -1889,5 +1889,25 @@ namespace Moq.Tests.Regressions
 #endif
 
         #endregion
+
+        #region Matcher should work with Convert
+
+        public class MatcherConvertFixture
+        {
+            public interface IFoo
+            {
+                string M(long l);
+            }
+
+            [Fact]
+            public void MatcherDoesNotIgnoreConvert()
+            {
+                var mock = new Mock<IFoo>(MockBehavior.Strict);
+                mock.Setup(x => x.M(int.Parse("2"))).Returns("OK");
+                Assert.Equal("OK", mock.Object.M(2L));
+            }
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Without this change, the following code doesn't work correctly,
because the passed in long is compared against int.

```
interface IFoo
{
    string M(long l);
}

var mock = new Mock<IFoo>(MockBehavior.Strict);
mock.Setup(x => x.M(int.Parse("2"))).Returns("OK");
var result = mock.Object.M(2L);
```

This commit is based on a [SO question](http://stackoverflow.com/q/18876436/41071) that asked about this.
