### PR TITLE
Fixed setup issues when specifying the same parameters in a different order (issue #252)

### DIFF
--- a/Source/Interceptor.cs
+++ b/Source/Interceptor.cs
@@ -175,21 +175,26 @@ namespace Moq
 				return eq;
 			}
 
-			public override int GetHashCode()
-			{
-				var hash = fixedString.GetHashCode();
+            public override int GetHashCode()
+            {
+                var hash = fixedString.GetHashCode();
 
-				foreach (var value in values)
-				{
-					if (value != null)
-					{
-						hash ^= value.GetHashCode();
-					}
-				}
+                var factor = 1;
+                foreach (var value in values)
+                {
+                    if (value != null)
+                    {
+                        // we use a factor that increases with each following value (argument)
+                        // so that if the values are in a different order, we get a different hash code
+                        // see GitHub issue #252
+                        hash ^= value.GetHashCode() / factor;
+                    }
+                    factor *= 3;
+                }
 
-				return hash;
-			}
-		}
+                return hash;
+            }
+        }
 
 		private class ConstantsVisitor : ExpressionVisitor
 		{

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -255,6 +255,36 @@ namespace Moq.Tests.Regressions
 
         #endregion // #184
 
+        #region #252
+
+        public class Issue252
+        {
+            [Fact]
+            public void SetupsWithSameArgumentsInDifferentOrderShouldNotOverwriteEachOther()
+            {
+                var mock = new Mock<ISimpleInterface>();
+
+                var a = new MyClass();
+                var b = new MyClass();
+                
+                mock.Setup(m => m.Method(a, b)).Returns(1);
+                mock.Setup(m => m.Method(b, a)).Returns(2);
+
+                Assert.Equal(1, mock.Object.Method(a, b));
+                Assert.Equal(2, mock.Object.Method(b, a));
+            }
+
+            public interface ISimpleInterface
+            {
+                int Method(MyClass a, MyClass b);
+            }
+
+            public class MyClass { }
+        }
+
+        #endregion // #252
+
+
         // Old @ Google Code
 
         #region #47


### PR DESCRIPTION
This should fix #252.
The problem was in how hash code was calculated for `ExpressionKey` objects: expression keys with the same values but in a different order would have the same hash code, so that `calls.ContainsKey(key)' would think that the key already existed in the dictionary.

I modified the `GetHashCode()` function in the `ExpressionKey` class to fix this. And added a unit test in `IssueReportsFixture.cs`.