### PR TITLE
Allow for class mocks and interface mocks to mock System.Object methods

### DIFF
--- a/Source/InterceptorStrategies.cs
+++ b/Source/InterceptorStrategies.cs
@@ -7,301 +7,301 @@ using System.Reflection;
 
 namespace Moq
 {
-    internal class HandleMockRecursion : IInterceptStrategy
-    {
+	internal class HandleMockRecursion : IInterceptStrategy
+	{
 		public InterceptionAction HandleIntercept(ICallContext invocation, InterceptorContext ctx, CurrentInterceptContext localctx)
-        {
+		{
 			if (invocation.Method != null && invocation.Method.ReturnType != null &&
-                    invocation.Method.ReturnType != typeof(void))
-            {
-                Mock recursiveMock;
-                if (ctx.Mock.InnerMocks.TryGetValue(invocation.Method, out recursiveMock))
-                {
-                    invocation.ReturnValue = recursiveMock.Object;
-                }
-                else
-                {
-                    invocation.ReturnValue = ctx.Mock.DefaultValueProvider.ProvideDefault(invocation.Method);
-                }
-                return InterceptionAction.Stop;
-            }
-            return InterceptionAction.Continue;
-        }
-    }
+					invocation.Method.ReturnType != typeof(void))
+			{
+				Mock recursiveMock;
+				if (ctx.Mock.InnerMocks.TryGetValue(invocation.Method, out recursiveMock))
+				{
+					invocation.ReturnValue = recursiveMock.Object;
+				}
+				else
+				{
+					invocation.ReturnValue = ctx.Mock.DefaultValueProvider.ProvideDefault(invocation.Method);
+				}
+				return InterceptionAction.Stop;
+			}
+			return InterceptionAction.Continue;
+		}
+	}
 
-    internal class InvokeBase : IInterceptStrategy
-    {
-        public InterceptionAction HandleIntercept(ICallContext invocation, InterceptorContext ctx, CurrentInterceptContext localctx)
-        {
-            if (invocation.Method.DeclaringType == typeof(object) || // interface proxy
-                ctx.Mock.ImplementedInterfaces.Contains(invocation.Method.DeclaringType) && !invocation.Method.IsEventAttach() && !invocation.Method.IsEventDetach() && ctx.Mock.CallBase && !ctx.Mock.MockedType.IsInterface || // class proxy with explicitly implemented interfaces. The method's declaring type is the interface and the method couldn't be abstract
-                invocation.Method.DeclaringType.IsClass && !invocation.Method.IsAbstract && ctx.Mock.CallBase // class proxy
-                )
-            {
-                // Invoke underlying implementation.
+	internal class InvokeBase : IInterceptStrategy
+	{
+		public InterceptionAction HandleIntercept(ICallContext invocation, InterceptorContext ctx, CurrentInterceptContext localctx)
+		{
+			if (invocation.Method.DeclaringType == typeof(object) || // interface proxy
+				ctx.Mock.ImplementedInterfaces.Contains(invocation.Method.DeclaringType) && !invocation.Method.IsEventAttach() && !invocation.Method.IsEventDetach() && ctx.Mock.CallBase && !ctx.Mock.MockedType.IsInterface || // class proxy with explicitly implemented interfaces. The method's declaring type is the interface and the method couldn't be abstract
+				invocation.Method.DeclaringType.IsClass && !invocation.Method.IsAbstract && ctx.Mock.CallBase // class proxy
+				)
+			{
+				// Invoke underlying implementation.
 
-                // For mocked classes, if the target method was not abstract, 
-                // invoke directly.
-                // Will only get here for Loose behavior.
-                // TODO: we may want to provide a way to skip this by the user.
-                invocation.InvokeBase();
-                return InterceptionAction.Stop;
-            }
-            else
-            {
-                return InterceptionAction.Continue;
-            }
-        }
-    }
+				// For mocked classes, if the target method was not abstract, 
+				// invoke directly.
+				// Will only get here for Loose behavior.
+				// TODO: we may want to provide a way to skip this by the user.
+				invocation.InvokeBase();
+				return InterceptionAction.Stop;
+			}
+			else
+			{
+				return InterceptionAction.Continue;
+			}
+		}
+	}
 
