### PR TITLE
Fix: #128 NotImplementedException DynamicProxy2 error when CallBase = true 

### DIFF
--- a/Source/InterceptorStrategies.cs
+++ b/Source/InterceptorStrategies.cs
@@ -34,7 +34,7 @@ namespace Moq
         public InterceptionAction HandleIntercept(ICallContext invocation, InterceptorContext ctx, CurrentInterceptContext localctx)
         {
             if (invocation.Method.DeclaringType == typeof(object) || // interface proxy
-                ctx.Mock.ImplementedInterfaces.Contains(invocation.Method.DeclaringType) && !invocation.Method.IsEventAttach() && !invocation.Method.IsEventDetach() && ctx.Mock.CallBase || // class proxy with explicitly implemented interfaces. The method's declaring type is the interface and the method couldn't be abstract
+                ctx.Mock.ImplementedInterfaces.Contains(invocation.Method.DeclaringType) && !invocation.Method.IsEventAttach() && !invocation.Method.IsEventDetach() && ctx.Mock.CallBase && !ctx.Mock.MockedType.IsInterface || // class proxy with explicitly implemented interfaces. The method's declaring type is the interface and the method couldn't be abstract
                 invocation.Method.DeclaringType.IsClass && !invocation.Method.IsAbstract && ctx.Mock.CallBase // class proxy
                 )
             {

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -469,6 +469,40 @@ namespace Moq.Tests.Regressions
 
         #endregion
 
+        #region #128
+
+        public class Issue128
+        {
+            [Fact]
+            public void That_CallBase_on_interface_should_not_throw_exception()
+            {
+                var mock = new Mock<IDataServiceFactory>() 
+                { 
+                    DefaultValue = DefaultValue.Mock,
+                    CallBase = true
+                };
+
+                var service = mock.Object.GetDataService();
+
+                var data = service.GetData();
+                var result = data.Sum();
+                
+                Assert.Equal( 0, result );
+            }
+
+            public interface IDataServiceFactory
+            {
+                IDataService GetDataService();
+            }
+
+            public interface IDataService
+            {
+                IList<int> GetData();
+            }
+        }
+
+        #endregion
+
         #region #134
 
         public class Issue134


### PR DESCRIPTION
Fix: #128 NotImplementedException DynamicProxy2 error when CallBase = true  while mocking interfaces 