### PR TITLE
Fixing #62 - Multithreaded test not working

### DIFF
--- a/Source/IInterceptStrategy.cs
+++ b/Source/IInterceptStrategy.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Moq.Proxy;
+using System.Reflection;
 
 namespace Moq
 {
@@ -26,28 +27,115 @@ namespace Moq
 
 	internal class InterceptStrategyContext
 	{
-		public InterceptStrategyContext(Mock Mock
-										, Type targetType
-										, Dictionary<string, List<Delegate>> invocationLists
-										, List<ICallContext> actualInvocations
-										, MockBehavior behavior
-										, List<IProxyCall> orderedCalls
-			)
+		private Dictionary<string, List<Delegate>> invocationLists = new Dictionary<string, List<Delegate>>();
+		private List<ICallContext> actualInvocations = new List<ICallContext>();
+		private List<IProxyCall> orderedCalls = new List<IProxyCall>();
+
+		public InterceptStrategyContext(Mock Mock, Type targetType, MockBehavior behavior)
 		{
 			this.Behavior = behavior;
 			this.Mock = Mock;
-			this.InvocationLists = invocationLists;
-			this.ActualInvocations = actualInvocations;
 			this.TargetType = targetType;
-			this.OrderedCalls = orderedCalls;
 		}
-		public Mock Mock {get;private set;}
+		public Mock Mock { get; private set; }
 		public Type TargetType { get; private set; }
-		public Dictionary<string, List<Delegate>> InvocationLists { get; private set; }
-		public List<ICallContext> ActualInvocations { get; private set; }
 		public MockBehavior Behavior { get; private set; }
-		public List<IProxyCall> OrderedCalls { get; private set; }
 		public IProxyCall CurrentCall { get; set; }
+		
+		#region InvocationLists
+		internal IEnumerable<Delegate> GetInvocationList(EventInfo ev)
+		{
+			lock (invocationLists)
+			{
+				List<Delegate> handlers;
+				if (!invocationLists.TryGetValue(ev.Name, out handlers))
+				{
+					return new Delegate[0];
+				}
+
+				return handlers.ToList();
+			}
+		}
+
+		internal void AddEventHandler(EventInfo ev, Delegate handler)
+		{
+			lock (invocationLists)
+			{
+				List<Delegate> handlers;
+				if (!invocationLists.TryGetValue(ev.Name, out handlers))
+				{
+					handlers = new List<Delegate>();
+					invocationLists.Add(ev.Name, handlers);
+				}
+
+				handlers.Add(handler);
+			}
+		}
+		internal void RemoveEventHandler(EventInfo ev, Delegate handler)
+		{
+			lock (invocationLists)
+			{
+				List<Delegate> handlers;
+				if (invocationLists.TryGetValue(ev.Name, out handlers))
+				{
+					handlers.Remove(handler);
+				}
+			}
+		}
+		#endregion
+		#region ActualInvocations
+		internal void AddInvocation(ICallContext invocation)
+		{
+			lock (actualInvocations)
+			{
+				actualInvocations.Add(invocation);
+			}
+		}
+		internal IEnumerable<ICallContext> ActualInvocations
+		{
+			get
+			{
+				lock (actualInvocations)
+				{
+					return actualInvocations.ToList();
+				}
+			}
+		}
+		internal void ClearInvocations()
+		{
+			lock (actualInvocations)
+			{
+				actualInvocations.Clear();
+			}
+		}
+		#endregion
+		#region OrderedCalls
+		internal void AddOrderedCall(IProxyCall call)
+		{
+			lock (orderedCalls)
+			{
+				orderedCalls.Add(call);
+			}
+		}
+		internal void RemoveOrderedCall(IProxyCall call)
+		{
+			lock (orderedCalls)
+			{
+				orderedCalls.Remove(call);
+			}
+		}
+		internal IEnumerable<IProxyCall> OrderedCalls
+		{
+			get
+			{
+				lock (orderedCalls)
+				{
+					return orderedCalls.ToList();
+				}
+			}
+		}
+		#endregion
+
 	}
 
 }

--- a/Source/InterceptorStrategies.cs
+++ b/Source/InterceptorStrategies.cs
@@ -233,26 +233,7 @@ namespace Moq
             }
 
             return initialType.GetInterfaces();
