### PR TITLE
Make TPL code Silverlight 5 compatible

### DIFF
--- a/Source.Silverlight/Moq.Silverlight.csproj
+++ b/Source.Silverlight/Moq.Silverlight.csproj
@@ -366,6 +366,9 @@
     <Compile Include="..\Source\Range.cs">
       <Link>Range.cs</Link>
     </Compile>
+    <Compile Include="..\Source\ReturnsExtensions.cs">
+      <Link>ReturnsExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\Source\SequenceExtensions.cs">
       <Link>SequenceExtensions.cs</Link>
     </Compile>

--- a/Source.Silverlight/Moq.Silverlight.csproj
+++ b/Source.Silverlight/Moq.Silverlight.csproj
@@ -423,11 +423,4 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
-  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-  </Target>
 </Project>

--- a/Source.Silverlight/Moq.Silverlight.csproj
+++ b/Source.Silverlight/Moq.Silverlight.csproj
@@ -21,6 +21,8 @@
     <AssemblyOriginatorKeyFile>..\Moq.snk</AssemblyOriginatorKeyFile>
     <SignManifests>false</SignManifests>
     <OldToolsVersion>4.0</OldToolsVersion>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition="'$(MSBuildToolsVersion)' == '3.5'">
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
@@ -81,7 +83,7 @@
   <ItemGroup>
     <Reference Include="Castle.Core, Version=3.2.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Castle.Core.3.2.0\lib\sl4\Castle.Core.dll</HintPath>
+      <HintPath>..\packages\Castle.Core.3.2.0\lib\sl5\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib" />
     <Reference Include="system" />
@@ -408,6 +410,7 @@
       <Link>Mock.Generic.xdoc</Link>
       <DependentUpon>Mock.Generic.cs</DependentUpon>
     </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Silverlight\$(SilverlightVersion)\Microsoft.Silverlight.CSharp.targets" />
   <ProjectExtensions>
@@ -417,4 +420,11 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
 </Project>

--- a/Source.Silverlight/packages.config
+++ b/Source.Silverlight/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Castle.Core" version="3.2.0" targetFramework="sl50" />
+</packages>

--- a/Source/EmptyDefaultValueProvider.cs
+++ b/Source/EmptyDefaultValueProvider.cs
@@ -43,7 +43,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-#if !NET3x && !SILVERLIGHT
+#if !NET3x
 using System.Threading.Tasks;
 #endif
 
@@ -89,7 +89,7 @@ namespace Moq
 			{
 				return new object[0].AsQueryable();
 			}
-#if !NET3x && !SILVERLIGHT
+#if !NET3x
 			else if (valueType == typeof(Task))
 			{
 				// Task<T> inherits from Task, so just return Task<bool>
@@ -111,7 +111,7 @@ namespace Moq
 					.MakeGenericMethod(genericType)
 					.Invoke(null, new[] { Activator.CreateInstance(genericListType) });
 			}
-#if !NET3x && !SILVERLIGHT
+#if !NET3x
 			else if (valueType.IsGenericType && valueType.GetGenericTypeDefinition() == typeof(Task<>))
 			{
 				var genericType = valueType.GetGenericArguments()[0];
@@ -133,7 +133,7 @@ namespace Moq
 			return Activator.CreateInstance(valueType);
 		}
 
-#if !NET3x && !SILVERLIGHT
+#if !NET3x
 		private static Task GetCompletedTaskForType(Type type)
 		{
 			var tcs = Activator.CreateInstance(typeof (TaskCompletionSource<>).MakeGenericType(type));

--- a/Source/ReturnsExtensions.cs
+++ b/Source/ReturnsExtensions.cs
@@ -1,4 +1,4 @@
-﻿#if !NET3x && !SILVERLIGHT
+﻿#if !NET3x
 using System;
 using System.Threading.Tasks;
 using Moq.Language;

--- a/UnitTests.Silverlight/Moq.Silverlight.Tests.csproj
+++ b/UnitTests.Silverlight/Moq.Silverlight.Tests.csproj
@@ -242,11 +242,4 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
-  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-  </Target>
 </Project>

--- a/UnitTests.Silverlight/Moq.Silverlight.Tests.csproj
+++ b/UnitTests.Silverlight/Moq.Silverlight.Tests.csproj
@@ -15,7 +15,7 @@
     <SilverlightVersion>$(TargetFrameworkVersion)</SilverlightVersion>
     <SilverlightApplication>true</SilverlightApplication>
     <XapOutputs>true</XapOutputs>
-    <GenerateSilverlightManifest>false</GenerateSilverlightManifest>
+    <GenerateSilverlightManifest>true</GenerateSilverlightManifest>
     <XapFilename>Moq.Tests.Silverlight.xap</XapFilename>
     <SilverlightManifestTemplate>Properties\AppManifest.xml</SilverlightManifestTemplate>
     <SilverlightAppEntry>Moq.Tests.Silverlight.App</SilverlightAppEntry>

--- a/UnitTests.Silverlight/Moq.Silverlight.Tests.csproj
+++ b/UnitTests.Silverlight/Moq.Silverlight.Tests.csproj
@@ -27,6 +27,8 @@
     <AssemblyOriginatorKeyFile>..\Moq.snk</AssemblyOriginatorKeyFile>
     <SignManifests>false</SignManifests>
     <OldToolsVersion>4.0</OldToolsVersion>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -78,9 +80,9 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=2.5.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+    <Reference Include="Castle.Core, Version=3.2.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Lib\Castle\bin-SL4\Castle.Core.dll</HintPath>
+      <HintPath>..\packages\Castle.Core.3.2.0\lib\sl5\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="ClassLibrary1.Silverlight">
       <HintPath>..\UnitTests\ClassLibrary1.Silverlight.dll</HintPath>
@@ -223,6 +225,7 @@
     <None Include="..\Moq.snk">
       <Link>Moq.snk</Link>
     </None>
+    <None Include="packages.config" />
     <None Include="Properties\AppManifest.xml" />
   </ItemGroup>
   <ItemGroup>
@@ -239,4 +242,11 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
 </Project>

--- a/UnitTests.Silverlight/packages.config
+++ b/UnitTests.Silverlight/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Castle.Core" version="3.2.0" targetFramework="sl50" />
+</packages>

--- a/UnitTests/EmptyDefaultValueProviderFixture.cs
+++ b/UnitTests/EmptyDefaultValueProviderFixture.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-#if !NET3x && !SILVERLIGHT
+#if !NET3x
 using System.Threading.Tasks;
 #endif
 using Xunit;
@@ -110,7 +110,7 @@ namespace Moq.Tests
 			Assert.Equal(0, ((IQueryable)value).Cast<object>().Count());
 		}
 
-#if !NET3x && !SILVERLIGHT
+#if !NET3x
 		[Fact]
 		public void ProvidesDefaultTask()
 		{
@@ -172,7 +172,7 @@ namespace Moq.Tests
 			IBar[] Bars { get; set; }
 			IQueryable<int> Queryable { get; }
 			IQueryable QueryableObjects { get; }
-#if !NET3x && !SILVERLIGHT
+#if !NET3x
 			Task TaskValue { get; set; }
 			Task<int> GenericTaskOfValueType { get; set; }
 			Task<string> GenericTaskOfReferenceType { get; set; }


### PR DESCRIPTION
Per discussion in #66, Silverlight 4 support was dropped and added TPL Task support to SL5 version. #70 just disabled TPL Task support for Silverlifht version, this PR re-enable it.