### PR TITLE
Issue 136 - SetupAllProperties doesn't setup properties that don't have a setter

### DIFF
--- a/UnitTests/StubExtensionsFixture.cs
+++ b/UnitTests/StubExtensionsFixture.cs
@@ -36,9 +36,15 @@ namespace Moq.Tests
 		[Fact]
 		public void StubsAllProperties()
 		{
-			var mock = new Mock<IFoo>();
+			var mock = new Mock<IFoo>(MockBehavior.Strict);
 
 			mock.SetupAllProperties();
+
+			// Verify defaults
+			Assert.Equal(default(int), mock.Object.ValueProperty);
+			Assert.Equal(null, mock.Object.Object);
+			Assert.Equal(null, mock.Object.Bar);
+			Assert.Equal(null, mock.Object.GetOnly);
 
 			mock.Object.ValueProperty = 5;
 			Assert.Equal(5, mock.Object.ValueProperty);
@@ -98,6 +104,7 @@ namespace Moq.Tests
 			int ValueProperty { get; set; }
 			object Object { get; set; }
 			IBar Bar { get; set; }
+			object GetOnly { get; }
 		}
 
 		public class Derived : Base


### PR DESCRIPTION
SetupAllProperties doesn't setup properties that only have a get. This
is a regression from previous behavior and this change fixes the issue.