-        }
-        internal void AddEventHandler(EventInfo ev, Delegate handler)
-        {
-            List<Delegate> handlers;
-            if (!ctx.InvocationLists.TryGetValue(ev.Name, out handlers))
-            {
-                handlers = new List<Delegate>();
-                ctx.InvocationLists.Add(ev.Name, handlers);
-            }
-
-            handlers.Add(handler);
-        }
-        internal void RemoveEventHandler(EventInfo ev, Delegate handler)
-        {
-            List<Delegate> handlers;
-            if (ctx.InvocationLists.TryGetValue(ev.Name, out handlers))
-            {
-                handlers.Remove(handler);
-            }
-        }
+        }        
         InterceptStrategyContext ctx;
         public InterceptionAction HandleIntercept(ICallContext invocation, InterceptStrategyContext ctx)
         {
@@ -272,7 +253,7 @@ namespace Moq
                     }
                     else if (delegateInstance != null)
                     {
-                        this.AddEventHandler(eventInfo, (Delegate)invocation.Arguments[0]);
+                        ctx.AddEventHandler(eventInfo, (Delegate)invocation.Arguments[0]);
                     }
 
                     return InterceptionAction.Stop;
@@ -289,7 +270,7 @@ namespace Moq
                     }
                     else if (delegateInstance != null)
                     {
-                        this.RemoveEventHandler(eventInfo, (Delegate)invocation.Arguments[0]);
+                        ctx.RemoveEventHandler(eventInfo, (Delegate)invocation.Arguments[0]);
                     }
 
                     return InterceptionAction.Stop;
@@ -300,7 +281,7 @@ namespace Moq
                 // mode we use to evaluate delegates by actually running them, 
                 // we don't want to count the invocation, or actually run 
                 // previous setups.
-                ctx.ActualInvocations.Add(invocation);
+                ctx.AddInvocation(invocation);
             }
             return InterceptionAction.Continue;
         }

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -353,13 +353,12 @@ namespace Moq
             Expression expression,
             Times times)
         {
-            // .Where does an enumeration, and calls to a mocked method concurrent to VerifyCalls might change the content of ActualCalls. therefore, it is necessary to take a snapshot, using ToList(), so that concurrent calls will not impact the ongoing verification.
-            var actualCalls = targetInterceptor.ActualCalls.ToList();
+			IEnumerable<ICallContext> actualCalls = targetInterceptor.InterceptionContext.ActualInvocations;
 
             var callCount = actualCalls.Where(ac => expected.Matches(ac)).Count();
             if (!times.Verify(callCount))
             {
-                var setups = targetInterceptor.OrderedCalls.Where(oc => AreSameMethod(oc.SetupExpression, expression));
+				var setups = targetInterceptor.InterceptionContext.OrderedCalls.Where(oc => AreSameMethod(oc.SetupExpression, expression));
                 ThrowVerifyException(expected, setups, actualCalls, expression, times, callCount);
             }
         }
@@ -913,7 +912,7 @@ namespace Moq
                 throw new InvalidOperationException(Resources.RaisedUnassociatedEvent);
             }
 
-            foreach (var del in this.Interceptor.GetInvocationList(ev).ToArray())
+            foreach (var del in this.Interceptor.InterceptionContext.GetInvocationList(ev).ToArray())
             {
                 del.InvokePreserveStack(this.Object, args);
             }
@@ -930,7 +929,7 @@ namespace Moq
                 throw new InvalidOperationException(Resources.RaisedUnassociatedEvent);
             }
 
-            foreach (var del in this.Interceptor.GetInvocationList(ev).ToArray())
+			foreach (var del in this.Interceptor.InterceptionContext.GetInvocationList(ev).ToArray())
             {
                 // Non EventHandler-compatible delegates get the straight 
                 // arguments, not the typical "sender, args" arguments.

--- a/Source/MockExtensions.cs
+++ b/Source/MockExtensions.cs
@@ -24,8 +24,7 @@ namespace Moq
         /// <param name="mock">The mock whose calls need to be reset.</param>
         public static void ResetCalls(this Mock mock) 
         {
-            var calls = (IList<ICallContext>)mock.Interceptor.ActualCalls;
-            calls.Clear();
+			mock.Interceptor.InterceptionContext.ClearInvocations();
         } 
     }
 }


### PR DESCRIPTION
I've got some code which fixes Issues 47 and 62.  I've done a bit of a refactor of the handling of the context in the Interceptor, this means we have one place that looks after access to the collections, and therefore one place for the locking.  Hope the whitespace and line endings are all intact, took longer than the code changes to get it this neat!

None of the repos for google code issue 247 fail anymore, they all progress past the collection access problems and either slowly finish or hit out of memory exceptions that were already there.