-    internal class ExecuteCall : IInterceptStrategy
-    {
-        InterceptorContext ctx;
-        public InterceptionAction HandleIntercept(ICallContext invocation, InterceptorContext ctx, CurrentInterceptContext localctx)
-        {
-            this.ctx = ctx;
-            IProxyCall currentCall = localctx.Call;
+	internal class ExecuteCall : IInterceptStrategy
+	{
+		InterceptorContext ctx;
+		public InterceptionAction HandleIntercept(ICallContext invocation, InterceptorContext ctx, CurrentInterceptContext localctx)
+		{
+			this.ctx = ctx;
+			IProxyCall currentCall = localctx.Call;
 
-            if (currentCall != null)
-            {
-                currentCall.SetOutParameters(invocation);
+			if (currentCall != null)
+			{
+				currentCall.SetOutParameters(invocation);
 
-                // We first execute, as there may be a Throws 
-                // and therefore we might never get to the 
-                // next line.
-                currentCall.Execute(invocation);
-                ThrowIfReturnValueRequired(currentCall, invocation);
-                return InterceptionAction.Stop;
-            }
-            else
-            {
-                return InterceptionAction.Continue;
-            }
-        }
-        private void ThrowIfReturnValueRequired(IProxyCall call, ICallContext invocation)
-        {
-            if (ctx.Behavior != MockBehavior.Loose &&
-                invocation.Method != null &&
-                invocation.Method.ReturnType != null &&
-                invocation.Method.ReturnType != typeof(void))
-            {
-                var methodCall = call as MethodCallReturn;
-                if (methodCall == null || !methodCall.HasReturnValue)
-                {
-                    throw new MockException(
-                        MockException.ExceptionReason.ReturnValueRequired,
-                        ctx.Behavior,
-                        invocation);
-                }
-            }
-        }
-    }
+				// We first execute, as there may be a Throws 
+				// and therefore we might never get to the 
+				// next line.
+				currentCall.Execute(invocation);
+				ThrowIfReturnValueRequired(currentCall, invocation);
+				return InterceptionAction.Stop;
+			}
+			else
+			{
+				return InterceptionAction.Continue;
+			}
+		}
+		private void ThrowIfReturnValueRequired(IProxyCall call, ICallContext invocation)
+		{
+			if (ctx.Behavior != MockBehavior.Loose &&
+				invocation.Method != null &&
+				invocation.Method.ReturnType != null &&
+				invocation.Method.ReturnType != typeof(void))
+			{
+				var methodCall = call as MethodCallReturn;
+				if (methodCall == null || !methodCall.HasReturnValue)
+				{
+					throw new MockException(
+						MockException.ExceptionReason.ReturnValueRequired,
+						ctx.Behavior,
+						invocation);
+				}
+			}
+		}
+	}
 
-    internal class ExtractProxyCall : IInterceptStrategy
-    {
+	internal class ExtractProxyCall : IInterceptStrategy
+	{
 
-        public InterceptionAction HandleIntercept(ICallContext invocation, InterceptorContext ctx, CurrentInterceptContext localctx)
-        {
-            localctx.Call = FluentMockContext.IsActive ? (IProxyCall)null : ctx.OrderedCalls.LastOrDefault(c => c.Matches(invocation));
-            if (localctx.Call != null)
-            {
-                localctx.Call.EvaluatedSuccessfully();
-            }
-            else if (!FluentMockContext.IsActive && ctx.Behavior == MockBehavior.Strict)
-            {
-                throw new MockException(MockException.ExceptionReason.NoSetup, ctx.Behavior, invocation);
-            }
+		public InterceptionAction HandleIntercept(ICallContext invocation, InterceptorContext ctx, CurrentInterceptContext localctx)
+		{
+			localctx.Call = FluentMockContext.IsActive ? (IProxyCall)null : ctx.OrderedCalls.LastOrDefault(c => c.Matches(invocation));
+			if (localctx.Call != null)
+			{
+				localctx.Call.EvaluatedSuccessfully();
+			}
+			else if (!FluentMockContext.IsActive && ctx.Behavior == MockBehavior.Strict)
+			{
+				throw new MockException(MockException.ExceptionReason.NoSetup, ctx.Behavior, invocation);
+			}
 
-            return InterceptionAction.Continue;
-        }
+			return InterceptionAction.Continue;
+		}
 
-    }
+	}
 
-    internal class InterceptMockPropertyMixin : IInterceptStrategy
-    {
-        public InterceptionAction HandleIntercept(ICallContext invocation, InterceptorContext ctx, CurrentInterceptContext localctx)
-        {
-            var method = invocation.Method;
+	internal class InterceptMockPropertyMixin : IInterceptStrategy
+	{
+		public InterceptionAction HandleIntercept(ICallContext invocation, InterceptorContext ctx, CurrentInterceptContext localctx)
+		{
+			var method = invocation.Method;
 
-            if (typeof(IMocked).IsAssignableFrom(method.DeclaringType) && method.Name == "get_Mock")
-            {
-                invocation.ReturnValue = ctx.Mock;
-                return InterceptionAction.Stop;
-            }
+			if (typeof(IMocked).IsAssignableFrom(method.DeclaringType) && method.Name == "get_Mock")
+			{
+				invocation.ReturnValue = ctx.Mock;
+				return InterceptionAction.Stop;
+			}
 
-            return InterceptionAction.Continue;
-        }
-    }
+			return InterceptionAction.Continue;
+		}
+	}
 
-    internal class InterceptToStringMixin : IInterceptStrategy
-    {
-        public InterceptionAction HandleIntercept(ICallContext invocation, InterceptorContext ctx, CurrentInterceptContext localctx)
-        {
-            var method = invocation.Method;
+	internal class InterceptToStringMixin : IInterceptStrategy
+	{
+		public InterceptionAction HandleIntercept(ICallContext invocation, InterceptorContext ctx, CurrentInterceptContext localctx)
+		{
+			var method = invocation.Method;
 
-            // Only if there is no corresponding setup
-            if (IsObjectToStringMethod(method) && !ctx.OrderedCalls.Select(c => IsObjectToStringMethod(c.Method)).Any())
-            {
-                invocation.ReturnValue = ctx.Mock.ToString() + ".Object";
-                return InterceptionAction.Stop;
-            }
+			// Only if there is no corresponding setup
+			if (IsObjectToStringMethod(method) && !ctx.OrderedCalls.Select(c => IsObjectToStringMethod(c.Method)).Any())
+			{
+				invocation.ReturnValue = ctx.Mock.ToString() + ".Object";
+				return InterceptionAction.Stop;
+			}
 
-            return InterceptionAction.Continue;
-        }
+			return InterceptionAction.Continue;
+		}
 
-        protected bool IsObjectToStringMethod(MethodInfo method)
-        {
-            if (method.DeclaringType == typeof(object) && method.Name == "ToString")
-            {
-                return true;
-            }
+		protected bool IsObjectToStringMethod(MethodInfo method)
+		{
+			if (method.DeclaringType == typeof(object) && method.Name == "ToString")
+			{
+				return true;
+			}
 
-            return false;
-        }
-    }
+			return false;
+		}
+	}
 
