### PR TITLE
InSequence-Setups can now be used on the same mock instance.

### DIFF
--- a/Source/ConditionalContext.cs
+++ b/Source/ConditionalContext.cs
@@ -38,10 +38,10 @@
 //[This is the BSD license, see
 // http://www.opensource.org/licenses/bsd-license.php]
 
-using System;
-using System.Linq.Expressions;
 using Moq.Language;
 using Moq.Language.Flow;
+using System;
+using System.Linq.Expressions;
 
 namespace Moq
 {
@@ -49,9 +49,9 @@ namespace Moq
 		where T : class
 	{
 		private Mock<T> mock;
-		private Func<bool> condition;
+		private Condition condition;
 
-		public ConditionalContext(Mock<T> mock, Func<bool> condition)
+		public ConditionalContext(Mock<T> mock, Condition condition)
 		{
 			this.mock = mock;
 			this.condition = condition;

--- a/Source/MethodCall.cs
+++ b/Source/MethodCall.cs
@@ -38,6 +38,11 @@
 //[This is the BSD license, see
 // http://www.opensource.org/licenses/bsd-license.php]
 
+using Moq.Language;
+using Moq.Language.Flow;
+using Moq.Matchers;
+using Moq.Properties;
+using Moq.Proxy;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -48,18 +53,13 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
-using Moq.Language;
-using Moq.Language.Flow;
-using Moq.Matchers;
-using Moq.Properties;
-using Moq.Proxy;
 
 namespace Moq
 {
 	internal partial class MethodCall<TMock> : MethodCall, ISetup<TMock>
 		where TMock : class
 	{
-		public MethodCall(Mock mock, Func<bool> condition, Expression originalExpression, MethodInfo method,
+		public MethodCall(Mock mock, Condition condition, Expression originalExpression, MethodInfo method,
 			params Expression[] arguments)
 			: base(mock, condition, originalExpression, method, arguments)
 		{
@@ -81,20 +81,20 @@ namespace Moq
 		}
 	}
 
-    internal class TypeEqualityComparer : IEqualityComparer<Type>
-    {
-        public bool Equals(Type x, Type y)
-        {
-            return y.IsAssignableFrom(x);
-        }
+	internal class TypeEqualityComparer : IEqualityComparer<Type>
+	{
+		public bool Equals(Type x, Type y)
+		{
+			return y.IsAssignableFrom(x);
+		}
 
-        public int GetHashCode(Type obj)
-        {
-            return obj.GetHashCode();
-        }
-    }
+		public int GetHashCode(Type obj)
+		{
+			return obj.GetHashCode();
+		}
+	}
 
-    internal partial class MethodCall : IProxyCall, ICallbackResult, IVerifies, IThrowsResult
+	internal partial class MethodCall : IProxyCall, ICallbackResult, IVerifies, IThrowsResult
 	{
 		// Internal for AsMockExtensions
 		private Expression originalExpression;
@@ -106,11 +106,11 @@ namespace Moq
 		private Delegate mockEventArgsFunc;
 		private object[] mockEventArgsParams;
 		private int? expectedCallCount = null;
-		protected Func<bool> condition;
+		protected Condition condition;
 		private List<KeyValuePair<int, object>> outValues = new List<KeyValuePair<int, object>>();
-	    private static readonly IEqualityComparer<Type> typesComparer = new TypeEqualityComparer();
+		private static readonly IEqualityComparer<Type> typesComparer = new TypeEqualityComparer();
 
-	    public MethodCall(Mock mock, Func<bool> condition, Expression originalExpression, MethodInfo method, params Expression[] arguments)
+		public MethodCall(Mock mock, Condition condition, Expression originalExpression, MethodInfo method, params Expression[] arguments)
 		{
 			this.Mock = mock;
 			this.condition = condition;
@@ -218,7 +218,7 @@ namespace Moq
 
 		public virtual bool Matches(ICallContext call)
 		{
-			if (condition != null && !condition())
+			if (condition != null && !condition.IsTrue)
 			{
 				return false;
 			}
@@ -243,6 +243,8 @@ namespace Moq
 					}
 				}
 
+				if (condition != null)
+					condition.EvaluatedSuccessfully();
 				return true;
 			}
 
@@ -377,13 +379,13 @@ namespace Moq
 			{
 				if (!this.Method.Name.Equals(call.Method.Name, StringComparison.Ordinal) ||
 					this.Method.ReturnType != call.Method.ReturnType ||
-                    !this.Method.IsGenericMethod &&
+					!this.Method.IsGenericMethod &&
 					!call.Method.GetParameterTypes().SequenceEqual(this.Method.GetParameterTypes()))
 				{
 					return false;
 				}
 
-				if (Method.IsGenericMethod && !call.Method.GetGenericArguments().SequenceEqual(Method.GetGenericArguments(),typesComparer))
+				if (Method.IsGenericMethod && !call.Method.GetGenericArguments().SequenceEqual(Method.GetGenericArguments(), typesComparer))
 				{
 					return false;
 				}
@@ -446,6 +448,35 @@ namespace Moq
 			}
 
 			return message.ToString().Trim();
+		}
+	}
+
+	internal class Condition
+	{
+		private readonly Func<bool> mCondition;
+		private readonly Action mSuccess;
+
+		public Condition(Func<bool> condition, Action success = null)
+		{
+			mCondition = condition;
+			mSuccess = success;
+		}
+
+		public bool IsTrue
+		{
+			get
+			{
+				if (mCondition != null)
+					return mCondition();
+				else
+					return false;
+			}
+		}
+
+		public void EvaluatedSuccessfully()
+		{
+			if (mSuccess != null)
+				mSuccess();
 		}
 	}
 }

--- a/Source/MethodCallReturn.cs
+++ b/Source/MethodCallReturn.cs
@@ -38,12 +38,12 @@
 //[This is the BSD license, see
 // http://www.opensource.org/licenses/bsd-license.php]
 
-using System;
-using System.Linq.Expressions;
-using System.Reflection;
 using Moq.Language;
 using Moq.Language.Flow;
 using Moq.Proxy;
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
 
 namespace Moq
 {
@@ -54,7 +54,7 @@ namespace Moq
 	/// </devdoc>
 	internal class MethodCallReturn : MethodCall
 	{
-		public MethodCallReturn(Mock mock, Func<bool> condition, Expression originalExpression, MethodInfo method, params Expression[] arguments)
+		public MethodCallReturn(Mock mock, Condition condition, Expression originalExpression, MethodInfo method, params Expression[] arguments)
 			: base(mock, condition, originalExpression, method, arguments)
 		{
 		}
@@ -69,7 +69,7 @@ namespace Moq
 		private Action<object[]> afterReturnCallback;
 		private bool callBase;
 
-		public MethodCallReturn(Mock mock, Func<bool> condition, Expression originalExpression, MethodInfo method, params Expression[] arguments)
+		public MethodCallReturn(Mock mock, Condition condition, Expression originalExpression, MethodInfo method, params Expression[] arguments)
 			: base(mock, condition, originalExpression, method, arguments)
 		{
 			this.HasReturnValue = false;

--- a/Source/Mock.Generic.cs
+++ b/Source/Mock.Generic.cs
@@ -281,6 +281,11 @@ namespace Moq
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.When"]/*'/>
 		public ISetupConditionResult<T> When(Func<bool> condition)
 		{
+			return When(new Condition(condition));
+		}
+
+		internal ISetupConditionResult<T> When(Condition condition)
+		{
 			return new ConditionalContext<T>(this, condition);
 		}
 

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -38,6 +38,8 @@
 //[This is the BSD license, see
 // http://www.opensource.org/licenses/bsd-license.php]
 
+using Moq.Properties;
+using Moq.Proxy;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -46,8 +48,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using Moq.Properties;
-using Moq.Proxy;
 
 namespace Moq
 {
@@ -231,7 +231,7 @@ namespace Moq
             }
         }
 
-        /// <include file='Mock.xdoc' path='docs/doc[@for="Mock.VerifyAll"]/*'/>		
+        /// <include file='Mock.xdoc' path='docs/doc[@for="Mock.VerifyAll"]/*'/>        
         [SuppressMessage("Microsoft.Usage", "CA2200:RethrowToPreserveStackDetails", Justification = "We want to explicitly reset the stack trace here.")]
         public void VerifyAll()
         {
@@ -419,7 +419,7 @@ namespace Moq
 
         #region Setup
 
-        internal static MethodCall<T> Setup<T>(Mock<T> mock, Expression<Action<T>> expression, Func<bool> condition)
+        internal static MethodCall<T> Setup<T>(Mock<T> mock, Expression<Action<T>> expression, Condition condition)
             where T : class
         {
             return PexProtector.Invoke(() =>
@@ -443,7 +443,7 @@ namespace Moq
         internal static MethodCallReturn<T, TResult> Setup<T, TResult>(
             Mock<T> mock,
             Expression<Func<T, TResult>> expression,
-            Func<bool> condition)
+            Condition condition)
             where T : class
         {
             return PexProtector.Invoke(() =>
@@ -472,7 +472,7 @@ namespace Moq
         internal static MethodCallReturn<T, TProperty> SetupGet<T, TProperty>(
             Mock<T> mock,
             Expression<Func<T, TProperty>> expression,
-            Func<bool> condition)
+            Condition condition)
             where T : class
         {
             return PexProtector.Invoke(() =>
@@ -502,7 +502,7 @@ namespace Moq
         internal static SetterMethodCall<T, TProperty> SetupSet<T, TProperty>(
             Mock<T> mock,
             Action<T> setterExpression,
-            Func<bool> condition)
+            Condition condition)
             where T : class
         {
             return PexProtector.Invoke(() =>
@@ -519,7 +519,7 @@ namespace Moq
             });
         }
 
-        internal static MethodCall<T> SetupSet<T>(Mock<T> mock, Action<T> setterExpression, Func<bool> condition)
+        internal static MethodCall<T> SetupSet<T>(Mock<T> mock, Action<T> setterExpression, Condition condition)
             where T : class
         {
             return PexProtector.Invoke(() =>

--- a/Source/MockSequence.cs
+++ b/Source/MockSequence.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Moq.Language;
+﻿using Moq.Language;
 
 namespace Moq
 {
@@ -40,18 +36,9 @@ namespace Moq
 		{
 			var expectationPosition = sequenceLength++;
 
-			// HACK assume condition is only
-			// evaluated once. issues to attach callback lately.
-			return mock.When(() =>
-			{
-				var c = expectationPosition == sequenceStep;
-				if (c)
-				{
-					this.NextStep();
-				}
-
-				return c;
-			});
+			return mock.When(new Condition(
+			   condition: () => expectationPosition == sequenceStep,
+			   success: NextStep));
 		}
 	}
 

--- a/Source/SetterMethodCall.cs
+++ b/Source/SetterMethodCall.cs
@@ -38,11 +38,11 @@
 //[This is the BSD license, see
 // http://www.opensource.org/licenses/bsd-license.php]
 
+using Moq.Language.Flow;
+using Moq.Protected;
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
-using Moq.Language.Flow;
-using Moq.Protected;
 
 namespace Moq
 {
@@ -59,7 +59,7 @@ namespace Moq
 		{
 		}
 
-		public SetterMethodCall(Mock mock, Func<bool> condition, Expression originalExpression, MethodInfo method, Expression value)
+		public SetterMethodCall(Mock mock, Condition condition, Expression originalExpression, MethodInfo method, Expression value)
 			: base(mock, condition, originalExpression, method, new[] { value })
 		{
 		}

--- a/UnitTests/MockSequenceFixture.cs
+++ b/UnitTests/MockSequenceFixture.cs
@@ -68,6 +68,33 @@ namespace Moq.Tests
 			Assert.Equal(201, b.Object.Do(200));
 		}
 
+		[Fact]
+		public void SameMockRightSequenceSuccess()
+		{
+			var a = new Mock<IFoo>(MockBehavior.Strict);
+
+			var sequence = new MockSequence();
+			a.InSequence(sequence).Setup(x => x.Do(100)).Returns(101);
+			a.InSequence(sequence).Setup(x => x.Do(200)).Returns(201);
+
+			Assert.Equal(101, a.Object.Do(100));
+			Assert.Equal(201, a.Object.Do(200));
+			Assert.Throws<MockException>(() => a.Object.Do(100));
+			Assert.Throws<MockException>(() => a.Object.Do(200));
+		}
+
+		[Fact]
+		public void SameMockInvalidSequenceFail()
+		{
+			var a = new Mock<IFoo>(MockBehavior.Strict);
+
+			var sequence = new MockSequence();
+			a.InSequence(sequence).Setup(x => x.Do(100)).Returns(101);
+			a.InSequence(sequence).Setup(x => x.Do(200)).Returns(201);
+
+			Assert.Throws<MockException>(() => a.Object.Do(200));
+		}
+
 		public interface IFoo
 		{
 			int Do(int arg);


### PR DESCRIPTION
The MockSequence conditional can now be evaluated many times without side effects because the side effect can be triggered explicitly.

I basically separated the evaluation of the condition and the side effect

``` csharp
// HACK assume condition is only
// evaluated once. issues to attach callback lately.
return mock.When(() =>
{
   var c = expectationPosition == sequenceStep;
   if (c)
   {
      this.NextStep();
   }
   return c;
});
```

to look like

``` csharp
return mock.When(new Condition(
   condition: () => expectationPosition == sequenceStep,
   success: NextStep));
```

In order to verify, I added these two tests

``` csharp
[Fact]
public void SameMockRightSequenceSuccess()
{
    var a = new Mock<IFoo>(MockBehavior.Strict);

    var sequence = new MockSequence();
    a.InSequence(sequence).Setup(x => x.Do(100)).Returns(101);
    a.InSequence(sequence).Setup(x => x.Do(200)).Returns(201);

    Assert.Equal(101, a.Object.Do(100));
    Assert.Equal(201, a.Object.Do(200));
    Assert.Throws<MockException>(() => a.Object.Do(100));
    Assert.Throws<MockException>(() => a.Object.Do(200));
}

[Fact]
public void SameMockInvalidSequenceFail()
{
    var a = new Mock<IFoo>(MockBehavior.Strict);

    var sequence = new MockSequence();
    a.InSequence(sequence).Setup(x => x.Do(100)).Returns(101);
    a.InSequence(sequence).Setup(x => x.Do(200)).Returns(201);

    Assert.Throws<MockException>(() => a.Object.Do(200));
}
```
