### PR TITLE
Fix NullReferenceException when passing null to a nullable argument but trying to match it with a non-nullable IsAny.

### DIFF
--- a/Source/Match.cs
+++ b/Source/Match.cs
@@ -128,7 +128,18 @@ namespace Moq
 			{
 				return false;
 			}
-
+			if (value == null && typeof(T).IsValueType)
+			{
+				// If this.Condition expects a value type and we've been passed null,
+				// it can't possibly match.
+				// This tends to happen when you are trying to match a parameter of type int?
+				// with IsAny<int> but then pass null into the mock.
+				// We have to return early from here because you can't cast null to T
+				// when T is a value type.
+				//
+				// See Github issue #90: https://github.com/Moq/moq4/issues/90
+				return false;
+			}
 			return this.Condition((T)value);
 		}
 	}

--- a/UnitTests/MatchersFixture.cs
+++ b/UnitTests/MatchersFixture.cs
@@ -255,6 +255,17 @@ namespace Moq.Tests
 			Assert.Equal(0, mock.Object.DoAddition(new[] { 2, 4, 6, 8 }));
 		}
 
+		[Fact]
+		public void MatchingNonNullableValueTypeForNullableParameterDoesNotMatchNull()
+		{
+			var mock = new Mock<IFoo>();
+
+			mock.Setup(x => x.TakesNullableParameter(It.IsAny<int>())).Returns(5);
+
+			Assert.Equal(5, mock.Object.TakesNullableParameter(5));
+			Assert.Equal(0, mock.Object.TakesNullableParameter(null));
+		}
+
 		private int GetToRange()
 		{
 			return 5;
@@ -271,6 +282,7 @@ namespace Moq.Tests
 			bool DoTypeOverload(Baz baz);
 			int DoAddition(int[] numbers);
 			int[] Items { get; set; }
+			int TakesNullableParameter(int? value);
 		}
 	}
 }


### PR DESCRIPTION
This fixes issue #90.

The problem was that `Matches()` has to cast its input to the type parameter `T` in order to call the `Condition` function.
Since `T` is a reference type, it does not accept nulls and throws a `NullReferenceException` at the site of the cast.

We get around this by treating value types as a special case inside `Matches`. If `T` is a value type and the input is null, it clearly doesn't match (since value types are not nullable).