### PR TITLE
Add support for SetupAnyArg and VerifyAnyArg

### DIFF
--- a/Source/ConditionalContext.cs
+++ b/Source/ConditionalContext.cs
@@ -59,12 +59,12 @@ namespace Moq
 
 		public ISetup<T> Setup(Expression<Action<T>> expression)
 		{
-			return Mock.Setup<T>(mock, expression, this.condition);
+			return Mock.Setup<T>(mock, expression, this.condition, false);
 		}
 
 		public ISetup<T, TResult> Setup<TResult>(Expression<Func<T, TResult>> expression)
 		{
-			return Mock.Setup<T, TResult>(mock, expression, this.condition);
+            return Mock.Setup<T, TResult>(mock, expression, this.condition, false);
 		}
 
 		public ISetupGetter<T, TProperty> SetupGet<TProperty>(Expression<Func<T, TProperty>> expression)

--- a/Source/MethodCallReturn.cs
+++ b/Source/MethodCallReturn.cs
@@ -54,8 +54,8 @@ namespace Moq
 	/// </devdoc>
 	internal class MethodCallReturn : MethodCall
 	{
-		public MethodCallReturn(Mock mock, Condition condition, Expression originalExpression, MethodInfo method, params Expression[] arguments)
-			: base(mock, condition, originalExpression, method, arguments)
+		public MethodCallReturn(Mock mock, Condition condition, Expression originalExpression, MethodInfo method, bool ignoreArgs, params Expression[] arguments)
+            : base(mock, condition, originalExpression, method, ignoreArgs, arguments)
 		{
 		}
 
@@ -69,8 +69,8 @@ namespace Moq
 		private Action<object[]> afterReturnCallback;
 		private bool callBase;
 
-		public MethodCallReturn(Mock mock, Condition condition, Expression originalExpression, MethodInfo method, params Expression[] arguments)
-			: base(mock, condition, originalExpression, method, arguments)
+		public MethodCallReturn(Mock mock, Condition condition, Expression originalExpression, MethodInfo method, bool ignoreArgs, params Expression[] arguments)
+            : base(mock, condition, originalExpression, method, ignoreArgs, arguments)
 		{
 			this.HasReturnValue = false;
 		}

--- a/Source/Mock.Generic.cs
+++ b/Source/Mock.Generic.cs
@@ -259,15 +259,29 @@ namespace Moq
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public ISetup<T> Setup(Expression<Action<T>> expression)
 		{
-			return Mock.Setup<T>(this, expression, null);
+			return Mock.Setup<T>(this, expression, null, false);
 		}
+
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Setup"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public ISetup<T> SetupAnyArg(Expression<Action<T>> expression)
+        {
+            return Mock.Setup<T>(this, expression, null, true);
+        }
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Setup{TResult}"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public ISetup<T, TResult> Setup<TResult>(Expression<Func<T, TResult>> expression)
 		{
-			return Mock.Setup(this, expression, null);
+            return Mock.Setup(this, expression, null, false);
 		}
+
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Setup{TResult}"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public ISetup<T, TResult> SetupAnyArg<TResult>(Expression<Func<T, TResult>> expression)
+        {
+            return Mock.Setup(this, expression, null, true);
+        }
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupGet"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
@@ -337,15 +351,29 @@ namespace Moq
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify(Expression<Action<T>> expression)
 		{
-			Mock.Verify(this, expression, Times.AtLeastOnce(), null);
+            Mock.Verify(this, expression, Times.AtLeastOnce(), null, false);
 		}
+
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void VerifyAnyArg(Expression<Action<T>> expression)
+        {
+            Mock.Verify(this, expression, Times.AtLeastOnce(), null, true);
+        }
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify(Expression<Action<T>> expression, Times times)
 		{
-			Mock.Verify(this, expression, times, null);
+			Mock.Verify(this, expression, times, null, false);
 		}
+
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void VerifyAnyArg(Expression<Action<T>> expression, Times times)
+        {
+            Mock.Verify(this, expression, times, null, true);
+        }
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
@@ -354,61 +382,126 @@ namespace Moq
 			Verify(expression, times());
 		}
 
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void VerifyAnyArg(Expression<Action<T>> expression, Func<Times> times)
+        {
+            VerifyAnyArg(expression, times());
+        }
+
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,failMessage)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify(Expression<Action<T>> expression, string failMessage)
 		{
-			Mock.Verify(this, expression, Times.AtLeastOnce(), failMessage);
+			Mock.Verify(this, expression, Times.AtLeastOnce(), failMessage, false);
 		}
