### PR TITLE
Avoid NullReferenceException with async methods

### DIFF
--- a/Source/EmptyDefaultValueProvider.cs
+++ b/Source/EmptyDefaultValueProvider.cs
@@ -43,7 +43,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+#if !NET3x
 using System.Threading.Tasks;
+#endif
 
 namespace Moq
 {
@@ -87,11 +89,13 @@ namespace Moq
 			{
 				return new object[0].AsQueryable();
 			}
+#if !NET3x
 			else if (valueType == typeof(Task))
 			{
 				// Task<T> inherits from Task, so just return Task<bool>
 				return GetCompletedTaskWithResult(false);
 			}
+#endif
 			else if (valueType.IsGenericType && valueType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
 			{
 				var genericListType = typeof(List<>).MakeGenericType(valueType.GetGenericArguments()[0]);
@@ -107,6 +111,7 @@ namespace Moq
 					.MakeGenericMethod(genericType)
 					.Invoke(null, new[] { Activator.CreateInstance(genericListType) });
 			}
+#if !NET3x
 			else if (valueType.IsGenericType && valueType.GetGenericTypeDefinition() == typeof(Task<>))
 			{
 				var genericType = valueType.GetGenericArguments()[0];
@@ -114,6 +119,7 @@ namespace Moq
 				return GetCompletedTaskWithResult(
 					genericType.IsValueType ? GetValueTypeDefault(genericType) : GetReferenceTypeDefault(genericType));
 			}
+#endif
 
 			return null;
 		}
@@ -129,6 +135,7 @@ namespace Moq
 			return Activator.CreateInstance(valueType);
 		}
 
+#if !NET3x
 		private static Task GetCompletedTaskWithResult(object result)
 		{
 			var type = result.GetType();
@@ -140,5 +147,6 @@ namespace Moq
 			setResultMethod.Invoke(tcs, new[] {result});
 			return (Task) taskProperty.GetValue(tcs, null);
 		}
+#endif
 	}
 }

--- a/Source/Language/IReturnsExtensions.cs
+++ b/Source/Language/IReturnsExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !NET3x
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -34,3 +35,4 @@ namespace Moq.Language.Flow
         }
     }
 }
+#endif

--- a/UnitTests/EmptyDefaultValueProviderFixture.cs
+++ b/UnitTests/EmptyDefaultValueProviderFixture.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+#if !NET3x
 using System.Threading.Tasks;
+#endif
 using Xunit;
 
 namespace Moq.Tests
@@ -108,6 +110,7 @@ namespace Moq.Tests
 			Assert.Equal(0, ((IQueryable)value).Cast<object>().Count());
 		}
 
+#if !NET3x
 		[Fact]
 		public void ProvidesDefaultTask()
 		{
@@ -142,6 +145,7 @@ namespace Moq.Tests
 			Assert.True(((Task)value).IsCompleted);
 			Assert.Equal(default(int), ((Task<Task<int>>) value).Result.Result);
 		}
+#endif
 
 		public interface IFoo
 		{
@@ -156,9 +160,11 @@ namespace Moq.Tests
 			IBar[] Bars { get; set; }
 			IQueryable<int> Queryable { get; }
 			IQueryable QueryableObjects { get; }
+#if !NET3x
 			Task TaskValue { get; set; }
 			Task<int> GenericTaskValue { get; set; }
 			Task<Task<int>> TaskOfGenericTaskValue { get; set; }
+#endif
 		}
 
 		public interface IBar { }


### PR DESCRIPTION
When using async methods and loose Mock Behavior, calls to `Task` methods give `NullReferenceException`, since `default(Task)` is `null`. Calls to `Task.Wait()` and `Task<T>.Result` should follow the loose behavior: do nothing and return the default value for `T`, respectively.

Related to #64.