-    internal class HandleTracking : IInterceptStrategy
-    {
+	internal class HandleTracking : IInterceptStrategy
+	{
 
-        public InterceptionAction HandleIntercept(ICallContext invocation, InterceptorContext ctx, CurrentInterceptContext localctx)
-        {
-            // Track current invocation if we're in "record" mode in a fluent invocation context.
-            if (FluentMockContext.IsActive)
-            {
-                FluentMockContext.Current.Add(ctx.Mock, invocation);
-            }
-            return InterceptionAction.Continue;
-        }
-    }
+		public InterceptionAction HandleIntercept(ICallContext invocation, InterceptorContext ctx, CurrentInterceptContext localctx)
+		{
+			// Track current invocation if we're in "record" mode in a fluent invocation context.
+			if (FluentMockContext.IsActive)
+			{
+				FluentMockContext.Current.Add(ctx.Mock, invocation);
+			}
+			return InterceptionAction.Continue;
+		}
+	}
 
-    internal class HandleDestructor : IInterceptStrategy
-    {
-        public InterceptionAction HandleIntercept(ICallContext invocation, InterceptorContext ctx, CurrentInterceptContext localctx)
-        {
-            return invocation.Method.IsDestructor() ? InterceptionAction.Stop : InterceptionAction.Continue;
-        }
-    }
+	internal class HandleDestructor : IInterceptStrategy
+	{
+		public InterceptionAction HandleIntercept(ICallContext invocation, InterceptorContext ctx, CurrentInterceptContext localctx)
+		{
+			return invocation.Method.IsDestructor() ? InterceptionAction.Stop : InterceptionAction.Continue;
+		}
+	}
 
