### PR TITLE
Moq Reset should clear all existing calls in the interceptor

### DIFF
--- a/Source/Interceptor.cs
+++ b/Source/Interceptor.cs
@@ -113,6 +113,11 @@ namespace Moq
 			InterceptionContext.AddOrderedCall(call);
 		}
 
+	    internal void ClearCalls()
+	    {
+	        calls.Clear();
+	    }
+
 		private IEnumerable<IInterceptStrategy> InterceptionStrategies()
 		{
 			yield return new HandleDestructor();

--- a/Source/MockExtensions.cs
+++ b/Source/MockExtensions.cs
@@ -35,6 +35,7 @@ namespace Moq
         {
             mock.Interceptor.InterceptionContext.ClearOrderedCalls();
             mock.Interceptor.InterceptionContext.ClearEventHandlers();
+            mock.Interceptor.ClearCalls();
             mock.ResetCalls();
         } 
     }

--- a/UnitTests/ExtensionsFixture.cs
+++ b/UnitTests/ExtensionsFixture.cs
@@ -38,6 +38,56 @@ namespace Moq.Tests
             var result = mock.Object.Execute("ping");
             Assert.Null(result);
         }
+
+        [Fact]
+       
+        public void Loose()
+        {
+            var myMock = new Mock<IEnumerable<int>>(MockBehavior.Loose);
+            myMock
+                .Setup(a => a.ToString())
+                .Returns("Hello");
+            myMock.Reset();
+            Assert.NotEqual("Hello", myMock.Object.ToString());
+            myMock.VerifyAll();
+        }
+
+        [Fact]
+       
+        public void Strict()
+        {
+            var myMock = new Mock<IEnumerable<int>>(MockBehavior.Strict);
+            myMock
+                .Setup(a => a.ToString())
+                .Returns("Hello");
+            myMock.Reset();
+            Assert.NotEqual("Hello", myMock.Object.ToString());
+            myMock.VerifyAll();
+        }
+
+        [Fact]
+       
+        public void LooseNoCall()
+        {
+            var myMock = new Mock<IEnumerable<int>>(MockBehavior.Loose);
+            myMock
+                .Setup(a => a.ToString())
+                .Returns("Hello");
+            myMock.Reset();
+            myMock.VerifyAll();
+        }
+
+        [Fact]
+       
+        public void StrictNoCall()
+        {
+            var myMock = new Mock<IEnumerable<int>>(MockBehavior.Strict);
+            myMock
+                .Setup(a => a.ToString())
+                .Returns("Hello");
+            myMock.Reset();
+            myMock.VerifyAll();
+        }
         #endregion
     }
 


### PR DESCRIPTION
This should fix https://github.com/Moq/moq4/issues/220

The issue was that the calls in the interceptor were not cleared when reset was called.