+
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,failMessage)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void VerifyAnyArg(Expression<Action<T>> expression, string failMessage)
+        {
+            Mock.Verify(this, expression, Times.AtLeastOnce(), failMessage, true);
+        }
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times,failMessage)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify(Expression<Action<T>> expression, Times times, string failMessage)
 		{
-			Mock.Verify(this, expression, times, failMessage);
+			Mock.Verify(this, expression, times, failMessage, false);
 		}
+
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times,failMessage)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void VerifyAnyArg(Expression<Action<T>> expression, Times times, string failMessage)
+        {
+            Mock.Verify(this, expression, times, failMessage, true);
+        }
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times,failMessage)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify(Expression<Action<T>> expression, Func<Times> times, string failMessage)
 		{
-			Verify(this, expression, times(), failMessage);
+			Verify(this, expression, times(), failMessage, false);
 		}
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression)"]/*'/>
+
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times,failMessage)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void VerifyAnyArg(Expression<Action<T>> expression, Func<Times> times, string failMessage)
+        {
+            Verify(this, expression, times(), failMessage, true);
+        }
+
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify<TResult>(Expression<Func<T, TResult>> expression)
 		{
-			Mock.Verify(this, expression, Times.AtLeastOnce(), null);
+			Mock.Verify(this, expression, Times.AtLeastOnce(), null, false);
 		}
+
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void VerifyAnyArg<TResult>(Expression<Func<T, TResult>> expression)
+        {
+            Mock.Verify(this, expression, Times.AtLeastOnce(), null, true);
+        }
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,times)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify<TResult>(Expression<Func<T, TResult>> expression, Times times)
 		{
-			Mock.Verify(this, expression, times, null);
+			Mock.Verify(this, expression, times, null, false);
 		}
+
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,times)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void VerifyAnyArg<TResult>(Expression<Func<T, TResult>> expression, Times times)
+        {
+            Mock.Verify(this, expression, times, null, true);
+        }
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,times)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify<TResult>(Expression<Func<T, TResult>> expression, Func<Times> times)
 		{
-			Verify(this, expression, times(), null);
+			Verify(this, expression, times(), null, false);
 		}
+
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,times)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void VerifyAnyArg<TResult>(Expression<Func<T, TResult>> expression, Func<Times> times)
+        {
+            Verify(this, expression, times(), null, true);
+        }
+
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,failMessage)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify<TResult>(Expression<Func<T, TResult>> expression, string failMessage)
 		{
-			Mock.Verify(this, expression, Times.AtLeastOnce(), failMessage);
+			Mock.Verify(this, expression, Times.AtLeastOnce(), failMessage, false);
 		}
+
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,failMessage)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void VerifyAnyArg<TResult>(Expression<Func<T, TResult>> expression, string failMessage)
+        {
+            Mock.Verify(this, expression, Times.AtLeastOnce(), failMessage, true);
+        }
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,times,failMessage)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify<TResult>(Expression<Func<T, TResult>> expression, Times times, string failMessage)
 		{
-			Mock.Verify(this, expression, times, failMessage);
+			Mock.Verify(this, expression, times, failMessage, false);
 		}
+
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,times,failMessage)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void VerifyAnyArg<TResult>(Expression<Func<T, TResult>> expression, Times times, string failMessage)
+        {
+            Mock.Verify(this, expression, times, failMessage, true);
+        }
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyGet(expression)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]

