### PR TITLE
Saturday morning cartoon version of "conjunction"

### DIFF
--- a/Source/Mock.Generic.xdoc
+++ b/Source/Mock.Generic.xdoc
@@ -285,7 +285,7 @@
 	<doc for="Mock{T}.Verify(expression)">
 		<summary>
 			Verifies that a specific invocation matching the given expression was performed on the mock. Use
-			in conjuntion with the default <see cref="MockBehavior.Loose"/>.
+			in conjunction with the default <see cref="MockBehavior.Loose"/>.
 		</summary>
 		<example group="verification">
 			This example assumes that the mock has been used, and later we want to verify that a given
@@ -304,7 +304,7 @@
 	<doc for="Mock{T}.Verify(expression,times)">
 		<summary>
 			Verifies that a specific invocation matching the given expression was performed on the mock. Use
-			in conjuntion with the default <see cref="MockBehavior.Loose"/>.
+			in conjunction with the default <see cref="MockBehavior.Loose"/>.
 		</summary>
 		<exception cref="MockException">
 			The invocation was not call the times specified by
@@ -316,7 +316,7 @@
 	<doc for="Mock{T}.Verify(expression,failMessage)">
 		<summary>
 			Verifies that a specific invocation matching the given expression was performed on the mock,
-			specifying a failure error message. Use in conjuntion with the default
+			specifying a failure error message. Use in conjunction with the default
 			<see cref="MockBehavior.Loose"/>.
 		</summary>
 		<example group="verification">
@@ -337,7 +337,7 @@
 	<doc for="Mock{T}.Verify(expression,times,failMessage)">
 		<summary>
 			Verifies that a specific invocation matching the given expression was performed on the mock,
-			specifying a failure error message. Use in conjuntion with the default
+			specifying a failure error message. Use in conjunction with the default
 			<see cref="MockBehavior.Loose"/>.
 		</summary>
 		<exception cref="MockException">
@@ -351,7 +351,7 @@
 	<doc for="Mock{T}.Verify{TResult}(expression)">
 		<summary>
 			Verifies that a specific invocation matching the given expression was performed on the mock. Use
-			in conjuntion with the default <see cref="MockBehavior.Loose"/>.
+			in conjunction with the default <see cref="MockBehavior.Loose"/>.
 		</summary>
 		<example group="verification">
 			This example assumes that the mock has been used, and later we want to verify that a given
@@ -371,7 +371,7 @@
 	<doc for="Mock{T}.Verify{TResult}(expression,times)">
 		<summary>
 			Verifies that a specific invocation matching the given
-			expression was performed on the mock. Use in conjuntion
+			expression was performed on the mock. Use in conjunction
 			with the default <see cref="MockBehavior.Loose"/>.
 		</summary>
 		<exception cref="MockException">

--- a/Source/Protected/IProtectedMock.cs
+++ b/Source/Protected/IProtectedMock.cs
@@ -96,7 +96,7 @@ namespace Moq.Protected
 
 		/// <summary>
 		/// Specifies a verify for a void method with the given <paramref name="methodName"/>,
-		/// optionally specifying arguments for the method call. Use in conjuntion with the default
+		/// optionally specifying arguments for the method call. Use in conjunction with the default
 		/// <see cref="MockBehavior.Loose"/>.
 		/// </summary>
 		/// <exception cref="MockException">The invocation was not call the times specified by


### PR DESCRIPTION
The [School House Rock](https://www.youtube.com/watch?v=ODGA7ssL-6g) spelling is the correct one. AFAIK, omitting the "c" isn't a valid alternative spelling. Ignore this PR if I'm wrong, though. Also, ignore the line-ending and end of file revisions. They're artifacts of GitHub's in-page editor.