### PR TITLE
Add an helper class to simplify parameter capture

### DIFF
--- a/Source/Capture.cs
+++ b/Source/Capture.cs
@@ -1,0 +1,118 @@
+//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//http://code.google.com/p/moq/
+//All rights reserved.
+
+//Redistribution and use in source and binary forms, 
+//with or without modification, are permitted provided 
+//that the following conditions are met:
+
+//    * Redistributions of source code must retain the 
+//    above copyright notice, this list of conditions and 
+//    the following disclaimer.
+
+//    * Redistributions in binary form must reproduce 
+//    the above copyright notice, this list of conditions 
+//    and the following disclaimer in the documentation 
+//    and/or other materials provided with the distribution.
+
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
+//    names of its contributors may be used to endorse 
+//    or promote products derived from this software 
+//    without specific prior written permission.
+
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+//SUCH DAMAGE.
+
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Moq
+{
+    /// <summary>
+    /// Allows to create parameter captures in setup expressions.
+    /// </summary>
+    public static class Capture
+    {
+        /// <summary>
+        /// Creates a parameter capture that will store values in a collection.
+        /// </summary>
+        /// <typeparam name="T">The captured object type</typeparam>
+        /// <param name="collection">The collection that will store captured parameter values</param>
+        /// <example>
+        /// Arrange code:
+        /// <code>
+        /// var parameters = new List{string}();
+        /// mock.Setup(x => x.DoSomething(Capture.In(parameters)));
+        /// </code>
+        /// Assert code:
+        /// <code>
+        /// Assert.Equal("Hello!", parameters.Single());
+        /// </code>
+        /// </example>
+        public static T In<T>(ICollection<T> collection)
+        {
+            var match = new CaptureMatch<T>(collection.Add);
+            return With(match);
+        }
+
+        /// <summary>
+        /// Creates a parameter capture that will store specific values in a collection.
+        /// </summary>
+        /// <typeparam name="T">The captured object type</typeparam>
+        /// <param name="collection">The collection that will store captured parameter values</param>
+        /// <param name="predicate">A predicate used to filter captured parameters</param>
+        /// <example>
+        /// Arrange code:
+        /// <code>
+        /// var parameters = new List{string}();
+        /// mock.Setup(x => x.DoSomething(Capture.In(parameters, p => p.StartsWith("W"))));
+        /// </code>
+        /// Assert code:
+        /// <code>
+        /// Assert.Equal("Hello!", parameters.Single());
+        /// </code>
+        /// </example>
+        public static T In<T>(IList<T> collection, Expression<Func<T, bool>> predicate)
+        {
+            var match = new CaptureMatch<T>(collection.Add, predicate);
+            return With(match);
+        }
+
+        /// <summary>
+        /// Creates a parameter capture using specified <see cref="CaptureMatch{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The captured object type</typeparam>
+        /// <example>
+        /// Arrange code:
+        /// <code>
+        /// var capturedValue = string.Empty;
+        /// var match = new CaptureMatch{string}(x => capturedValue = x);
+        /// mock.Setup(x => x.DoSomething(Capture.With(match)));
+        /// </code>
+        /// Assert code:
+        /// <code>
+        /// Assert.Equal("Hello!", capturedValue);
+        /// </code>
+        /// </example>
+        public static T With<T>(CaptureMatch<T> match)
+        {
+            return Match.Create(match);
+        }
+    }
+}

--- a/Source/CaptureMatch.cs
+++ b/Source/CaptureMatch.cs
@@ -1,0 +1,93 @@
+﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//http://code.google.com/p/moq/
+//All rights reserved.
+
+//Redistribution and use in source and binary forms, 
+//with or without modification, are permitted provided 
+//that the following conditions are met:
+
+//    * Redistributions of source code must retain the 
+//    above copyright notice, this list of conditions and 
+//    the following disclaimer.
+
+//    * Redistributions in binary form must reproduce 
+//    the above copyright notice, this list of conditions 
+//    and the following disclaimer in the documentation 
+//    and/or other materials provided with the distribution.
+
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
+//    names of its contributors may be used to endorse 
+//    or promote products derived from this software 
+//    without specific prior written permission.
+
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+//SUCH DAMAGE.
+
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System;
+using System.Linq.Expressions;
+
+namespace Moq
+{
+    /// <summary>
+    /// Allows creation custom matchers that can be used on setups to capture parameter values.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class CaptureMatch<T> : Match<T>
+    {
+        /// <summary>
+        /// Initializes an instance of the capture match.
+        /// </summary>
+        /// <param name="captureCallback">An action to run on captured value</param>
+        public CaptureMatch(Action<T> captureCallback)
+            : base(CreatePredicate(captureCallback), () => It.IsAny<T>())
+        {
+        }
+
+        /// <summary>
+        /// Initializes an instance of the capture match.
+        /// </summary>
+        /// <param name="captureCallback">An action to run on captured value</param>
+        /// <param name="predicate">A predicate used to filter captured parameters</param>
+        public CaptureMatch(Action<T> captureCallback, Expression<Func<T, bool>> predicate)
+            : base(CreatePredicate(captureCallback, predicate), () => It.Is(predicate))
+        {
+        }
+
+        private static Predicate<T> CreatePredicate(Action<T> captureCallback)
+        {
+            return value =>
+            {
+                captureCallback.Invoke(value);
+                return true;
+            };
+        }
+
+        private static Predicate<T> CreatePredicate(Action<T> captureCallback, Expression<Func<T, bool>> predicate)
+        {
+            var predicateDelegate = predicate.Compile();
+            return value =>
+            {
+                var matches = predicateDelegate.Invoke(value);
+                if (matches)
+                    captureCallback.Invoke(value);
+
+                return matches;
+            };
+        }
+    }
+}