--- a/Source/Protected/ProtectedMock.cs
+++ b/Source/Protected/ProtectedMock.cs
@@ -69,7 +69,7 @@ namespace Moq.Protected
 			ThrowIfMemberMissing(methodName, method);
 			ThrowIfPublicMethod(method);
 
-			return Mock.Setup(mock, GetMethodCall(method, args), null);
+            return Mock.Setup(mock, GetMethodCall(method, args), null, false);
 		}
 
 		public ISetup<T, TResult> Setup<TResult>(string methodName, params object[] args)
@@ -89,7 +89,7 @@ namespace Moq.Protected
 			ThrowIfVoidMethod(method);
 			ThrowIfPublicMethod(method);
 
-			return Mock.Setup(mock, GetMethodCall<TResult>(method, args), null);
+            return Mock.Setup(mock, GetMethodCall<TResult>(method, args), null, false);
 		}
 
 		public ISetupGetter<T, TProperty> SetupGet<TProperty>(string propertyName)
@@ -128,7 +128,7 @@ namespace Moq.Protected
 			ThrowIfMemberMissing(methodName, method);
 			ThrowIfPublicMethod(method);
 
-			Mock.Verify(mock, GetMethodCall(method, args), times, null);
+			Mock.Verify(mock, GetMethodCall(method, args), times, null, false);
 		}
 
 		public void Verify<TResult>(string methodName, Times times, object[] args)
@@ -148,7 +148,7 @@ namespace Moq.Protected
 			ThrowIfMemberMissing(methodName, method);
 			ThrowIfPublicMethod(method);
 
-			Mock.Verify(mock, GetMethodCall<TResult>(method, args), times, null);
+			Mock.Verify(mock, GetMethodCall<TResult>(method, args), times, null, false);
 		}
 
 		// TODO should receive args to support indexers

--- a/UnitTests/MatchersFixture.cs
+++ b/UnitTests/MatchersFixture.cs
@@ -9,7 +9,21 @@ namespace Moq.Tests
 {
 	public class MatchersFixture
 	{
-		[Fact]
+        [Fact]
+        public void MatchesAnyParameterValueWithSetupAnyArg()
+        {
+            var mock = new Mock<IFoo>();
+
+            mock.SetupAnyArg(x => x.Echo(17)).Returns(5);
+            mock.SetupAnyArg(x => x.Execute(null)).Returns("foo");
+
+            Assert.Equal(5, mock.Object.Echo(5));
+            Assert.Equal(5, mock.Object.Echo(25));
+            Assert.Equal("foo", mock.Object.Execute("hello"));
+            Assert.Equal("foo", mock.Object.Execute((string)null));
+        }
+
+        [Fact]
 		public void MatchesAnyParameterValue()
 		{
 			var mock = new Mock<IFoo>();

--- a/UnitTests/VerifyFixture.cs
+++ b/UnitTests/VerifyFixture.cs
@@ -880,6 +880,15 @@ namespace Moq.Tests
             mock.Verify(foo => foo.Call(It.IsAny<IBazParam>()), Times.Exactly(2));
         }
 
+        [Fact]
+        public void MatchesVerifyAnyArg()
+        {
+            var mock = new Mock<IBaz>();
+            mock.Object.Call(new BazParam());
+
+            mock.VerifyAnyArg(foo => foo.Call<BazParam>(null), Times.Once());
+        }
+
 #if !SILVERLIGHT
         /// <summary>
         /// Warning, this is a flaky test and doesn't fail when run as standalone. Running all tests at once will increase the chances of that test to fail.


### PR DESCRIPTION
We use Moq a lot in our team and I find that I spend a lot of time writing the correct It.IsAny<T>() parameters for Verify and Setup methods. I really wanted a simple way match any parameters and created two methods SetupAnyArg and VerifyAnyArg. When they are used, the underlying logic ignores any expression parameters and just matches the method by the signature. 

I realize that my current implementation might not be up to the standards of the Moq code-base and maybe I missed some important design principle. If you are interested in integrating this feature, give me some comments and I will gladly make the adjustments.