### PR TITLE
VerityMocks and VerifyAllMocks Static Helper Methods

### DIFF
--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -122,8 +122,8 @@ namespace Moq
 			throw new ArgumentException(Resources.ObjectInstanceNotMock, "mocked");
 		}
 		
-		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.VerifyMocks"]/*'/>
-		public static void VerifyMocks(params Mock[] mocks)
+		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.Verify"]/*'/>
+		public static void Verify(params Mock[] mocks)
         	{
             		foreach (var mock in mocks)
             		{
@@ -131,8 +131,8 @@ namespace Moq
             		}
         	}
 		
-		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.VerifyAllMocks"]/*'/>
-		public static void VerifyAllMocks(params Mock[] mocks)
+		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.VerifyAll"]/*'/>
+		public static void VerifyAll(params Mock[] mocks)
         	{
             		foreach (var mock in mocks)
             		{

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -121,6 +121,24 @@ namespace Moq
 
 			throw new ArgumentException(Resources.ObjectInstanceNotMock, "mocked");
 		}
+		
+		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.VerifyMocks"]/*'/>
+		public static void VerifyMocks(params Mock[] mocks)
+        	{
+            		foreach (var mock in mocks)
+            		{
+                		mock.Verify();
+            		}
+        	}
+		
+		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.VerifyAllMocks"]/*'/>
+		public static void VerifyAllMocks(params Mock[] mocks)
+        	{
+            		foreach (var mock in mocks)
+            		{
+                		mock.VerifyAll();
+            		}
+        	}
 
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.Behavior"]/*'/>
 		public virtual MockBehavior Behavior { get; internal set; }


### PR DESCRIPTION
I tend to write a method that does multiple verifications a lot, it saves a few lines:

```
mock1.VerifyAll();
mock2.VerifyAll();
mock3.VerifyAll();

// Versus

Mock.VerifyAll(mock1, mock2, mock3);
```