### PR TITLE
Use default proxy generation options, rather than an explicitly empty one

### DIFF
--- a/Source/Proxy/CastleProxyFactory.cs
+++ b/Source/Proxy/CastleProxyFactory.cs
@@ -83,7 +83,7 @@ namespace Moq.Proxy
 
 			try
 			{
-				return generator.CreateClassProxy(mockType, interfaces, new ProxyGenerationOptions(), arguments, new Interceptor(interceptor));
+				return generator.CreateClassProxy(mockType, interfaces, ProxyGenerationOptions.Default, arguments, new Interceptor(interceptor));
 			}
 			catch (TypeLoadException e)
 			{


### PR DESCRIPTION
Very minor, but this patch switches to using the Castle default proxy options, rather than explicitly creating a new one. This is currently functionally equivalent (except it means you only build one set of options, rather than one per mock type), but semantically better & clearer, and will make life easier if Castle ever do add new settings to the default.