-    internal class AddActualInvocation : IInterceptStrategy
-    {
+	internal class AddActualInvocation : IInterceptStrategy
+	{
 
-        /// <summary>
-        /// Get an eventInfo for a given event name.  Search type ancestors depth first if necessary.
-        /// </summary>
-        /// <param name="eventName">Name of the event, with the set_ or get_ prefix already removed</param>
-        private EventInfo GetEventFromName(string eventName)
-        {
-            var depthFirstProgress = new Queue<Type>(ctx.Mock.ImplementedInterfaces.Skip(1));
-            depthFirstProgress.Enqueue(ctx.TargetType);
-            while (depthFirstProgress.Count > 0)
-            {
-                var currentType = depthFirstProgress.Dequeue();
-                var eventInfo = currentType.GetEvent(eventName);
-                if (eventInfo != null)
-                {
-                    return eventInfo;
-                }
+		/// <summary>
+		/// Get an eventInfo for a given event name.  Search type ancestors depth first if necessary.
+		/// </summary>
+		/// <param name="eventName">Name of the event, with the set_ or get_ prefix already removed</param>
+		private EventInfo GetEventFromName(string eventName)
+		{
+			var depthFirstProgress = new Queue<Type>(ctx.Mock.ImplementedInterfaces.Skip(1));
+			depthFirstProgress.Enqueue(ctx.TargetType);
+			while (depthFirstProgress.Count > 0)
+			{
+				var currentType = depthFirstProgress.Dequeue();
+				var eventInfo = currentType.GetEvent(eventName);
+				if (eventInfo != null)
+				{
+					return eventInfo;
+				}
 
-                foreach (var implementedType in GetAncestorTypes(currentType))
-                {
-                    depthFirstProgress.Enqueue(implementedType);
-                }
-            }
-            return GetNonPublicEventFromName(eventName);
-        }
+				foreach (var implementedType in GetAncestorTypes(currentType))
+				{
+					depthFirstProgress.Enqueue(implementedType);
+				}
+			}
+			return GetNonPublicEventFromName(eventName);
+		}
 
-        /// <summary>
-        /// Get an eventInfo for a given event name.  Search type ancestors depth first if necessary.
-        /// Searches also in non public events.
-        /// </summary>
-        /// <param name="eventName">Name of the event, with the set_ or get_ prefix already removed</param>
-        private EventInfo GetNonPublicEventFromName(string eventName)
-        {
-            var depthFirstProgress = new Queue<Type>(ctx.Mock.ImplementedInterfaces.Skip(1));
-            depthFirstProgress.Enqueue(ctx.TargetType);
-            while (depthFirstProgress.Count > 0)
-            {
-                var currentType = depthFirstProgress.Dequeue();
-                var eventInfo = currentType.GetEvent(eventName, BindingFlags.Instance | BindingFlags.NonPublic);
-                if (eventInfo != null)
-                {
-                    return eventInfo;
-                }
+		/// <summary>
+		/// Get an eventInfo for a given event name.  Search type ancestors depth first if necessary.
+		/// Searches also in non public events.
+		/// </summary>
+		/// <param name="eventName">Name of the event, with the set_ or get_ prefix already removed</param>
+		private EventInfo GetNonPublicEventFromName(string eventName)
+		{
+			var depthFirstProgress = new Queue<Type>(ctx.Mock.ImplementedInterfaces.Skip(1));
+			depthFirstProgress.Enqueue(ctx.TargetType);
+			while (depthFirstProgress.Count > 0)
+			{
+				var currentType = depthFirstProgress.Dequeue();
+				var eventInfo = currentType.GetEvent(eventName, BindingFlags.Instance | BindingFlags.NonPublic);
+				if (eventInfo != null)
+				{
+					return eventInfo;
+				}
 
-                foreach (var implementedType in GetAncestorTypes(currentType))
-                {
-                    depthFirstProgress.Enqueue(implementedType);
-                }
-            }
+				foreach (var implementedType in GetAncestorTypes(currentType))
+				{
+					depthFirstProgress.Enqueue(implementedType);
+				}
+			}
 
-            return null;
-        }
+			return null;
+		}
 
 
-        /// <summary>
-        /// Given a type return all of its ancestors, both types and interfaces.
-        /// </summary>
-        /// <param name="initialType">The type to find immediate ancestors of</param>
-        private static IEnumerable<Type> GetAncestorTypes(Type initialType)
-        {
-            var baseType = initialType.BaseType;
-            if (baseType != null)
-            {
-                return new[] { baseType };
-            }
+		/// <summary>
+		/// Given a type return all of its ancestors, both types and interfaces.
+		/// </summary>
+		/// <param name="initialType">The type to find immediate ancestors of</param>
+		private static IEnumerable<Type> GetAncestorTypes(Type initialType)
+		{
+			var baseType = initialType.BaseType;
+			if (baseType != null)
+			{
+				return new[] { baseType };
+			}
 
-            return initialType.GetInterfaces();
-        }        
-        InterceptorContext ctx;
-        public InterceptionAction HandleIntercept(ICallContext invocation, InterceptorContext ctx, CurrentInterceptContext localctx)
-        {
-            this.ctx = ctx;
-            if (!FluentMockContext.IsActive)
-            {
-                //Special case for events
-                if (invocation.Method.IsEventAttach())
-                {
-                    var delegateInstance = (Delegate)invocation.Arguments[0];
-                    // TODO: validate we can get the event?
-                    var eventInfo = this.GetEventFromName(invocation.Method.Name.Substring(4));
+			return initialType.GetInterfaces();
+		}
+		InterceptorContext ctx;
+		public InterceptionAction HandleIntercept(ICallContext invocation, InterceptorContext ctx, CurrentInterceptContext localctx)
+		{
+			this.ctx = ctx;
+			if (!FluentMockContext.IsActive)
+			{
+				//Special case for events
+				if (invocation.Method.IsEventAttach())
+				{
+					var delegateInstance = (Delegate)invocation.Arguments[0];
+					// TODO: validate we can get the event?
+					var eventInfo = this.GetEventFromName(invocation.Method.Name.Substring(4));
 
-                    if (ctx.Mock.CallBase && !eventInfo.DeclaringType.IsInterface)
-                    {
-                        invocation.InvokeBase();
-                    }
-                    else if (delegateInstance != null)
-                    {
-                        ctx.AddEventHandler(eventInfo, (Delegate)invocation.Arguments[0]);
-                    }
+					if (ctx.Mock.CallBase && !eventInfo.DeclaringType.IsInterface)
+					{
+						invocation.InvokeBase();
+					}
+					else if (delegateInstance != null)
+					{
+						ctx.AddEventHandler(eventInfo, (Delegate)invocation.Arguments[0]);
+					}
 
-                    return InterceptionAction.Stop;
-                }
-                else if (invocation.Method.IsEventDetach())
-                {
-                    var delegateInstance = (Delegate)invocation.Arguments[0];
-                    // TODO: validate we can get the event?
-                    var eventInfo = this.GetEventFromName(invocation.Method.Name.Substring(7));
+					return InterceptionAction.Stop;
+				}
+				else if (invocation.Method.IsEventDetach())
+				{
+					var delegateInstance = (Delegate)invocation.Arguments[0];
+					// TODO: validate we can get the event?
+					var eventInfo = this.GetEventFromName(invocation.Method.Name.Substring(7));
 
-                    if (ctx.Mock.CallBase && !eventInfo.DeclaringType.IsInterface)
-                    {
-                        invocation.InvokeBase();
-                    }
-                    else if (delegateInstance != null)
-                    {
-                        ctx.RemoveEventHandler(eventInfo, (Delegate)invocation.Arguments[0]);
-                    }
+					if (ctx.Mock.CallBase && !eventInfo.DeclaringType.IsInterface)
+					{
+						invocation.InvokeBase();
+					}
+					else if (delegateInstance != null)
+					{
+						ctx.RemoveEventHandler(eventInfo, (Delegate)invocation.Arguments[0]);
+					}
 
-                    return InterceptionAction.Stop;
-                }
+					return InterceptionAction.Stop;
+				}
 
-                // Save to support Verify[expression] pattern.
-                // In a fluent invocation context, which is a recorder-like 
-                // mode we use to evaluate delegates by actually running them, 
-                // we don't want to count the invocation, or actually run 
-                // previous setups.
-                ctx.AddInvocation(invocation);
-            }
-            return InterceptionAction.Continue;
-        }
-    }
+				// Save to support Verify[expression] pattern.
+				// In a fluent invocation context, which is a recorder-like 
+				// mode we use to evaluate delegates by actually running them, 
+				// we don't want to count the invocation, or actually run 
+				// previous setups.
+				ctx.AddInvocation(invocation);
+			}
+			return InterceptionAction.Continue;
+		}
+	}
 }

