### PR TITLE
Issue 184: allow null to match nullable value types

### DIFF
--- a/Source/Match.cs
+++ b/Source/Match.cs
@@ -1,4 +1,4 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
 //http://code.google.com/p/moq/
 //All rights reserved.
 
@@ -128,7 +128,10 @@ namespace Moq
 			{
 				return false;
 			}
-			if (value == null && typeof(T).IsValueType)
+
+			var matchType = typeof(T);
+			if (value == null && matchType.IsValueType 
+				&& ( !matchType.IsGenericType || matchType.GetGenericTypeDefinition() != typeof(Nullable<>)))
 			{
 				// If this.Condition expects a value type and we've been passed null,
 				// it can't possibly match.

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -234,7 +234,28 @@ namespace Moq.Tests.Regressions
 
 		#endregion // #176
 
-		// Old @ Google Code
+        #region #184
+
+		public class Issue184
+		{
+			public interface ISimpleInterface
+			{
+				void Method(Guid? g);
+			}
+
+			[Fact]
+			public void strict_mock_accepts_null_as_nullable_guid_value()
+			{
+				var mock = new Mock<ISimpleInterface>(MockBehavior.Strict);
+				mock.Setup(x => x.Method(It.IsAny<Guid?>()));
+				mock.Object.Method(null);
+				mock.Verify();
+			}
+		}
+
+        #endregion // #184
+
+        // Old @ Google Code
 
         #region #47
 


### PR DESCRIPTION
In the case where a null is passed and a value type is expected, allow a match where the value type is an instance of Nullable<T>.