### PR TITLE
Exceptions using Verify for specific calls should include actual values

### DIFF
--- a/Source/Extensions.cs
+++ b/Source/Extensions.cs
@@ -39,6 +39,7 @@
 // http://www.opensource.org/licenses/bsd-license.php]
 
 using System;
+using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
@@ -102,7 +103,10 @@ namespace Moq
 			{
 				return "\"" + typedValue + "\"";
 			}
-
+		    if (value is IEnumerable)
+		    {
+		        return "[" + string.Join(", ", ((IEnumerable) value).OfType<object>().Select(GetValue)) + "]";
+		    }
 			return value.ToString();
 		}
 

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -373,7 +373,7 @@ namespace Moq
 			Times times,
 			int callCount)
 		{
-			var message = times.GetExceptionMessage(expected.FailMessage, expression.ToStringFixed(), callCount) +
+			var message = times.GetExceptionMessage(expected.FailMessage, expression.PartialMatcherAwareEval().ToLambda().ToStringFixed(), callCount) +
 				Environment.NewLine + FormatSetupsInfo(setups) +
 				Environment.NewLine + FormatInvocations(actualCalls);
 			throw new MockException(MockException.ExceptionReason.VerificationFailed, message);
@@ -382,7 +382,7 @@ namespace Moq
 		private static string FormatSetupsInfo(IEnumerable<IProxyCall> setups)
 		{
 			var expressionSetups = setups
-				.Select(s => s.SetupExpression.ToStringFixed() + ", " + FormatCallCount(s.CallCount))
+				.Select(s => s.SetupExpression.PartialMatcherAwareEval().ToLambda().ToStringFixed() + ", " + FormatCallCount(s.CallCount))
 				.ToArray();
 
 			return expressionSetups.Length == 0 ?

--- a/UnitTests/VerifyFixture.cs
+++ b/UnitTests/VerifyFixture.cs
@@ -848,6 +848,7 @@ namespace Moq.Tests
 			mock.Object.Execute("ping");
 			mock.Object.Echo(42);
 			mock.Object.Submit();
+            mock.Object.Save(new object[] {1, 2, "hello"});
 
 			var mex = Assert.Throws<MockException>(() => mock.Verify(f => f.Execute("pong")));
 
@@ -856,7 +857,8 @@ namespace Moq.Tests
 				"Performed invocations:" + Environment.NewLine +
 				"IFoo.Execute(\"ping\")" + Environment.NewLine +
 				"IFoo.Echo(42)" + Environment.NewLine +
-				"IFoo.Submit()",
+				"IFoo.Submit()" + Environment.NewLine +
+                "IFoo.Save([1, 2, \"hello\"])",
 				mex.Message);
 		}
 
@@ -910,6 +912,7 @@ namespace Moq.Tests
 			int Echo(int value);
 			void Submit();
 			string Execute(string command);
+		    void Save(object o);
 		}
 
         public interface IBazParam

--- a/UnitTests/VerifyFixture.cs
+++ b/UnitTests/VerifyFixture.cs
@@ -862,6 +862,27 @@ namespace Moq.Tests
 				mex.Message);
 		}
 
+        [Fact]
+	    public void IncludesActualValuesFromVerifyNotVariableNames()
+        {
+            var expectedArg = "lorem,ipsum";
+            var mock = new Moq.Mock<IFoo>();
+
+            var mex = Assert.Throws<MockException>(() => mock.Verify(f => f.Execute(expectedArg.Substring(0, 5))));
+            Assert.Contains("f.Execute(\"lorem\")", mex.Message);
+        }
+
+	    [Fact]
+	    public void IncludesActualValuesFromSetups()
+        {
+            var expectedArg = "lorem,ipsum";
+            var mock = new Moq.Mock<IFoo>();
+	        mock.Setup(f => f.Save(expectedArg.Substring(0, 5)));
+
+	        var mex = Assert.Throws<MockException>(() => mock.Verify(foo => foo.Save("never")));
+            Assert.Contains("f.Save(\"lorem\")", mex.Message);
+	    }
+
 		[Fact]
 		public void IncludesMessageAboutNoActualCallsInFailureMessage()
 		{
@@ -870,6 +891,16 @@ namespace Moq.Tests
 			MockException mex = Assert.Throws<MockException>(() => mock.Verify(f => f.Execute("pong")));
 
 			Assert.Contains(Environment.NewLine + "No invocations performed.", mex.Message);
+		}
+
+		[Fact]
+		public void IncludesMessageAboutNoSetupCallsInFailureMessage()
+		{
+			var mock = new Moq.Mock<IFoo>();
+
+			MockException mex = Assert.Throws<MockException>(() => mock.Verify(f => f.Execute("pong")));
+
+			Assert.Contains(Environment.NewLine + "No setups configured.", mex.Message);
 		}
 
         [Fact]


### PR DESCRIPTION
There's a couple cases of using Verify that don't print very nice values when they fail. I've attempted to resolve a couple of these. 

1. parameter values that are arrays print as "System.String[]" instead of printing out and joining into a comma delimited list
2. setup and verify calls shown in exception messages display the variables referenced and not the values of those variables

Tests have been written/updated for these cases