--- a/Source/InterceptorStrategies.cs
+++ b/Source/InterceptorStrategies.cs
@@ -139,13 +139,24 @@ namespace Moq
         {
             var method = invocation.Method;
 
-            if (method.DeclaringType == typeof(Object) && method.Name == "ToString")
+            // Only if there is no corresponding setup
+            if (IsObjectToStringMethod(method) && !ctx.OrderedCalls.Select(c => IsObjectToStringMethod(c.Method)).Any())
             {
                 invocation.ReturnValue = ctx.Mock.ToString() + ".Object";
                 return InterceptionAction.Stop;
             }
 
             return InterceptionAction.Continue;
+        }
+
+        protected bool IsObjectToStringMethod(MethodInfo method)
+        {
+            if (method.DeclaringType == typeof(object) && method.Name == "ToString")
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 

--- a/Source/Proxy/CastleProxyFactory.cs
+++ b/Source/Proxy/CastleProxyFactory.cs
@@ -71,15 +71,20 @@ namespace Moq.Proxy
 			AttributesToAvoidReplicating.Add<System.Runtime.InteropServices.TypeIdentifierAttribute>();
 #endif
 #endif
-			proxyOptions = new ProxyGenerationOptions { Hook = new ProxyMethodHook(), BaseTypeForInterfaceProxy = typeof(InterfaceProxy) };
+			proxyOptions = new ProxyGenerationOptions { Hook = new ProxyMethodHook() };
 		}
 
 		/// <inheritdoc />
 		public object CreateProxy(Type mockType, ICallInterceptor interceptor, Type[] interfaces, object[] arguments)
 		{
-			if (mockType.IsInterface) {
-				return generator.CreateInterfaceProxyWithoutTarget(mockType, interfaces, proxyOptions, new Interceptor(interceptor));
-			}
+			if (mockType.IsInterface)
+            {
+                // Add type to additional interfaces and mock System.Object instead.
+                // This way it is also possible to mock System.Object methods.
+                Array.Resize(ref interfaces, interfaces.Length + 1);
+                interfaces[interfaces.Length - 1] = mockType;
+                mockType = typeof(object);
+            }
 
 			try
 			{

--- a/Source/Proxy/CastleProxyFactory.cs
+++ b/Source/Proxy/CastleProxyFactory.cs
@@ -78,13 +78,13 @@ namespace Moq.Proxy
 		public object CreateProxy(Type mockType, ICallInterceptor interceptor, Type[] interfaces, object[] arguments)
 		{
 			if (mockType.IsInterface)
-            {
-                // Add type to additional interfaces and mock System.Object instead.
-                // This way it is also possible to mock System.Object methods.
-                Array.Resize(ref interfaces, interfaces.Length + 1);
-                interfaces[interfaces.Length - 1] = mockType;
-                mockType = typeof(object);
-            }
+			{
+				// Add type to additional interfaces and mock System.Object instead.
+				// This way it is also possible to mock System.Object methods.
+				Array.Resize(ref interfaces, interfaces.Length + 1);
+				interfaces[interfaces.Length - 1] = mockType;
+				mockType = typeof(object);
+			}
 
 			try
 			{
@@ -112,23 +112,23 @@ namespace Moq.Proxy
 			lock (this)
 			{
 				if (!delegateInterfaceCache.TryGetValue(delegateType, out delegateInterfaceType))
- 				{
+				{
 					var interfaceName = String.Format(CultureInfo.InvariantCulture, "DelegateInterface_{0}_{1}",
-					                                  delegateType.Name, delegateInterfaceSuffix++);
+													  delegateType.Name, delegateInterfaceSuffix++);
 
 					var moduleBuilder = generator.ProxyBuilder.ModuleScope.ObtainDynamicModule(true);
 					var newTypeBuilder = moduleBuilder.DefineType(interfaceName,
-					                                              TypeAttributes.Public | TypeAttributes.Interface |
-					                                              TypeAttributes.Abstract);
+																  TypeAttributes.Public | TypeAttributes.Interface |
+																  TypeAttributes.Abstract);
 
 					var invokeMethodOnDelegate = delegateType.GetMethod("Invoke");
 					var delegateParameterTypes = invokeMethodOnDelegate.GetParameters().Select(p => p.ParameterType).ToArray();
 
 					// Create a method on the interface with the same signature as the delegate.
 					var newMethBuilder = newTypeBuilder.DefineMethod("Invoke",
-					                                                 MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Abstract,
-					                                                 CallingConventions.HasThis,
-					                                                 invokeMethodOnDelegate.ReturnType, delegateParameterTypes);
+																	 MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Abstract,
+																	 CallingConventions.HasThis,
+																	 invokeMethodOnDelegate.ReturnType, delegateParameterTypes);
 
 					foreach (var param in invokeMethodOnDelegate.GetParameters())
 					{
@@ -137,12 +137,12 @@ namespace Moq.Proxy
 
 					delegateInterfaceType = newTypeBuilder.CreateType();
 					delegateInterfaceCache[delegateType] = delegateInterfaceType;
- 				}
- 			}
+				}
+			}
 
 			delegateInterfaceMethod = delegateInterfaceType.GetMethod("Invoke");
 			return delegateInterfaceType;
- 		}
+		}
 
 		private static ProxyGenerator CreateProxyGenerator()
 		{

--- a/Source/Proxy/ProxyGenerationHelpers.cs
+++ b/Source/Proxy/ProxyGenerationHelpers.cs
@@ -7,31 +7,31 @@ using System.Linq;
 
 namespace Moq.Proxy
 {
-    /// <summary>
-    /// Hook used to tells Castle which methods to proxy in mocked classes.
-    /// 
-    /// Here we proxy the default methods Castle suggests (everything Object's methods)
-    /// plus Object.ToString(), so we can give mocks useful default names.
-    /// 
-    /// This is required to allow Moq to mock ToString on proxy *class* implementations.
-    /// </summary>
-    internal class ProxyMethodHook : AllMethodsHook
-    {
-        protected static readonly Tuple<Type, string>[] GrantedMethods = new Tuple<Type, string>[]
-        {
-            Tuple.Create(typeof(object), "ToString"),
-            Tuple.Create(typeof(object), "Equals"),
-            Tuple.Create(typeof(object), "GetHashCode")
-        };
-
-        /// <summary>
-        /// Extends AllMethodsHook.ShouldInterceptMethod to also intercept Object.ToString().
-        /// </summary>
-        public override bool ShouldInterceptMethod(Type type, MethodInfo methodInfo)
+	/// <summary>
+	/// Hook used to tells Castle which methods to proxy in mocked classes.
+	/// 
+	/// Here we proxy the default methods Castle suggests (everything Object's methods)
+	/// plus Object.ToString(), so we can give mocks useful default names.
+	/// 
+	/// This is required to allow Moq to mock ToString on proxy *class* implementations.
+	/// </summary>
+	internal class ProxyMethodHook : AllMethodsHook
+	{
+		protected static readonly HashSet<Tuple<Type, string>> GrantedMethods = new HashSet<Tuple<Type, string>>
 		{
-            bool isGranted = GrantedMethods.Contains(Tuple.Create(methodInfo.DeclaringType, methodInfo.Name));
-            return base.ShouldInterceptMethod(type, methodInfo) || isGranted;
-        }
+			Tuple.Create(typeof(object), "ToString"),
+			Tuple.Create(typeof(object), "Equals"),
+			Tuple.Create(typeof(object), "GetHashCode")
+		};
+
+		/// <summary>
+		/// Extends AllMethodsHook.ShouldInterceptMethod to also intercept Object.ToString().
+		/// </summary>
+		public override bool ShouldInterceptMethod(Type type, MethodInfo methodInfo)
+		{
+			bool isGranted = GrantedMethods.Contains(Tuple.Create(methodInfo.DeclaringType, methodInfo.Name));
+			return base.ShouldInterceptMethod(type, methodInfo) || isGranted;
+		}
 	}
 
 	///// <summary>
@@ -50,14 +50,14 @@ namespace Moq.Proxy
 	//[EditorBrowsable(EditorBrowsableState.Never)]
 	//public abstract class InterfaceProxy
 	//{
- //       /// <summary>
- //       /// Overrides the default ToString implementation to instead find the mock for this mock.Object,
- //       /// and return MockName + '.Object' as the mocked object's ToString, to make it easy to relate
- //       /// mocks and mock object instances in error messages.
- //       /// </summary>
- //       public override string ToString()
- //       {
- //           return ((IMocked)this).Mock.ToString() + ".Object";
- //       }
- //   }
+	//       /// <summary>
+	//       /// Overrides the default ToString implementation to instead find the mock for this mock.Object,
+	//       /// and return MockName + '.Object' as the mocked object's ToString, to make it easy to relate
+	//       /// mocks and mock object instances in error messages.
+	//       /// </summary>
+	//       public override string ToString()
+	//       {
+	//           return ((IMocked)this).Mock.ToString() + ".Object";
+	//       }
+	//   }
 }

--- a/Source/Proxy/ProxyGenerationHelpers.cs
+++ b/Source/Proxy/ProxyGenerationHelpers.cs
@@ -2,53 +2,62 @@
 using System.ComponentModel;
 using System.Reflection;
 using Castle.DynamicProxy;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Moq.Proxy
 {
-	/// <summary>
-	/// Hook used to tells Castle which methods to proxy in mocked classes.
-	/// 
-	/// Here we proxy the default methods Castle suggests (everything Object's methods)
-	/// plus Object.ToString(), so we can give mocks useful default names.
-	/// 
-	/// This is required to allow Moq to mock ToString on proxy *class* implementations.
-	/// </summary>
-	internal class ProxyMethodHook : AllMethodsHook
-	{
-		/// <summary>
-		/// Extends AllMethodsHook.ShouldInterceptMethod to also intercept Object.ToString().
-		/// </summary>
-		public override bool ShouldInterceptMethod(Type type, MethodInfo methodInfo)
+    /// <summary>
+    /// Hook used to tells Castle which methods to proxy in mocked classes.
+    /// 
+    /// Here we proxy the default methods Castle suggests (everything Object's methods)
+    /// plus Object.ToString(), so we can give mocks useful default names.
+    /// 
+    /// This is required to allow Moq to mock ToString on proxy *class* implementations.
+    /// </summary>
+    internal class ProxyMethodHook : AllMethodsHook
+    {
+        protected static readonly Tuple<Type, string>[] GrantedMethods = new Tuple<Type, string>[]
+        {
+            Tuple.Create(typeof(object), "ToString"),
+            Tuple.Create(typeof(object), "Equals"),
+            Tuple.Create(typeof(object), "GetHashCode")
+        };
+
+        /// <summary>
+        /// Extends AllMethodsHook.ShouldInterceptMethod to also intercept Object.ToString().
+        /// </summary>
+        public override bool ShouldInterceptMethod(Type type, MethodInfo methodInfo)
 		{
-			var isObjectToString = methodInfo.DeclaringType == typeof(Object) && methodInfo.Name == "ToString";
-			return base.ShouldInterceptMethod(type, methodInfo) || isObjectToString;
-		}
+            bool isGranted = GrantedMethods.Contains(Tuple.Create(methodInfo.DeclaringType, methodInfo.Name));
+            return base.ShouldInterceptMethod(type, methodInfo) || isGranted;
+        }
 	}
 
-	/// <summary>
-	/// <para>The base class used for all our interface-inheriting proxies, which overrides the default
-	/// Object.ToString() behavior, to route it via the mock by default, unless overriden by a
-	/// real implementation.</para>
-	/// 
-	/// <para>This is required to allow Moq to mock ToString on proxy *interface* implementations.</para>
-	/// </summary>
-	/// <remarks>
-	/// <para><strong>This is internal to Moq and should not be generally used.</strong></para>
-	/// 
-	/// <para>Unfortunately it must be public, due to cross-assembly visibility issues with reflection, 
-	/// see github.com/Moq/moq4/issues/98 for details.</para>
-	/// </remarks>
-	[EditorBrowsable(EditorBrowsableState.Never)]
-	public abstract class InterfaceProxy
-	{
-		/// <summary>
-		/// Overrides the default ToString implementation to instead find the mock for this mock.Object,
-		/// and return MockName + '.Object' as the mocked object's ToString, to make it easy to relate
-		/// mocks and mock object instances in error messages.
-		/// </summary>
-		public override string ToString()
-		{
-			return ((IMocked)this).Mock.ToString() + ".Object";
-		}
-	}
+	///// <summary>
+	///// <para>The base class used for all our interface-inheriting proxies, which overrides the default
+	///// Object.ToString() behavior, to route it via the mock by default, unless overriden by a
+	///// real implementation.</para>
+	///// 
+	///// <para>This is required to allow Moq to mock ToString on proxy *interface* implementations.</para>
+	///// </summary>
+	///// <remarks>
+	///// <para><strong>This is internal to Moq and should not be generally used.</strong></para>
+	///// 
+	///// <para>Unfortunately it must be public, due to cross-assembly visibility issues with reflection, 
+	///// see github.com/Moq/moq4/issues/98 for details.</para>
+	///// </remarks>
+	//[EditorBrowsable(EditorBrowsableState.Never)]
+	//public abstract class InterfaceProxy
+	//{
+ //       /// <summary>
+ //       /// Overrides the default ToString implementation to instead find the mock for this mock.Object,
+ //       /// and return MockName + '.Object' as the mocked object's ToString, to make it easy to relate
+ //       /// mocks and mock object instances in error messages.
+ //       /// </summary>
+ //       public override string ToString()
+ //       {
+ //           return ((IMocked)this).Mock.ToString() + ".Object";
+ //       }
+ //   }
 }

--- a/UnitTests/MockFixture.cs
+++ b/UnitTests/MockFixture.cs
@@ -254,9 +254,65 @@ namespace Moq.Tests
 
 			Assert.False(mock.Object.Check("foo"));
 			Assert.True(mock.Object.Check("bar"));
-		}
+        }
 
