### PR TITLE
Update Match<T>.Matches(object)

### DIFF
--- a/Source/Match.cs
+++ b/Source/Match.cs
@@ -124,7 +124,12 @@ namespace Moq
 
 		internal override bool Matches(object value)
 		{
-			if (value != null && !(value is T))
+			if (value == null)
+			{
+				return true;
+			}
+
+			if (!(value is T))
 			{
 				return false;
 			}


### PR DESCRIPTION
Adding an if-condition when argument is null. Otherwise NullReferenceException occurs.
