### PR TITLE
Added MockBehavior overload to Mock.Of<T>()

### DIFF
--- a/Source/IInterceptStrategy.cs
+++ b/Source/IInterceptStrategy.cs
@@ -28,21 +28,26 @@ namespace Moq
 
 	internal class InterceptorContext
 	{
-		private Dictionary<string, List<Delegate>> invocationLists = new Dictionary<string, List<Delegate>>();
-		private List<ICallContext> actualInvocations = new List<ICallContext>();
-		private List<IProxyCall> orderedCalls = new List<IProxyCall>();
+		private readonly Dictionary<string, List<Delegate>> invocationLists = new Dictionary<string, List<Delegate>>();
+		private readonly List<ICallContext> actualInvocations = new List<ICallContext>();
+		private readonly List<IProxyCall> orderedCalls = new List<IProxyCall>();
 
-		public InterceptorContext(Mock Mock, Type targetType, MockBehavior behavior)
+		public InterceptorContext(Mock mock, Type targetType)
 		{
-			this.Behavior = behavior;
-			this.Mock = Mock;
+			this.Mock = mock;
 			this.TargetType = targetType;
 		}
-		public Mock Mock { get; private set; }
-		public Type TargetType { get; private set; }
-		public MockBehavior Behavior { get; private set; }
 		
-		#region InvocationLists
+        public Mock Mock { get; private set; }
+		
+        public Type TargetType { get; private set; }
+
+	    public MockBehavior Behavior
+	    {
+	        get { return Mock.Behavior; }
+	    }
+
+	    #region InvocationLists
 		internal IEnumerable<Delegate> GetInvocationList(EventInfo ev)
 		{
 			lock (invocationLists)

--- a/Source/Interceptor.cs
+++ b/Source/Interceptor.cs
@@ -54,11 +54,11 @@ namespace Moq
 	/// </summary>
 	internal class Interceptor : ICallInterceptor
 	{
-		private Dictionary<ExpressionKey, IProxyCall> calls = new Dictionary<ExpressionKey, IProxyCall>();
+		private readonly Dictionary<ExpressionKey, IProxyCall> calls = new Dictionary<ExpressionKey, IProxyCall>();
 
-		public Interceptor(MockBehavior behavior, Type targetType, Mock mock)
+		public Interceptor(Type targetType, Mock mock)
 		{
-			InterceptionContext = new InterceptorContext(mock, targetType, behavior);
+			InterceptionContext = new InterceptorContext(mock, targetType);
 		}
 
         internal InterceptorContext InterceptionContext { get; private set; }

--- a/Source/InterceptorStrategies.cs
+++ b/Source/InterceptorStrategies.cs
@@ -99,7 +99,6 @@ namespace Moq
 
     internal class ExtractProxyCall : IInterceptStrategy
     {
-
         public InterceptionAction HandleIntercept(ICallContext invocation, InterceptorContext ctx, CurrentInterceptContext localctx)
         {
             localctx.Call = FluentMockContext.IsActive ? (IProxyCall)null : ctx.OrderedCalls.LastOrDefault(c => c.Matches(invocation));

--- a/Source/Linq/Mock.cs
+++ b/Source/Linq/Mock.cs
@@ -48,28 +48,54 @@ using Moq.Linq;
 
 namespace Moq
 {
-	public partial class Mock
-	{
-		/// <summary>
-		/// Creates an mock object of the indicated type.
-		/// </summary>
-		/// <typeparam name="T">The type of the mocked object.</typeparam>
-		/// <returns>The mocked object created.</returns>
-		public static T Of<T>() where T : class
-		{
-			return Mocks.CreateMockQuery<T>().First<T>();
-		}
+    public partial class Mock
+    {
+        /// <summary>
+        /// Creates an mock object of the indicated type.
+        /// </summary>
+        /// <typeparam name="T">The type of the mocked object.</typeparam>
+        /// <returns>The mocked object created.</returns>
+        public static T Of<T>() where T : class
+        {
+            return Mocks.CreateMockQuery<T>().First<T>();
+        }
 
-		/// <summary>
-		/// Creates an mock object of the indicated type.
-		/// </summary>
-		/// <param name="predicate">The predicate with the specification of how the mocked object should behave.</param>
-		/// <typeparam name="T">The type of the mocked object.</typeparam>
-		/// <returns>The mocked object created.</returns>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By Design")]
-		public static T Of<T>(Expression<Func<T, bool>> predicate) where T : class
-		{
-			return Mocks.CreateMockQuery<T>().First<T>(predicate);
-		}
-	}
+        /// <summary>
+        /// Creates an mock object of the indicated type.
+        /// </summary>
+        /// <param name="predicate">The predicate with the specification of how the mocked object should behave.</param>
+        /// <typeparam name="T">The type of the mocked object.</typeparam>
+        /// <returns>The mocked object created.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By Design")]
+        public static T Of<T>(Expression<Func<T, bool>> predicate) where T : class
+        {
+            return Mocks.CreateMockQuery<T>().First<T>(predicate);
+        }
+
+        /// <summary>
+        /// Creates an mock object of the indicated type.
+        /// </summary>
+        /// <param name="predicate">The predicate with the specification of how the mocked object should behave.</param>
+        /// <param name="behavior">Behavior of the mock.</param>
+        /// <typeparam name="T">The type of the mocked object.</typeparam>
+        /// <returns>The mocked object created.</returns>
+        public static T Of<T>(Expression<Func<T, bool>> predicate, MockBehavior behavior) where T : class
+        {
+            var mockQuery = Mocks.CreateMockQuery<T>(behavior);
+            var mocked = mockQuery.First(predicate);
+            return mocked;
+        }
+
+        /// <summary>
+        /// Creates an mock object of the indicated type.
+        /// </summary>
+        /// <param name="behavior">Behavior of the mock.</param>
+        /// <typeparam name="T">The type of the mocked object.</typeparam>
+        /// <returns>The mocked object created.</returns>
+        public static T Of<T>(MockBehavior behavior) where T : class
+        {
+            var mock = new Mock<T>(behavior);
+            return mock.Object;
+        }
+    }
 }

--- a/Source/Linq/MockQuery.cs
+++ b/Source/Linq/MockQuery.cs
@@ -52,7 +52,7 @@ namespace Moq.Linq
 	/// </summary>
 	internal class MockQueryable<T> : IQueryable<T>, IQueryProvider
 	{
-		private MethodCallExpression underlyingCreateMocks;
+		private readonly MethodCallExpression underlyingCreateMocks;
 
 		/// <summary>
 		/// The <paramref name="underlyingCreateMocks"/> is a 

--- a/Source/Linq/MockSetupsBuilder.cs
+++ b/Source/Linq/MockSetupsBuilder.cs
@@ -54,7 +54,7 @@ namespace Moq.Linq
 		private static readonly string[] unsupportedMethods = new[] { "All", "Any", "Last", "LastOrDefault", "Single", "SingleOrDefault" };
 
 		private int stackIndex;
-		private MethodCallExpression underlyingCreateMocks;
+		private readonly MethodCallExpression underlyingCreateMocks;
 
 		public MockSetupsBuilder(MethodCallExpression underlyingCreateMocks)
 		{
@@ -208,7 +208,7 @@ namespace Moq.Linq
 			// which also allows the use of this querying capability against plain DTO even 
 			// if their properties are not virtual.
 			var setPropertyMethod = typeof(Mocks)
-				.GetMethod("SetPropery", BindingFlags.Static | BindingFlags.NonPublic)
+				.GetMethod("SetProperty", BindingFlags.Static | BindingFlags.NonPublic)
 				.MakeGenericMethod(mockExpression.Type.GetGenericArguments().First(), propertyInfo.PropertyType);
 
 			return Expression.Equal(

--- a/Source/Mock.Generic.cs
+++ b/Source/Mock.Generic.cs
@@ -54,75 +54,75 @@ using Microsoft.CSharp;
 
 namespace Moq
 {
-	/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}"]/*'/>
+    /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}"]/*'/>
     public partial class Mock<T> : Mock, IMock<T> where T : class
-	{
-		private static IProxyFactory proxyFactory = new CastleProxyFactory();
-		private T instance;
-		private object[] constructorArguments;
+    {
+        private static IProxyFactory proxyFactory = new CastleProxyFactory();
+        private T instance;
+        private object[] constructorArguments;
 
-		#region Ctors
+        #region Ctors
 
-		/// <summary>
-		/// Ctor invoked by AsTInterface exclusively.
-		/// </summary>
-		[SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "skipInitialize")]
-		internal Mock(bool skipInitialize)
-		{
-			// HACK: this is quick hackish. 
-			// In order to avoid having an IMock<T> I relevant members 
-			// virtual so that As<TInterface> overrides them (i.e. Interceptor).
-			// The skipInitialize parameter is not used at all, and it's 
-			// just to differentiate this ctor that should do nothing 
-			// from the regular ones which initializes the proxy, etc.
-		}
+        /// <summary>
+        /// Ctor invoked by AsTInterface exclusively.
+        /// </summary>
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "skipInitialize")]
+        internal Mock(bool skipInitialize)
+        {
+            // HACK: this is quick hackish. 
+            // In order to avoid having an IMock<T> I relevant members 
+            // virtual so that As<TInterface> overrides them (i.e. Interceptor).
+            // The skipInitialize parameter is not used at all, and it's 
+            // just to differentiate this ctor that should do nothing 
+            // from the regular ones which initializes the proxy, etc.
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.ctor()"]/*'/>
-		[SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors")]
-		public Mock()
-			: this(MockBehavior.Default)
-		{
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.ctor()"]/*'/>
+        [SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors")]
+        public Mock()
+            : this(MockBehavior.Default)
+        {
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.ctor(object[])"]/*'/>
-		[SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors")]
-		public Mock(params object[] args)
-			: this(MockBehavior.Default, args)
-		{
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.ctor(params object[])"]/*'/>
+        [SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors")]
+        public Mock(params object[] args)
+            : this(MockBehavior.Default, args)
+        {
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.ctor(MockBehavior)"]/*'/>
-		[SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors")]
-		public Mock(MockBehavior behavior)
-			: this(behavior, new object[0])
-		{
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.ctor(MockBehavior)"]/*'/>
+        [SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors")]
+        public Mock(MockBehavior behavior)
+            : this(behavior, new object[0])
+        {
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.ctor(MockBehavior,object[])"]/*'/>
-		[SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors")]
-		public Mock(MockBehavior behavior, params object[] args)
-		{
-			if (args == null)
-			{
-				args = new object[] { null };
-			}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.ctor(MockBehavior,object[])"]/*'/>
+        [SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors")]
+        public Mock(MockBehavior behavior, params object[] args)
+        {
+            if (args == null)
+            {
+                args = new object[] { null };
+            }
 
-			this.Name = GenerateMockName();
+            this.Name = GenerateMockName();
 
-			this.Behavior = behavior;
-			this.Interceptor = new Interceptor(behavior, typeof(T), this);
-			this.constructorArguments = args;
-			this.ImplementedInterfaces.AddRange(typeof(T).GetInterfaces().Where(i => (i.IsPublic || i.IsNestedPublic) && !i.IsImport));
-			this.ImplementedInterfaces.Add(typeof(IMocked<T>));
+            this.Behavior = behavior;
+            this.Interceptor = new Interceptor(typeof(T), this);
+            this.constructorArguments = args;
+            this.ImplementedInterfaces.AddRange(typeof(T).GetInterfaces().Where(i => (i.IsPublic || i.IsNestedPublic) && !i.IsImport));
+            this.ImplementedInterfaces.Add(typeof(IMocked<T>));
 
-			this.CheckParameters();
-		}
+            this.CheckParameters();
+        }
 
-		private string GenerateMockName()
-		{
-			var randomId = Guid.NewGuid().ToString("N").Substring(0, 4);
+        private string GenerateMockName()
+        {
+            var randomId = Guid.NewGuid().ToString("N").Substring(0, 4);
 
-			var typeName = typeof (T).FullName;
+            var typeName = typeof(T).FullName;
 
 #if !SILVERLIGHT
 			if (typeof (T).IsGenericType)
@@ -135,409 +135,409 @@ namespace Moq
 			}
 #endif
 
-			return "Mock<" + typeName + ":" + randomId + ">";
-		}
+            return "Mock<" + typeName + ":" + randomId + ">";
+        }
 
-		private void CheckParameters()
-		{
-			typeof(T).ThrowIfNotMockeable();
+        private void CheckParameters()
+        {
+            typeof(T).ThrowIfNotMockeable();
 
-			if (this.constructorArguments.Length > 0)
-			{
-				if (typeof(T).IsInterface)
-				{
-					throw new ArgumentException(Properties.Resources.ConstructorArgsForInterface);
-				}
-				if (typeof(T).IsDelegate())
-				{
-					throw new ArgumentException(Properties.Resources.ConstructorArgsForDelegate);
-				}
-			}
-		}
+            if (this.constructorArguments.Length > 0)
+            {
+                if (typeof(T).IsInterface)
+                {
+                    throw new ArgumentException(Properties.Resources.ConstructorArgsForInterface);
+                }
+                if (typeof(T).IsDelegate())
+                {
+                    throw new ArgumentException(Properties.Resources.ConstructorArgsForDelegate);
+                }
+            }
+        }
 
-		#endregion
+        #endregion
 
-		#region Properties
+        #region Properties
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Object"]/*'/>
-		[SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Object", Justification = "Exposes the mocked object instance, so it's appropriate.")]
-		[SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods", Justification = "The public Object property is the only one visible to Moq consumers. The protected member is for internal use only.")]
-		public virtual new T Object
-		{
-			get { return (T)base.Object; }
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Object"]/*'/>
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Object", Justification = "Exposes the mocked object instance, so it's appropriate.")]
+        [SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods", Justification = "The public Object property is the only one visible to Moq consumers. The protected member is for internal use only.")]
+        public virtual new T Object
+        {
+            get { return (T)base.Object; }
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Name"]/*'/>
-		public string Name { get; set; }
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Name"]/*'/>
+        public string Name { get; set; }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.ToString"]/*'/>
-		public override string ToString()
-		{
-			return this.Name;
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.ToString"]/*'/>
+        public override string ToString()
+        {
+            return this.Name;
+        }
 
-		internal override bool IsDelegateMock
+        internal override bool IsDelegateMock
         {
             get { return typeof(T).IsDelegate(); }
         }
 
-		private void InitializeInstance()
-		{
-			PexProtector.Invoke(() =>
-			{
-				if (this.IsDelegateMock)
-				{
-					// We're mocking a delegate.
-					// Firstly, get/create an interface with a method whose signature
-					// matches that of the delegate.
-					var delegateInterfaceType = proxyFactory.GetDelegateProxyInterface(typeof(T), out delegateInterfaceMethod);
+        private void InitializeInstance()
+        {
+            PexProtector.Invoke(() =>
+            {
+                if (this.IsDelegateMock)
+                {
+                    // We're mocking a delegate.
+                    // Firstly, get/create an interface with a method whose signature
+                    // matches that of the delegate.
+                    var delegateInterfaceType = proxyFactory.GetDelegateProxyInterface(typeof(T), out delegateInterfaceMethod);
 
-					// Then create a proxy for that.
-					var delegateProxy = proxyFactory.CreateProxy(
-						delegateInterfaceType,
-						this.Interceptor,
-						this.ImplementedInterfaces.ToArray(),
-						this.constructorArguments);
+                    // Then create a proxy for that.
+                    var delegateProxy = proxyFactory.CreateProxy(
+                        delegateInterfaceType,
+                        this.Interceptor,
+                        this.ImplementedInterfaces.ToArray(),
+                        this.constructorArguments);
 
-					// Then our instance is a delegate of the desired type, pointing at the
-					// appropriate method on that proxied interface instance.
-					this.instance = (T)(object)Delegate.CreateDelegate(typeof(T), delegateProxy, delegateInterfaceMethod);
-				}
-				else
-				{
-					this.instance = (T)proxyFactory.CreateProxy(
-						typeof(T),
-						this.Interceptor,
-						this.ImplementedInterfaces.ToArray(),
-						this.constructorArguments);
-				}
-			});
-		}
+                    // Then our instance is a delegate of the desired type, pointing at the
+                    // appropriate method on that proxied interface instance.
+                    this.instance = (T)(object)Delegate.CreateDelegate(typeof(T), delegateProxy, delegateInterfaceMethod);
+                }
+                else
+                {
+                    this.instance = (T)proxyFactory.CreateProxy(
+                        typeof(T),
+                        this.Interceptor,
+                        this.ImplementedInterfaces.ToArray(),
+                        this.constructorArguments);
+                }
+            });
+        }
 
-		private MethodInfo delegateInterfaceMethod;
+        private MethodInfo delegateInterfaceMethod;
 
-		/// <inheritdoc />
-		internal override MethodInfo DelegateInterfaceMethod
-		{
-			get
-			{
-				// Ensure object is created, which causes the delegateInterfaceMethod
-				// to be initialised.
-				OnGetObject();
+        /// <inheritdoc />
+        internal override MethodInfo DelegateInterfaceMethod
+        {
+            get
+            {
+                // Ensure object is created, which causes the delegateInterfaceMethod
+                // to be initialised.
+                OnGetObject();
 
-				return delegateInterfaceMethod;
-			}
-		}
+                return delegateInterfaceMethod;
+            }
+        }
 
-		/// <summary>
-		/// Returns the mocked object value.
-		/// </summary>
-		[SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "This is actually the protected virtual implementation of the property Object.")]
-		protected override object OnGetObject()
-		{
-			if (this.instance == null)
-			{
-				this.InitializeInstance();
-			}
+        /// <summary>
+        /// Returns the mocked object value.
+        /// </summary>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "This is actually the protected virtual implementation of the property Object.")]
+        protected override object OnGetObject()
+        {
+            if (this.instance == null)
+            {
+                this.InitializeInstance();
+            }
 
-			return this.instance;
-		}
+            return this.instance;
+        }
 
-		internal override Type MockedType
-		{
-			get { return typeof(T); }
-		}
+        internal override Type MockedType
+        {
+            get { return typeof(T); }
+        }
 
-		#endregion
+        #endregion
 
-		#region Setup
+        #region Setup
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Setup"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
-		public ISetup<T> Setup(Expression<Action<T>> expression)
-		{
-			return Mock.Setup<T>(this, expression, null);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Setup"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public ISetup<T> Setup(Expression<Action<T>> expression)
+        {
+            return Mock.Setup<T>(this, expression, null);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Setup{TResult}"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
-		public ISetup<T, TResult> Setup<TResult>(Expression<Func<T, TResult>> expression)
-		{
-			return Mock.Setup(this, expression, null);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Setup{TResult}"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public ISetup<T, TResult> Setup<TResult>(Expression<Func<T, TResult>> expression)
+        {
+            return Mock.Setup(this, expression, null);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupGet"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
-		public ISetupGetter<T, TProperty> SetupGet<TProperty>(Expression<Func<T, TProperty>> expression)
-		{
-			return Mock.SetupGet(this, expression, null);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupGet"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public ISetupGetter<T, TProperty> SetupGet<TProperty>(Expression<Func<T, TProperty>> expression)
+        {
+            return Mock.SetupGet(this, expression, null);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupSet{TProperty}"]/*'/>
-		public ISetupSetter<T, TProperty> SetupSet<TProperty>(Action<T> setterExpression)
-		{
-			return Mock.SetupSet<T, TProperty>(this, setterExpression, null);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupSet{TProperty}"]/*'/>
+        public ISetupSetter<T, TProperty> SetupSet<TProperty>(Action<T> setterExpression)
+        {
+            return Mock.SetupSet<T, TProperty>(this, setterExpression, null);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupSet"]/*'/>
-		public ISetup<T> SetupSet(Action<T> setterExpression)
-		{
-			return Mock.SetupSet<T>(this, setterExpression, null);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupSet"]/*'/>
+        public ISetup<T> SetupSet(Action<T> setterExpression)
+        {
+            return Mock.SetupSet<T>(this, setterExpression, null);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupProperty(property)"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
-		[SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Property", Justification = "This sets properties, so it's appropriate.")]
-		public Mock<T> SetupProperty<TProperty>(Expression<Func<T, TProperty>> property)
-		{
-			return this.SetupProperty(property, default(TProperty));
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupProperty(property)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Property", Justification = "This sets properties, so it's appropriate.")]
+        public Mock<T> SetupProperty<TProperty>(Expression<Func<T, TProperty>> property)
+        {
+            return this.SetupProperty(property, default(TProperty));
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupProperty(property,initialValue)"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
-		[SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Property", Justification = "We're setting up a property, so it's appropriate.")]
-		public Mock<T> SetupProperty<TProperty>(Expression<Func<T, TProperty>> property, TProperty initialValue)
-		{
-			TProperty value = initialValue;
-			this.SetupGet(property).Returns(() => value);
-			SetupSet<T, TProperty>(this, property).Callback(p => value = p);
-			return this;
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupProperty(property,initialValue)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Property", Justification = "We're setting up a property, so it's appropriate.")]
+        public Mock<T> SetupProperty<TProperty>(Expression<Func<T, TProperty>> property, TProperty initialValue)
+        {
+            TProperty value = initialValue;
+            this.SetupGet(property).Returns(() => value);
+            SetupSet<T, TProperty>(this, property).Callback(p => value = p);
+            return this;
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupAllProperties"]/*'/>
-		public Mock<T> SetupAllProperties()
-		{
-			SetupAllProperties(this);
-			return this;
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupAllProperties"]/*'/>
+        public Mock<T> SetupAllProperties()
+        {
+            SetupAllProperties(this);
+            return this;
+        }
 
-		#endregion
+        #endregion
 
-		#region When
+        #region When
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.When"]/*'/>
-		public ISetupConditionResult<T> When(Func<bool> condition)
-		{
-			return When(new Condition(condition));
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.When"]/*'/>
+        public ISetupConditionResult<T> When(Func<bool> condition)
+        {
+            return When(new Condition(condition));
+        }
 
-		internal ISetupConditionResult<T> When(Condition condition)
-		{
-			return new ConditionalContext<T>(this, condition);
-		}
+        internal ISetupConditionResult<T> When(Condition condition)
+        {
+            return new ConditionalContext<T>(this, condition);
+        }
 
-		#endregion
+        #endregion
 
-		#region Verify
+        #region Verify
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression)"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
-		public void Verify(Expression<Action<T>> expression)
-		{
-			Mock.Verify(this, expression, Times.AtLeastOnce(), null);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void Verify(Expression<Action<T>> expression)
+        {
+            Mock.Verify(this, expression, Times.AtLeastOnce(), null);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times)"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
-		public void Verify(Expression<Action<T>> expression, Times times)
-		{
-			Mock.Verify(this, expression, times, null);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void Verify(Expression<Action<T>> expression, Times times)
+        {
+            Mock.Verify(this, expression, times, null);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times)"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
-		public void Verify(Expression<Action<T>> expression, Func<Times> times)
-		{
-			Verify(expression, times());
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void Verify(Expression<Action<T>> expression, Func<Times> times)
+        {
+            Verify(expression, times());
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,failMessage)"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
-		public void Verify(Expression<Action<T>> expression, string failMessage)
-		{
-			Mock.Verify(this, expression, Times.AtLeastOnce(), failMessage);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,failMessage)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void Verify(Expression<Action<T>> expression, string failMessage)
+        {
+            Mock.Verify(this, expression, Times.AtLeastOnce(), failMessage);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times,failMessage)"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
-		public void Verify(Expression<Action<T>> expression, Times times, string failMessage)
-		{
-			Mock.Verify(this, expression, times, failMessage);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times,failMessage)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void Verify(Expression<Action<T>> expression, Times times, string failMessage)
+        {
+            Mock.Verify(this, expression, times, failMessage);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times,failMessage)"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
-		public void Verify(Expression<Action<T>> expression, Func<Times> times, string failMessage)
-		{
-			Verify(this, expression, times(), failMessage);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times,failMessage)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void Verify(Expression<Action<T>> expression, Func<Times> times, string failMessage)
+        {
+            Verify(this, expression, times(), failMessage);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression)"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
-		public void Verify<TResult>(Expression<Func<T, TResult>> expression)
-		{
-			Mock.Verify(this, expression, Times.AtLeastOnce(), null);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void Verify<TResult>(Expression<Func<T, TResult>> expression)
+        {
+            Mock.Verify(this, expression, Times.AtLeastOnce(), null);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,times)"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
-		public void Verify<TResult>(Expression<Func<T, TResult>> expression, Times times)
-		{
-			Mock.Verify(this, expression, times, null);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,times)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void Verify<TResult>(Expression<Func<T, TResult>> expression, Times times)
+        {
+            Mock.Verify(this, expression, times, null);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,times)"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
-		public void Verify<TResult>(Expression<Func<T, TResult>> expression, Func<Times> times)
-		{
-			Verify(this, expression, times(), null);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,times)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void Verify<TResult>(Expression<Func<T, TResult>> expression, Func<Times> times)
+        {
+            Verify(this, expression, times(), null);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,failMessage)"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
-		public void Verify<TResult>(Expression<Func<T, TResult>> expression, string failMessage)
-		{
-			Mock.Verify(this, expression, Times.AtLeastOnce(), failMessage);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,failMessage)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void Verify<TResult>(Expression<Func<T, TResult>> expression, string failMessage)
+        {
+            Mock.Verify(this, expression, Times.AtLeastOnce(), failMessage);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,times,failMessage)"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
-		public void Verify<TResult>(Expression<Func<T, TResult>> expression, Times times, string failMessage)
-		{
-			Mock.Verify(this, expression, times, failMessage);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,times,failMessage)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void Verify<TResult>(Expression<Func<T, TResult>> expression, Times times, string failMessage)
+        {
+            Mock.Verify(this, expression, times, failMessage);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyGet(expression)"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
-		public void VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression)
-		{
-			Mock.VerifyGet(this, expression, Times.AtLeastOnce(), null);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyGet(expression)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression)
+        {
+            Mock.VerifyGet(this, expression, Times.AtLeastOnce(), null);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyGet(expression,times)"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
-		public void VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression, Times times)
-		{
-			Mock.VerifyGet(this, expression, times, null);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyGet(expression,times)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression, Times times)
+        {
+            Mock.VerifyGet(this, expression, times, null);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyGet(expression,times)"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
-		public void VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression, Func<Times> times)
-		{
-			VerifyGet(this, expression, times(), null);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyGet(expression,times)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression, Func<Times> times)
+        {
+            VerifyGet(this, expression, times(), null);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyGet(expression,failMessage)"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
-		public void VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression, string failMessage)
-		{
-			Mock.VerifyGet(this, expression, Times.AtLeastOnce(), failMessage);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyGet(expression,failMessage)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression, string failMessage)
+        {
+            Mock.VerifyGet(this, expression, Times.AtLeastOnce(), failMessage);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyGet(expression,times,failMessage)"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
-		public void VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression, Times times, string failMessage)
-		{
-			Mock.VerifyGet(this, expression, times, failMessage);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyGet(expression,times,failMessage)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression, Times times, string failMessage)
+        {
+            Mock.VerifyGet(this, expression, times, failMessage);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyGet(expression,times,failMessage)"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
-		public void VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression, Func<Times> times, string failMessage)
-		{
-			VerifyGet(this, expression, times(), failMessage);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyGet(expression,times,failMessage)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+        public void VerifyGet<TProperty>(Expression<Func<T, TProperty>> expression, Func<Times> times, string failMessage)
+        {
+            VerifyGet(this, expression, times(), failMessage);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifySet(expression)"]/*'/>
-		public void VerifySet(Action<T> setterExpression)
-		{
-			Mock.VerifySet<T>(this, setterExpression, Times.AtLeastOnce(), null);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifySet(expression)"]/*'/>
+        public void VerifySet(Action<T> setterExpression)
+        {
+            Mock.VerifySet<T>(this, setterExpression, Times.AtLeastOnce(), null);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifySet(expression,times)"]/*'/>
-		public void VerifySet(Action<T> setterExpression, Times times)
-		{
-			Mock.VerifySet(this, setterExpression, times, null);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifySet(expression,times)"]/*'/>
+        public void VerifySet(Action<T> setterExpression, Times times)
+        {
+            Mock.VerifySet(this, setterExpression, times, null);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifySet(expression,times)"]/*'/>
-		public void VerifySet(Action<T> setterExpression, Func<Times> times)
-		{
-			Mock.VerifySet(this, setterExpression, times(), null);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifySet(expression,times)"]/*'/>
+        public void VerifySet(Action<T> setterExpression, Func<Times> times)
+        {
+            Mock.VerifySet(this, setterExpression, times(), null);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifySet(expression,failMessage)"]/*'/>
-		public void VerifySet(Action<T> setterExpression, string failMessage)
-		{
-			Mock.VerifySet(this, setterExpression, Times.AtLeastOnce(), failMessage);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifySet(expression,failMessage)"]/*'/>
+        public void VerifySet(Action<T> setterExpression, string failMessage)
+        {
+            Mock.VerifySet(this, setterExpression, Times.AtLeastOnce(), failMessage);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifySet(expression,times,failMessage)"]/*'/>
-		public void VerifySet(Action<T> setterExpression, Times times, string failMessage)
-		{
-			Mock.VerifySet(this, setterExpression, times, failMessage);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifySet(expression,times,failMessage)"]/*'/>
+        public void VerifySet(Action<T> setterExpression, Times times, string failMessage)
+        {
+            Mock.VerifySet(this, setterExpression, times, failMessage);
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifySet(expression,times,failMessage)"]/*'/>
-		public void VerifySet(Action<T> setterExpression, Func<Times> times, string failMessage)
-		{
-			Mock.VerifySet(this, setterExpression, times(), failMessage);
-		}
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifySet(expression,times,failMessage)"]/*'/>
+        public void VerifySet(Action<T> setterExpression, Func<Times> times, string failMessage)
+        {
+            Mock.VerifySet(this, setterExpression, times(), failMessage);
+        }
 
-		#endregion
+        #endregion
 
-		#region Raise
+        #region Raise
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Raise"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate", Justification = "Raises the event, rather than being one.")]
-		[SuppressMessage("Microsoft.Usage", "CA2200:RethrowToPreserveStackDetails", Justification = "We want to reset the stack trace to avoid Moq noise in it.")]
-		public void Raise(Action<T> eventExpression, EventArgs args)
-		{
-			var ev = eventExpression.GetEvent(this.Object);
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Raise"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate", Justification = "Raises the event, rather than being one.")]
+        [SuppressMessage("Microsoft.Usage", "CA2200:RethrowToPreserveStackDetails", Justification = "We want to reset the stack trace to avoid Moq noise in it.")]
+        public void Raise(Action<T> eventExpression, EventArgs args)
+        {
+            var ev = eventExpression.GetEvent(this.Object);
 
-			try
-			{
-				this.DoRaise(ev, args);
-			}
-			catch (Exception e)
-			{
-				// Reset stacktrace so user gets this call site only.
-				throw e;
-			}
-		}
+            try
+            {
+                this.DoRaise(ev, args);
+            }
+            catch (Exception e)
+            {
+                // Reset stacktrace so user gets this call site only.
+                throw e;
+            }
+        }
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Raise(args)"]/*'/>
-		[SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate", Justification = "Raises the event, rather than being one.")]
-		[SuppressMessage("Microsoft.Usage", "CA2200:RethrowToPreserveStackDetails", Justification = "We want to reset the stack trace to avoid Moq noise in it.")]
-		public void Raise(Action<T> eventExpression, params object[] args)
-		{
-			var ev = eventExpression.GetEvent(this.Object);
+        /// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Raise(args)"]/*'/>
+        [SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate", Justification = "Raises the event, rather than being one.")]
+        [SuppressMessage("Microsoft.Usage", "CA2200:RethrowToPreserveStackDetails", Justification = "We want to reset the stack trace to avoid Moq noise in it.")]
+        public void Raise(Action<T> eventExpression, params object[] args)
+        {
+            var ev = eventExpression.GetEvent(this.Object);
 
-			try
-			{
-				this.DoRaise(ev, args);
-			}
-			catch (Exception e)
-			{
-				// Reset stacktrace so user gets this call site only.
-				throw e;
-			}
-		}
+            try
+            {
+                this.DoRaise(ev, args);
+            }
+            catch (Exception e)
+            {
+                // Reset stacktrace so user gets this call site only.
+                throw e;
+            }
+        }
 
-		#endregion
+        #endregion
 
-		// NOTE: known issue. See https://connect.microsoft.com/VisualStudio/feedback/ViewFeedback.aspx?FeedbackID=318122
-		//public static implicit operator TInterface(Mock<T> mock)
-		//{
-		//    // TODO: doesn't work as expected but ONLY with interfaces :S
-		//    return mock.Object;
-		//}
+        // NOTE: known issue. See https://connect.microsoft.com/VisualStudio/feedback/ViewFeedback.aspx?FeedbackID=318122
+        //public static implicit operator TInterface(Mock<T> mock)
+        //{
+        //    // TODO: doesn't work as expected but ONLY with interfaces :S
+        //    return mock.Object;
+        //}
 
-		//public static explicit operator TInterface(Mock<T> mock)
-		//{
-		//    // TODO: doesn't work as expected but ONLY with interfaces :S
-		//    throw new NotImplementedException();
-		//}
-	}
+        //public static explicit operator TInterface(Mock<T> mock)
+        //{
+        //    // TODO: doesn't work as expected but ONLY with interfaces :S
+        //    throw new NotImplementedException();
+        //}
+    }
 }

--- a/UnitTests/Linq/BehaviorFixture.cs
+++ b/UnitTests/Linq/BehaviorFixture.cs
@@ -1,0 +1,124 @@
+﻿namespace Moq.Tests.Linq
+{
+    using System;
+
+    using Xunit;
+
+    public class BehaviorFixture
+    {
+        [Fact]
+        public void NoQuery_Default()
+        {
+            var target = Mock.Of<IFoo>();
+            Assert.Equal(MockBehavior.Default, Mock.Get(target).Behavior);
+            Assert.False(target.BoolProperty1);
+        }
+
+        [Fact]
+        public void WithQuery_Default()
+        {
+            var target = Mock.Of<IFoo>(x => x.BoolProperty1 == true);
+            Assert.Equal(MockBehavior.Default, Mock.Get(target).Behavior);
+            Assert.True(target.BoolProperty1);
+        }
+
+        [Fact]
+        public void NoQuery_Strict()
+        {
+            var target = Mock.Of<IFoo>(MockBehavior.Strict);
+            Assert.Equal(MockBehavior.Strict, Mock.Get(target).Behavior);
+            var mex = Assert.Throws<MockException>(() => target.BoolProperty1);
+            Assert.Equal(MockException.ExceptionReason.NoSetup, mex.Reason);
+
+        }
+
+        [Fact]
+        public void NoQuery_Loose()
+        {
+            var target = Mock.Of<IFoo>(MockBehavior.Loose);
+            Assert.Equal(MockBehavior.Loose, Mock.Get(target).Behavior);
+            Assert.False(target.BoolProperty1);
+        }
+
+        [Fact]
+        public void WithQuery_Strict()
+        {
+            var target = Mock.Of<IFoo>(x => x.BoolProperty1 == true, MockBehavior.Strict);
+            Assert.True(target.BoolProperty1);
+            Assert.Equal(MockBehavior.Strict, Mock.Get(target).Behavior);
+            var mex = Assert.Throws<MockException>(() => target.BoolProperty2);
+            Assert.Equal(MockException.ExceptionReason.NoSetup, mex.Reason);
+        }
+
+        [Fact]
+        public void WithQuery_Loose()
+        {
+            var target = Mock.Of<IFoo>(x => x.BoolProperty1 == true, MockBehavior.Loose);
+            Assert.True(target.BoolProperty1);
+            Assert.Equal(MockBehavior.Loose, Mock.Get(target).Behavior);
+            Assert.False(target.BoolProperty2);
+        }
+
+        [Fact]
+        public void ShouldAllowFluentOnNonVirtualReadWriteProperty_Strict()
+        {
+            var dto = Mock.Of<QueryableMocksFixture.Dto>(x => x.Value == "foo", MockBehavior.Strict);
+            Assert.Equal("foo", dto.Value);
+        }
+
+        [Fact]
+        public void WithQuery_ThrowsWhenStrict()
+        {
+            var target = Mock.Of<IFoo>(x => x.BoolProperty1 == true, MockBehavior.Strict);
+            Assert.True(target.BoolProperty1);
+
+            var mex = Assert.Throws<MockException>(() => target.BoolProperty2);
+            Assert.Equal(MockException.ExceptionReason.NoSetup, mex.Reason);
+
+            mex = Assert.Throws<MockException>(() => target.BoolMethod());
+            Assert.Equal(MockException.ExceptionReason.NoSetup, mex.Reason);
+        }
+
+        [Fact]
+        public void NoQuery_ThrowsWhenStrict()
+        {
+            var target = Mock.Of<IFoo>(MockBehavior.Strict);
+            var mex = Assert.Throws<MockException>(() => target.BoolProperty1);
+            Assert.Equal(MockException.ExceptionReason.NoSetup, mex.Reason);
+
+            mex = Assert.Throws<MockException>(() => target.BoolMethod());
+            Assert.Equal(MockException.ExceptionReason.NoSetup, mex.Reason);
+        }
+
+        [Fact]
+        public void WithQuery_DoesNotThrowWhenLoose()
+        {
+            var target = Mock.Of<IFoo>(x => x.BoolProperty1 == true, MockBehavior.Loose);
+            Assert.True(target.BoolProperty1);
+
+            Assert.False(target.BoolProperty2);
+
+            Assert.False(target.BoolMethod());
+
+            Assert.DoesNotThrow(() => target.VoidMethod());
+        }
+
+        [Fact]
+        public void NoQuery_DoesNotThrowsWhenLoose()
+        {
+            var target = Mock.Of<IFoo>(MockBehavior.Loose);
+            Assert.DoesNotThrow(() => { var temp = target.BoolProperty1; });
+            Assert.DoesNotThrow(() => { var temp = target.BoolProperty2; });
+            Assert.DoesNotThrow(() => target.BoolMethod());
+            Assert.DoesNotThrow(() => target.VoidMethod());
+        }
+
+        public interface IFoo
+        {
+            bool BoolProperty1 { get; set; }
+            bool BoolProperty2 { get; set; }
+            bool BoolMethod();
+            void VoidMethod();
+        }
+    }
+}

--- a/UnitTests/Linq/QueryableMocksFixture.cs
+++ b/UnitTests/Linq/QueryableMocksFixture.cs
@@ -1,11 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
-using System.Collections.Generic;
-using System.Linq.Expressions;
-using System.Reflection;
 
-namespace Moq.Tests
+namespace Moq.Tests.Linq
 {
 	public class QueryableMocksFixture
 	{

--- a/UnitTests/MockBehaviorFixture.cs
+++ b/UnitTests/MockBehaviorFixture.cs
@@ -6,304 +6,317 @@ using Xunit;
 
 namespace Moq.Tests
 {
-	public class MockBehaviorFixture
-	{
-		[Fact]
-		public void ShouldThrowIfStrictNoExpectation()
-		{
-			var mock = new Mock<IFoo>(MockBehavior.Strict);
-			try
-			{
-				mock.Object.Do();
-				Assert.True(false, "Should have thrown for unexpected call with MockBehavior.Strict");
-			}
-			catch (MockException mex)
-			{
-				Assert.Equal(MockException.ExceptionReason.NoSetup, mex.Reason);
-			}
-		}
-
-		[Fact]
-		public void ShouldReturnDefaultForLooseBehaviorOnInterface()
-		{
-			var mock = new Mock<IFoo>(MockBehavior.Loose);
-
-			Assert.Equal(0, mock.Object.Get());
-			Assert.Null(mock.Object.GetObject());
-		}
-
-		[Fact]
-		public void ShouldReturnDefaultForLooseBehaviorOnAbstract()
-		{
-			var mock = new Mock<Foo>(MockBehavior.Loose);
-
-			Assert.Equal(0, mock.Object.AbstractGet());
-			Assert.Null(mock.Object.GetObject());
-		}
-
-		[Fact]
-		public void ShouldReturnEmptyArrayOnLoose()
-		{
-			var mock = new Mock<IFoo>(MockBehavior.Loose);
-
-			Assert.NotNull(mock.Object.GetArray());
-			Assert.Equal(0, mock.Object.GetArray().Length);
-		}
-
-		[Fact]
-		public void ShouldReturnEmptyArrayTwoDimensionsOnLoose()
-		{
-			var mock = new Mock<IFoo>(MockBehavior.Loose);
-
-			Assert.NotNull(mock.Object.GetArrayTwoDimensions());
-			Assert.Equal(0, mock.Object.GetArrayTwoDimensions().Length);
-		}
-
-		[Fact]
-		public void ShouldReturnNullListOnLoose()
-		{
-			var mock = new Mock<IFoo>(MockBehavior.Loose);
-
-			Assert.Null(mock.Object.GetList());
-		}
-
-		[Fact]
-		public void ShouldReturnEmptyEnumerableStringOnLoose()
-		{
-			var mock = new Mock<IFoo>(MockBehavior.Loose);
-
-			Assert.NotNull(mock.Object.GetEnumerable());
-			Assert.Equal(0, mock.Object.GetEnumerable().Count());
-		}
-
-		[Fact]
-		public void ShouldReturnEmptyEnumerableObjectsOnLoose()
-		{
-			var mock = new Mock<IFoo>(MockBehavior.Loose);
-
-			Assert.NotNull(mock.Object.GetEnumerableObjects());
-			Assert.Equal(0, mock.Object.GetEnumerableObjects().Cast<object>().Count());
-		}
-
-		[Fact]
-		public void ShouldReturnDefaultGuidOnLoose()
-		{
-			var mock = new Mock<IFoo>(MockBehavior.Loose);
-			Assert.Equal(default(Guid), mock.Object.GetGuid());
-		}
-
-		[Fact]
-		public void ShouldReturnNullStringOnLoose()
-		{
-			var mock = new Mock<IFoo>(MockBehavior.Loose);
-
-			Assert.Null(mock.Object.DoReturnString());
-		}
-
-		[Fact]
-		public void ShouldReturnNullStringOnLooseWithExpect()
-		{
-			var mock = new Mock<IFoo>(MockBehavior.Loose);
-
-			mock.Setup(x => x.DoReturnString());
-
-			Assert.Null(mock.Object.DoReturnString());
-		}
+    public class MockBehaviorFixture
+    {
+        [Fact]
+        public void ShouldThrowIfStrictNoExpectation()
+        {
+            var mock = new Mock<IFoo>(MockBehavior.Strict);
+            var mex = Assert.Throws<MockException>(() => mock.Object.Do());
+            Assert.Equal(MockException.ExceptionReason.NoSetup, mex.Reason);
+        }
+
+        [Fact]
+        public void BehaviorStrictThenLooseUpdates()
+        {
+            var mock = new Mock<IFoo>(MockBehavior.Strict);
+            Assert.Throws<MockException>(() => mock.Object.Do());
+
+            mock.Behavior = MockBehavior.Loose;
+            Assert.DoesNotThrow(() => mock.Object.Do());
+        }
+
+        [Fact]
+        public void BehaviorLooseThenStrictUpdates()
+        {
+            var mock = new Mock<IFoo>(MockBehavior.Loose);
+            Assert.DoesNotThrow(() => mock.Object.Do());
+
+            mock.Behavior = MockBehavior.Strict;
+            Assert.Throws<MockException>(() => mock.Object.Do());
+        }
+
+        [Fact]
+        public void ShouldReturnDefaultForLooseBehaviorOnInterface()
+        {
+            var mock = new Mock<IFoo>(MockBehavior.Loose);
+
+            Assert.Equal(0, mock.Object.Get());
+            Assert.Null(mock.Object.GetObject());
+        }
+
+        [Fact]
+        public void ShouldReturnDefaultForLooseBehaviorOnAbstract()
+        {
+            var mock = new Mock<Foo>(MockBehavior.Loose);
+
+            Assert.Equal(0, mock.Object.AbstractGet());
+            Assert.Null(mock.Object.GetObject());
+        }
+
+        [Fact]
+        public void ShouldReturnEmptyArrayOnLoose()
+        {
+            var mock = new Mock<IFoo>(MockBehavior.Loose);
+
+            Assert.NotNull(mock.Object.GetArray());
+            Assert.Equal(0, mock.Object.GetArray().Length);
+        }
+
+        [Fact]
+        public void ShouldReturnEmptyArrayTwoDimensionsOnLoose()
+        {
+            var mock = new Mock<IFoo>(MockBehavior.Loose);
+
+            Assert.NotNull(mock.Object.GetArrayTwoDimensions());
+            Assert.Equal(0, mock.Object.GetArrayTwoDimensions().Length);
+        }
+
+        [Fact]
+        public void ShouldReturnNullListOnLoose()
+        {
+            var mock = new Mock<IFoo>(MockBehavior.Loose);
+
+            Assert.Null(mock.Object.GetList());
+        }
+
+        [Fact]
+        public void ShouldReturnEmptyEnumerableStringOnLoose()
+        {
+            var mock = new Mock<IFoo>(MockBehavior.Loose);
+
+            Assert.NotNull(mock.Object.GetEnumerable());
+            Assert.Equal(0, mock.Object.GetEnumerable().Count());
+        }
+
+        [Fact]
+        public void ShouldReturnEmptyEnumerableObjectsOnLoose()
+        {
+            var mock = new Mock<IFoo>(MockBehavior.Loose);
+
+            Assert.NotNull(mock.Object.GetEnumerableObjects());
+            Assert.Equal(0, mock.Object.GetEnumerableObjects().Cast<object>().Count());
+        }
+
+        [Fact]
+        public void ShouldReturnDefaultGuidOnLoose()
+        {
+            var mock = new Mock<IFoo>(MockBehavior.Loose);
+            Assert.Equal(default(Guid), mock.Object.GetGuid());
+        }
+
+        [Fact]
+        public void ShouldReturnNullStringOnLoose()
+        {
+            var mock = new Mock<IFoo>(MockBehavior.Loose);
 
-		[Fact]
-		public void ReturnsMockDefaultValueForLooseBehaviorOnInterface()
-		{
-			var mock = new Mock<IFoo>(MockBehavior.Loose) { DefaultValue = DefaultValue.Mock };
+            Assert.Null(mock.Object.DoReturnString());
+        }
 
-			var value = mock.Object.GetObject();
+        [Fact]
+        public void ShouldReturnNullStringOnLooseWithExpect()
+        {
+            var mock = new Mock<IFoo>(MockBehavior.Loose);
 
-			Assert.True(value is IMocked);
-		}
+            mock.Setup(x => x.DoReturnString());
 
-		[Fact]
-		public void ReturnsMockDefaultValueForLooseBehaviorOnAbstract()
-		{
-			var mock = new Mock<Foo>(MockBehavior.Loose) { DefaultValue = DefaultValue.Mock };
+            Assert.Null(mock.Object.DoReturnString());
+        }
 
-			var value = mock.Object.Bar;
+        [Fact]
+        public void ReturnsMockDefaultValueForLooseBehaviorOnInterface()
+        {
+            var mock = new Mock<IFoo>(MockBehavior.Loose) { DefaultValue = DefaultValue.Mock };
 
-			Assert.True(value is IMocked);
-
-			value = mock.Object.GetBar();
-
-			Assert.True(value is IMocked);
-		}
-
-		[Fact]
-		public void ReturnsEmptyArrayOnLooseWithMockDefaultValue()
-		{
-			var mock = new Mock<IFoo>(MockBehavior.Loose) { DefaultValue = DefaultValue.Mock };
-
-			Assert.NotNull(mock.Object.GetArray());
-			Assert.Equal(0, mock.Object.GetArray().Length);
-		}
-
-		[Fact]
-		public void ReturnsEmptyArrayTwoDimensionsOnLooseWithMockDefaultValue()
-		{
-			var mock = new Mock<IFoo>(MockBehavior.Loose) { DefaultValue = DefaultValue.Mock };
-
-			Assert.NotNull(mock.Object.GetArrayTwoDimensions());
-			Assert.Equal(0, mock.Object.GetArrayTwoDimensions().Length);
-		}
-
-		[Fact]
-		public void ReturnsMockListOnLooseWithMockDefaultValue()
-		{
-			var mock = new Mock<IFoo>(MockBehavior.Loose) { DefaultValue = DefaultValue.Mock };
-
-			Assert.NotNull(mock.Object.GetList());
-
-			var list = mock.Object.GetList();
-
-			list.Add("foo");
-
-			Assert.Equal("foo", list[0]);
-		}
-
-		[Fact]
-		public void ReturnsEmptyEnumerableStringOnLooseWithMockDefaultValue()
-		{
-			var mock = new Mock<IFoo>(MockBehavior.Loose) { DefaultValue = DefaultValue.Mock };
-
-			Assert.NotNull(mock.Object.GetEnumerable());
-			Assert.Equal(0, mock.Object.GetEnumerable().Count());
-		}
-
-		[Fact]
-		public void ReturnsEmptyQueryableStringOnLooseWithMockDefaultValue()
-		{
-			var mock = new Mock<IFoo>(MockBehavior.Loose) { DefaultValue = DefaultValue.Mock };
-
-			Assert.NotNull(mock.Object.GetQueryable());
-			Assert.Equal(0, mock.Object.GetQueryable().Count());
-		}
-
-		[Fact]
-		public void ReturnsEmptyEnumerableObjectsOnLooseWithMockDefaultValue()
-		{
-			var mock = new Mock<IFoo>(MockBehavior.Loose) { DefaultValue = DefaultValue.Mock };
-
-			Assert.NotNull(mock.Object.GetEnumerableObjects());
-			Assert.Equal(0, mock.Object.GetEnumerableObjects().Cast<object>().Count());
-		}
-
-		[Fact]
-		public void ReturnsEmptyQueryableObjectsOnLooseWithMockDefaultValue()
-		{
-			var mock = new Mock<IFoo>(MockBehavior.Loose) { DefaultValue = DefaultValue.Mock };
-
-			Assert.NotNull(mock.Object.GetQueryableObjects());
-			Assert.Equal(0, mock.Object.GetQueryableObjects().Cast<object>().Count());
-		}
-
-		[Fact]
-		public void ReturnsDefaultGuidOnLooseWithMockDefaultValueWithMockDefaultValue()
-		{
-			var mock = new Mock<IFoo>(MockBehavior.Loose) { DefaultValue = DefaultValue.Mock };
-			Assert.Equal(default(Guid), mock.Object.GetGuid());
-		}
-
-		[Fact]
-		public void ReturnsNullStringOnLooseWithMockDefaultValue()
-		{
-			var mock = new Mock<IFoo>(MockBehavior.Loose) { DefaultValue = DefaultValue.Mock };
-
-			Assert.Null(mock.Object.DoReturnString());
-		}
-
-		public interface IFoo
-		{
-			void Do();
-			int Get();
-			Guid GetGuid();
-			object GetObject();
-			string[] GetArray();
-			string[][] GetArrayTwoDimensions();
-			List<string> GetList();
-			IEnumerable<string> GetEnumerable();
-			IEnumerable GetEnumerableObjects();
-			string DoReturnString();
-			IQueryable<string> GetQueryable();
-			IQueryable GetQueryableObjects();
-		}
-
-		public interface IBar { }
-
-		public abstract class Foo : IFoo
-		{
-			public abstract IBar Bar { get; set; }
-			public abstract IBar GetBar();
-
-			public abstract void Do();
-			public abstract object GetObject();
-			public abstract string DoReturnString();
-
-			public void DoNonVirtual() { }
-			public virtual void DoVirtual() { }
-
-			public int NonVirtualGet()
-			{
-				return 0;
-			}
-
-			public int VirtualGet()
-			{
-				return 0;
-			}
-
-			public virtual int Get()
-			{
-				return AbstractGet();
-			}
-
-			public abstract int AbstractGet();
-
-			public string[] GetArray()
-			{
-				return new string[0];
-			}
-
-			public string[][] GetArrayTwoDimensions()
-			{
-				return new string[0][];
-			}
-
-			public List<string> GetList()
-			{
-				return null;
-			}
-
-			public IEnumerable<string> GetEnumerable()
-			{
-				return new string[0];
-			}
-
-			public IEnumerable GetEnumerableObjects()
-			{
-				return new object[0];
-			}
-
-
-			public Guid GetGuid()
-			{
-				return default(Guid);
-			}
-
-			public IQueryable<string> GetQueryable()
-			{
-				return new string[0].AsQueryable();
-			}
-
-			public IQueryable GetQueryableObjects()
-			{
-				return new object[0].AsQueryable();
-			}
-		}
-	}
+            var value = mock.Object.GetObject();
+
+            Assert.True(value is IMocked);
+        }
+
+        [Fact]
+        public void ReturnsMockDefaultValueForLooseBehaviorOnAbstract()
+        {
+            var mock = new Mock<Foo>(MockBehavior.Loose) { DefaultValue = DefaultValue.Mock };
+
+            var value = mock.Object.Bar;
+
+            Assert.True(value is IMocked);
+
+            value = mock.Object.GetBar();
+
+            Assert.True(value is IMocked);
+        }
+
+        [Fact]
+        public void ReturnsEmptyArrayOnLooseWithMockDefaultValue()
+        {
+            var mock = new Mock<IFoo>(MockBehavior.Loose) { DefaultValue = DefaultValue.Mock };
+
+            Assert.NotNull(mock.Object.GetArray());
+            Assert.Equal(0, mock.Object.GetArray().Length);
+        }
+
+        [Fact]
+        public void ReturnsEmptyArrayTwoDimensionsOnLooseWithMockDefaultValue()
+        {
+            var mock = new Mock<IFoo>(MockBehavior.Loose) { DefaultValue = DefaultValue.Mock };
+
+            Assert.NotNull(mock.Object.GetArrayTwoDimensions());
+            Assert.Equal(0, mock.Object.GetArrayTwoDimensions().Length);
+        }
+
+        [Fact]
+        public void ReturnsMockListOnLooseWithMockDefaultValue()
+        {
+            var mock = new Mock<IFoo>(MockBehavior.Loose) { DefaultValue = DefaultValue.Mock };
+
+            Assert.NotNull(mock.Object.GetList());
+
+            var list = mock.Object.GetList();
+
+            list.Add("foo");
+
+            Assert.Equal("foo", list[0]);
+        }
+
+        [Fact]
+        public void ReturnsEmptyEnumerableStringOnLooseWithMockDefaultValue()
+        {
+            var mock = new Mock<IFoo>(MockBehavior.Loose) { DefaultValue = DefaultValue.Mock };
+
+            Assert.NotNull(mock.Object.GetEnumerable());
+            Assert.Equal(0, mock.Object.GetEnumerable().Count());
+        }
+
+        [Fact]
+        public void ReturnsEmptyQueryableStringOnLooseWithMockDefaultValue()
+        {
+            var mock = new Mock<IFoo>(MockBehavior.Loose) { DefaultValue = DefaultValue.Mock };
+
+            Assert.NotNull(mock.Object.GetQueryable());
+            Assert.Equal(0, mock.Object.GetQueryable().Count());
+        }
+
+        [Fact]
+        public void ReturnsEmptyEnumerableObjectsOnLooseWithMockDefaultValue()
+        {
+            var mock = new Mock<IFoo>(MockBehavior.Loose) { DefaultValue = DefaultValue.Mock };
+
+            Assert.NotNull(mock.Object.GetEnumerableObjects());
+            Assert.Equal(0, mock.Object.GetEnumerableObjects().Cast<object>().Count());
+        }
+
+        [Fact]
+        public void ReturnsEmptyQueryableObjectsOnLooseWithMockDefaultValue()
+        {
+            var mock = new Mock<IFoo>(MockBehavior.Loose) { DefaultValue = DefaultValue.Mock };
+
+            Assert.NotNull(mock.Object.GetQueryableObjects());
+            Assert.Equal(0, mock.Object.GetQueryableObjects().Cast<object>().Count());
+        }
+
+        [Fact]
+        public void ReturnsDefaultGuidOnLooseWithMockDefaultValueWithMockDefaultValue()
+        {
+            var mock = new Mock<IFoo>(MockBehavior.Loose) { DefaultValue = DefaultValue.Mock };
+            Assert.Equal(default(Guid), mock.Object.GetGuid());
+        }
+
+        [Fact]
+        public void ReturnsNullStringOnLooseWithMockDefaultValue()
+        {
+            var mock = new Mock<IFoo>(MockBehavior.Loose) { DefaultValue = DefaultValue.Mock };
+
+            Assert.Null(mock.Object.DoReturnString());
+        }
+
+        public interface IFoo
+        {
+            void Do();
+            int Get();
+            Guid GetGuid();
+            object GetObject();
+            string[] GetArray();
+            string[][] GetArrayTwoDimensions();
+            List<string> GetList();
+            IEnumerable<string> GetEnumerable();
+            IEnumerable GetEnumerableObjects();
+            string DoReturnString();
+            IQueryable<string> GetQueryable();
+            IQueryable GetQueryableObjects();
+        }
+
+        public interface IBar { }
+
+        public abstract class Foo : IFoo
+        {
+            public abstract IBar Bar { get; set; }
+            public abstract IBar GetBar();
+
+            public abstract void Do();
+            public abstract object GetObject();
+            public abstract string DoReturnString();
+
+            public void DoNonVirtual() { }
+            public virtual void DoVirtual() { }
+
+            public int NonVirtualGet()
+            {
+                return 0;
+            }
+
+            public int VirtualGet()
+            {
+                return 0;
+            }
+
+            public virtual int Get()
+            {
+                return AbstractGet();
+            }
+
+            public abstract int AbstractGet();
+
+            public string[] GetArray()
+            {
+                return new string[0];
+            }
+
+            public string[][] GetArrayTwoDimensions()
+            {
+                return new string[0][];
+            }
+
+            public List<string> GetList()
+            {
+                return null;
+            }
+
+            public IEnumerable<string> GetEnumerable()
+            {
+                return new string[0];
+            }
+
+            public IEnumerable GetEnumerableObjects()
+            {
+                return new object[0];
+            }
+
+
+            public Guid GetGuid()
+            {
+                return default(Guid);
+            }
+
+            public IQueryable<string> GetQueryable()
+            {
+                return new string[0].AsQueryable();
+            }
+
+            public IQueryable GetQueryableObjects()
+            {
+                return new object[0].AsQueryable();
+            }
+        }
+    }
 }

--- a/UnitTests/Moq.Tests.csproj
+++ b/UnitTests/Moq.Tests.csproj
@@ -50,7 +50,7 @@
       <HintPath>..\packages\Castle.Core.3.3.3\lib\net35\Castle.Core.dll</HintPath>
       <Visible>False</Visible>
     </Reference>
-		<Reference Include="ClassLibrary1">
+    <Reference Include="ClassLibrary1">
       <HintPath>.\ClassLibrary1.dll</HintPath>
     </Reference>
     <Reference Include="ClassLibrary2">
@@ -84,6 +84,7 @@
     <Compile Include="ConditionalSetupFixture.cs" />
     <Compile Include="CustomMatcherFixture.cs" />
     <Compile Include="ExtensionsFixture.cs" />
+    <Compile Include="Linq\BehaviorFixture.cs" />
     <Compile Include="ReturnsExtensionsFixture.cs" />
     <Compile Include="Linq\MockRepositoryQuerying.cs" />
     <Compile Include="MockedDelegatesFixture.cs" />


### PR DESCRIPTION
Removed MockBehavior parameter from InterceptorContext ctor + tests.

Added overloads with MockBehavior to Mock.Of<T>(...) I could not figure out what problem CreateMockQuery et al. are solving. Wrote a couple of overloads with MockBehaviour. Threw in a couple of tests but don't know what all relevant testcases are.
