### PR TITLE
Issue #78

### DIFF
--- a/Source/IInterceptStrategy.cs
+++ b/Source/IInterceptStrategy.cs
@@ -19,19 +19,20 @@ namespace Moq
 		/// Handle interception
 		/// </summary>
 		/// <param name="invocation">the current invocation context</param>
-		/// <param name="ctx">shared data among the strategies during an interception</param>
-		/// <returns>true if further interception has to be processed, otherwise false</returns>
-		InterceptionAction HandleIntercept(ICallContext invocation, InterceptStrategyContext ctx);
+		/// <param name="ctx">shared data for the interceptor as a whole</param>
+		/// <param name="localCtx">shared data among the strategies during a single interception</param>
+		/// <returns>InterceptionAction.Continue if further interception has to be processed, otherwise InterceptionAction.Stop</returns>
+		InterceptionAction HandleIntercept(ICallContext invocation, InterceptorContext ctx, CurrentInterceptContext localCtx);
 		
 	}
 
-	internal class InterceptStrategyContext
+	internal class InterceptorContext
 	{
 		private Dictionary<string, List<Delegate>> invocationLists = new Dictionary<string, List<Delegate>>();
 		private List<ICallContext> actualInvocations = new List<ICallContext>();
 		private List<IProxyCall> orderedCalls = new List<IProxyCall>();
 
-		public InterceptStrategyContext(Mock Mock, Type targetType, MockBehavior behavior)
+		public InterceptorContext(Mock Mock, Type targetType, MockBehavior behavior)
 		{
 			this.Behavior = behavior;
 			this.Mock = Mock;
@@ -40,7 +41,6 @@ namespace Moq
 		public Mock Mock { get; private set; }
 		public Type TargetType { get; private set; }
 		public MockBehavior Behavior { get; private set; }
-		public IProxyCall CurrentCall { get; set; }
 		
 		#region InvocationLists
 		internal IEnumerable<Delegate> GetInvocationList(EventInfo ev)
@@ -136,6 +136,10 @@ namespace Moq
 		}
 		#endregion
 
+    }
+	
+	internal class CurrentInterceptContext
+	{        
+		public IProxyCall Call {get; set; }
 	}
-
 }

--- a/Source/Interceptor.cs
+++ b/Source/Interceptor.cs
@@ -58,10 +58,10 @@ namespace Moq
 
 		public Interceptor(MockBehavior behavior, Type targetType, Mock mock)
 		{
-			InterceptionContext = new InterceptStrategyContext(mock, targetType, behavior);
+			InterceptionContext = new InterceptorContext(mock, targetType, behavior);
 		}
 
-		internal InterceptStrategyContext InterceptionContext { get; private set; }
+        internal InterceptorContext InterceptionContext { get; private set; }
 
 		internal void Verify()
 		{
@@ -128,9 +128,10 @@ namespace Moq
 		[SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity")]
 		public void Intercept(ICallContext invocation)
 		{
+            CurrentInterceptContext localCtx = new CurrentInterceptContext();
 			foreach (var strategy in InterceptionStrategies())
 			{
-				if (InterceptionAction.Stop == strategy.HandleIntercept(invocation, InterceptionContext))
+                if (InterceptionAction.Stop == strategy.HandleIntercept(invocation, InterceptionContext, localCtx))
 				{
 					break;
 				}

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -18,6 +18,9 @@ using System.ServiceModel.Web;
 using System.Web.UI.HtmlControls;
 using System.Threading;
 #endif
+#if !Net3x
+using System.Threading.Tasks;
+#endif
 
 #region #181
 
@@ -120,7 +123,58 @@ namespace Moq.Tests.Regressions
 
 #endif
 		#endregion
-		
+
+		#region #78
+#if !NET3x
+		public interface IIssue78Interface
+		{
+			Issue78TypeOne GetTypeOne();
+			Issue78TypeTwo GetTypeTwo();
+		}
+
+		public class Issue78TypeOne
+		{
+
+		}
+		public class Issue78TypeTwo
+		{
+
+		}
+
+		public class Issue78Sut
+		{
+			public void TestMethod(IIssue78Interface intOne)
+			{
+				Task<Issue78TypeOne> getTypeOneTask = Task<Issue78TypeOne>.Factory.StartNew(() => intOne.GetTypeOne());
+				Task<Issue78TypeTwo> getTypeTwoTask = Task<Issue78TypeTwo>.Factory.StartNew(() => intOne.GetTypeTwo());
+
+				Issue78TypeOne objOne = getTypeOneTask.Result;
+				Issue78TypeTwo objTwo = getTypeTwoTask.Result;
+			}
+		}
+
+		public class Issue78Tests
+		{
+			[Fact()]
+			public void DoTest()
+			{
+				Mock<IIssue78Interface> mock = new Mock<IIssue78Interface>();
+
+				Issue78TypeOne expectedResOne = new Issue78TypeOne();
+				Issue78TypeTwo expectedResTwo = new Issue78TypeTwo();
+
+				mock.Setup(it => it.GetTypeOne()).Returns(expectedResOne);
+				mock.Setup(it => it.GetTypeTwo()).Returns(expectedResTwo);
+
+				Issue78Sut sut = new Issue78Sut();
+				sut.TestMethod(mock.Object);
+
+				mock.VerifyAll();
+			}
+		}
+#endif
+		#endregion
+
 		// Old @ Google Code
 
         #region #47


### PR DESCRIPTION
Fixed the multi-threaded return type exception by splitting the
interceptor context into a global one and one for the current call to
Intercept.

Would have preferred to simply find the CurrentCall wherever I needed
it, but this broke the MockSequence tests.  I'll explain this in the
comments to #78.