-		[Fact]
+        [Fact]
+        public void CanSetupToString()
+        {
+            var mock = new Mock<Foo>();
+            mock.Setup(x => x.ToString()).Returns("This is me");
+
+            Assert.Equal("This is me", mock.Object.ToString());
+        }
+
+        [Fact]
+        public void CanSetupToStringForInterface()
+        {
+            var mock = new Mock<IFoo>();
+            mock.Setup(x => x.ToString()).Returns("This is me");
+
+            Assert.Equal("This is me", mock.Object.ToString());
+        }
+
+        [Fact]
+        public void CanSetupGetHashCode()
+        {
+            var mock = new Mock<Foo>();
+            mock.Setup(x => x.GetHashCode()).Returns(527);
+
+            Assert.Equal(527, mock.Object.GetHashCode());
+        }
+
+        [Fact]
+        public void CanSetupGetHashCodeForInterface()
+        {
+            var mock = new Mock<IFoo>();
+            mock.Setup(x => x.GetHashCode()).Returns(527);
+
+            Assert.Equal(527, mock.Object.GetHashCode());
+        }
+
+        [Fact]
+        public void CanSetupObjectEquals()
+        {
+            var mock = new Mock<Foo>();
+            mock.Setup(x => x.Equals(It.IsAny<object>())).Returns<object>((obj) => false);
+            var foo = mock.Object;
+
+            Assert.True(!foo.Equals(foo));
+        }
+
+        [Fact]
+        public void CanSetupObjectEqualsForInterface()
+        {
+            var mock = new Mock<IFoo>();
+            mock.Setup(x => x.Equals(It.IsAny<object>())).Returns<object>((obj) => false);
+            var foo = mock.Object;
+
+            Assert.True(!foo.Equals(foo));
+        }
+
+        [Fact]
 		public void CallsUnderlyingClassEquals()
 		{
 			var mock = new Mock<FooOverrideEquals>();

--- a/UnitTests/MockFixture.cs
+++ b/UnitTests/MockFixture.cs
@@ -72,7 +72,8 @@ namespace Moq.Tests
 
 		public class ToStringOverrider
 		{
-			public override string ToString() {
+			public override string ToString()
+			{
 				return "real value";
 			}
 		}
@@ -254,65 +255,65 @@ namespace Moq.Tests
 
 			Assert.False(mock.Object.Check("foo"));
 			Assert.True(mock.Object.Check("bar"));
-        }
+		}
 
