### PR TITLE
Fixed `InterceptObjectMethodsMixin` to properly check for `System.Object` methods

### DIFF
--- a/Source/InterceptorStrategies.cs
+++ b/Source/InterceptorStrategies.cs
@@ -143,21 +143,21 @@ namespace Moq
 			var method = invocation.Method;
 
 			// Only if there is no corresponding setup for `ToString()`
-			if (IsObjectMethod(method, "ToString") && !ctx.OrderedCalls.Select(c => IsObjectMethod(c.Method, "ToString")).Any())
+			if (IsObjectMethod(method, "ToString") && !ctx.OrderedCalls.Any(c => IsObjectMethod(c.Method, "ToString")))
 			{
 				invocation.ReturnValue = ctx.Mock.ToString() + ".Object";
 				return InterceptionAction.Stop;
 			}
 
 			// Only if there is no corresponding setup for `GetHashCode()`
-			if (IsObjectMethod(method, "GetHashCode") && !ctx.OrderedCalls.Select(c => IsObjectMethod(c.Method, "GetHashCode")).Any())
+			if (IsObjectMethod(method, "GetHashCode") && !ctx.OrderedCalls.Any(c => IsObjectMethod(c.Method, "GetHashCode")))
 			{
 				invocation.ReturnValue = ctx.Mock.GetHashCode();
 				return InterceptionAction.Stop;
 			}
 
 			// Only if there is no corresponding setup for `Equals()`
-			if (IsObjectMethod(method, "Equals") && !ctx.OrderedCalls.Select(c => IsObjectMethod(c.Method, "Equals")).Any())
+			if (IsObjectMethod(method, "Equals") && !ctx.OrderedCalls.Any(c => IsObjectMethod(c.Method, "Equals")))
 			{
 				invocation.ReturnValue = ReferenceEquals(invocation.Arguments.First(), ctx.Mock.Object);
 				return InterceptionAction.Stop;

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -285,16 +285,19 @@ namespace Moq.Tests.Regressions
 			[Fact]
 			public void SystemObjectMethodsShouldWorkInStrictMocks()
 			{
-				var mockObject = new Mock<IMyInterface>(MockBehavior.Strict).Object;
+				var mock = new Mock<IMyInterface>(MockBehavior.Strict);
 
-				Assert.IsType(typeof(int), mockObject.GetHashCode());
-				Assert.IsType(typeof(string), mockObject.ToString());
-				Assert.False(mockObject.Equals("ImNotTheObject"));
-				Assert.True(mockObject.Equals(mockObject));
+				mock.Setup(x => x.Test()).Returns(true);
+
+				Assert.IsType(typeof(int), mock.Object.GetHashCode());
+				Assert.IsType(typeof(string), mock.Object.ToString());
+				Assert.False(mock.Object.Equals("ImNotTheObject"));
+				Assert.True(mock.Object.Equals(mock.Object));
 			}
 
 			public interface IMyInterface
 			{
+				bool Test();
 			}
 		}
 


### PR DESCRIPTION
Fixes #273 (again :-))