### PR TITLE
Added MockExtensions.Reset() to clear mock state (expectations+invocations)

### DIFF
--- a/Source/IInterceptStrategy.cs
+++ b/Source/IInterceptStrategy.cs
@@ -82,6 +82,13 @@ namespace Moq
 				}
 			}
 		}
+		internal void ClearEventHandlers()
+		{
+			lock (invocationLists)
+			{
+				invocationLists.Clear();
+			}
+		}
 		#endregion
 		#region ActualInvocations
 		internal void AddInvocation(ICallContext invocation)
@@ -122,6 +129,13 @@ namespace Moq
 			lock (orderedCalls)
 			{
 				orderedCalls.Remove(call);
+			}
+		}
+		internal void ClearOrderedCalls()
+		{
+			lock (orderedCalls)
+			{
+				orderedCalls.Clear();
 			}
 		}
 		internal IEnumerable<IProxyCall> OrderedCalls

--- a/Source/MockExtensions.cs
+++ b/Source/MockExtensions.cs
@@ -24,7 +24,18 @@ namespace Moq
         /// <param name="mock">The mock whose calls need to be reset.</param>
         public static void ResetCalls(this Mock mock) 
         {
-			mock.Interceptor.InterceptionContext.ClearInvocations();
+            mock.Interceptor.InterceptionContext.ClearInvocations();
+        }
+
+        /// <summary>
+        /// Resets mock state, including setups and any previously made calls.
+        /// </summary>
+        /// <param name="mock">The mock that needs to be reset.</param>
+        public static void Reset(this Mock mock)
+        {
+            mock.Interceptor.InterceptionContext.ClearOrderedCalls();
+            mock.Interceptor.InterceptionContext.ClearEventHandlers();
+            mock.ResetCalls();
         } 
     }
 }

--- a/UnitTests/ExtensionsFixture.cs
+++ b/UnitTests/ExtensionsFixture.cs
@@ -28,6 +28,16 @@ namespace Moq.Tests
             mock.Verify(o => o.Execute("ping"), Times.Once());
         }
 
+        [Fact]
+        public void SetupDoesNotApplyAfterMockWasReset()
+        {
+            var mock = new Mock<IFooReset>();
+            mock.Setup(foo => foo.Execute("ping")).Returns("ack");
+            mock.Reset();
+
+            var result = mock.Object.Execute("ping");
+            Assert.Null(result);
+        }
         #endregion
     }
 


### PR DESCRIPTION
This change adds `MockExtensions.Reset(Mock)` that completely resets the mock by removing all expectations and all actual invocations.

**Use case:**
Mocking singleton-lifetime object in integration tests where it is not possible to reset application state completely between tests -- so the mock instance can potentially be cached in other singleton services and cannot be replaced with a new mock.