-        [Fact]
-        public void CanSetupToString()
-        {
-            var mock = new Mock<Foo>();
-            mock.Setup(x => x.ToString()).Returns("This is me");
+		[Fact]
+		public void CanSetupToString()
+		{
+			var mock = new Mock<Foo>();
+			mock.Setup(x => x.ToString()).Returns("This is me");
 
-            Assert.Equal("This is me", mock.Object.ToString());
-        }
+			Assert.Equal("This is me", mock.Object.ToString());
+		}
 
-        [Fact]
-        public void CanSetupToStringForInterface()
-        {
-            var mock = new Mock<IFoo>();
-            mock.Setup(x => x.ToString()).Returns("This is me");
+		[Fact]
+		public void CanSetupToStringForInterface()
+		{
+			var mock = new Mock<IFoo>();
+			mock.Setup(x => x.ToString()).Returns("This is me");
 
-            Assert.Equal("This is me", mock.Object.ToString());
-        }
+			Assert.Equal("This is me", mock.Object.ToString());
+		}
 
-        [Fact]
-        public void CanSetupGetHashCode()
-        {
-            var mock = new Mock<Foo>();
-            mock.Setup(x => x.GetHashCode()).Returns(527);
+		[Fact]
+		public void CanSetupGetHashCode()
+		{
+			var mock = new Mock<Foo>();
+			mock.Setup(x => x.GetHashCode()).Returns(527);
 
-            Assert.Equal(527, mock.Object.GetHashCode());
-        }
+			Assert.Equal(527, mock.Object.GetHashCode());
+		}
 
