### PR TITLE
Fix typo

### DIFF
--- a/Source/Matchers/ExpressionComparer.cs
+++ b/Source/Matchers/ExpressionComparer.cs
@@ -162,7 +162,7 @@ namespace Moq.Matchers
 
 		private bool EqualsBinary(BinaryExpression x, BinaryExpression y)
 		{
-			return x.Method == x.Method && this.Equals(x.Left, y.Left) && this.Equals(x.Right, y.Right) &&
+			return x.Method == y.Method && this.Equals(x.Left, y.Left) && this.Equals(x.Right, y.Right) &&
 				this.Equals(x.Conversion, y.Conversion);
 		}
 


### PR DESCRIPTION
Field of object is compared with itself - probably, it is typo

Found by AppChecker.