--- a/Source/Match.cs
+++ b/Source/Match.cs
@@ -65,17 +65,21 @@ namespace Moq
 		/// <include file='Match.xdoc' path='docs/doc[@for="Match.Create{T}(condition)"]/*'/>
 		public static T Create<T>(Predicate<T> condition)
 		{
-			SetLastMatch(new Match<T>(condition));
-			return default(T);
+			return Create(new Match<T>(condition));
 		}
 
 		/// <include file='Match.xdoc' path='docs/doc[@for="Match.Create{T}(condition,renderExpression"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
 		public static T Create<T>(Predicate<T> condition, Expression<Func<T>> renderExpression)
 		{
-			SetLastMatch(new Match<T>(condition, renderExpression));
-			return default(T);
+			return Create(new Match<T>(condition, renderExpression));
 		}
+
+	    internal static T Create<T>(Match<T> match)
+	    {
+            SetLastMatch(match);
+            return default(T);
+        }
 
 		/// <devdoc>
 		/// This method is used to set an expression as the last matcher invoked, 
@@ -98,7 +102,7 @@ namespace Moq
 
 			return match;
 		}
-	}
+    }
 
 	/// <include file='Match.xdoc' path='docs/doc[@for="Match{T}"]/*'/>
 	public class Match<T> : Match

--- a/Source/Moq.csproj
+++ b/Source/Moq.csproj
@@ -42,6 +42,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Capture.cs" />
+    <Compile Include="CaptureMatch.cs" />
     <Compile Include="ConditionalContext.cs" />
     <Compile Include="IInterceptStrategy.cs" />
     <Compile Include="IMock.cs" />

--- a/UnitTests/CaptureFixture.cs
+++ b/UnitTests/CaptureFixture.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using Xunit;
+
+namespace Moq.Tests
+{
+    public class CaptureFixture
+    {
+        [Fact]
+        public void CanCaptureAnyParameterInCollection()
+        {
+            var items = new List<string>();
+            var mock = new Mock<IFoo>();
+            mock.Setup(x => x.DoSomething(Capture.In(items)));
+
+            mock.Object.DoSomething("Hello!");
+
+            var expectedValues = new List<string> { "Hello!" };
+            Assert.Equal(expectedValues, items);
+        }
+
+        [Fact]
+        public void CanCaptureSpecificParameterInCollection()
+        {
+            var items = new List<string>();
+            var mock = new Mock<IFoo>();
+            mock.Setup(x => x.DoSomething(Capture.In(items, p => p.StartsWith("W"))));
+
+            mock.Object.DoSomething("Hello!");
+            mock.Object.DoSomething("World!");
+
+            var expectedValues = new List<string> { "World!" };
+            Assert.Equal(expectedValues, items);
+        }
+
+        public interface IFoo
+        {
+            void DoSomething(string s);
+        }
+    }
+}

--- a/UnitTests/CaptureMatchFixture.cs
+++ b/UnitTests/CaptureMatchFixture.cs
@@ -1,0 +1,41 @@
+﻿using Xunit;
+
+namespace Moq.Tests
+{
+    public class CaptureMatchFixture
+    {
+        [Fact]
+        public void CanRunCaptureCallback()
+        {
+            var capturedValue = string.Empty;
+            var captureMatch = new CaptureMatch<string>(s => capturedValue = s);
+
+            var mock = new Mock<IFoo>();
+            mock.Setup(x => x.DoSomething(Capture.With(captureMatch)));
+
+            mock.Object.DoSomething("Hello!");
+            
+            Assert.Equal("Hello!", capturedValue);
+        }
+
+        [Fact]
+        public void CanRunCaptureCallbackWithPredicate()
+        {
+            var capturedValue = string.Empty;
+            var captureMatch = new CaptureMatch<string>(s => capturedValue += s, s => s.StartsWith("W"));
+
+            var mock = new Mock<IFoo>();
+            mock.Setup(x => x.DoSomething(Capture.With(captureMatch)));
+
+            mock.Object.DoSomething("Hello!");
+            mock.Object.DoSomething("World!");
+
+            Assert.Equal("World!", capturedValue);
+        }
+
+        public interface IFoo
+        {
+            void DoSomething(string item);
+        }
+    }
+}

--- a/UnitTests/Moq.Tests.csproj
+++ b/UnitTests/Moq.Tests.csproj
@@ -55,9 +55,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsInterfaceFixture.cs" />
+    <Compile Include="CaptureFixture.cs" />
     <Compile Include="ConditionalSetupFixture.cs" />
     <Compile Include="CustomMatcherFixture.cs" />
     <Compile Include="ExtensionsFixture.cs" />
+    <Compile Include="CaptureMatchFixture.cs" />
     <Compile Include="ReturnsExtensionsFixture.cs" />
     <Compile Include="Linq\MockRepositoryQuerying.cs" />
     <Compile Include="MockedDelegatesFixture.cs" />


### PR DESCRIPTION
It is frequently required to capture a mock parameter to perform complex assertions. Parameter capture is [a regular request from new Moq users](https://www.google.com/#q=moq+capture+argument).

It can be done with setups and callbacks, but the syntax can be tricky, especially for methods with many parameters.

This helper class simplifies parameter capture:
```cs
// Arrange
var capture = new MockCapture<string>();
mock.Setup(x => x.DoSomething(capture.CaptureAny()));

// Act
// ...

// Assert
Assert.Equal("World!", capture.Last);
```