-        [Fact]
-        public void CanSetupGetHashCodeForInterface()
-        {
-            var mock = new Mock<IFoo>();
-            mock.Setup(x => x.GetHashCode()).Returns(527);
+		[Fact]
+		public void CanSetupGetHashCodeForInterface()
+		{
+			var mock = new Mock<IFoo>();
+			mock.Setup(x => x.GetHashCode()).Returns(527);
 
-            Assert.Equal(527, mock.Object.GetHashCode());
-        }
+			Assert.Equal(527, mock.Object.GetHashCode());
+		}
 
-        [Fact]
-        public void CanSetupObjectEquals()
-        {
-            var mock = new Mock<Foo>();
-            mock.Setup(x => x.Equals(It.IsAny<object>())).Returns<object>((obj) => false);
-            var foo = mock.Object;
+		[Fact]
+		public void CanSetupObjectEquals()
+		{
+			var mock = new Mock<Foo>();
+			mock.Setup(x => x.Equals(It.IsAny<object>())).Returns<object>((obj) => false);
+			var foo = mock.Object;
 
-            Assert.True(!foo.Equals(foo));
-        }
+			Assert.True(!foo.Equals(foo));
+		}
 
-        [Fact]
-        public void CanSetupObjectEqualsForInterface()
-        {
-            var mock = new Mock<IFoo>();
-            mock.Setup(x => x.Equals(It.IsAny<object>())).Returns<object>((obj) => false);
-            var foo = mock.Object;
+		[Fact]
+		public void CanSetupObjectEqualsForInterface()
+		{
+			var mock = new Mock<IFoo>();
+			mock.Setup(x => x.Equals(It.IsAny<object>())).Returns<object>((obj) => false);
+			var foo = mock.Object;
 
-            Assert.True(!foo.Equals(foo));
-        }
+			Assert.True(!foo.Equals(foo));
+		}
 
-        [Fact]
+		[Fact]
 		public void CallsUnderlyingClassEquals()
 		{
 			var mock = new Mock<FooOverrideEquals>();
@@ -390,14 +391,14 @@ namespace Moq.Tests
 		[Fact]
 		public void ThrowsIfNoMatchingConstructorFound()
 		{
-            try
-            {
-                Console.WriteLine(new Mock<ClassWithNoDefaultConstructor>(25, true).Object);
-                Assert.True(false, "Should have thrown an exception since constructor does not exist.");
-            }
-            catch (Exception)
-            {
-            }
+			try
+			{
+				Console.WriteLine(new Mock<ClassWithNoDefaultConstructor>(25, true).Object);
+				Assert.True(false, "Should have thrown an exception since constructor does not exist.");
+			}
+			catch (Exception)
+			{
+			}
 		}
 
 		[Fact]


### PR DESCRIPTION
- int object.GetHashCode()
- bool object.Equals(object obj)
- string object.ToString()

This fixes #248.