### PR TITLE
Fix for issue #228: Events not raised on mocked type with multiple interfaces

### DIFF
--- a/Source/InterceptorStrategies.cs
+++ b/Source/InterceptorStrategies.cs
@@ -208,38 +208,25 @@ namespace Moq
 		/// <param name="eventName">Name of the event, with the set_ or get_ prefix already removed</param>
 		private EventInfo GetEventFromName(string eventName)
 		{
-			var depthFirstProgress = new Queue<Type>(ctx.Mock.ImplementedInterfaces.Skip(1));
-			depthFirstProgress.Enqueue(ctx.TargetType);
-			while (depthFirstProgress.Count > 0)
-			{
-				var currentType = depthFirstProgress.Dequeue();
-				var eventInfo = currentType.GetEvent(eventName);
-				if (eventInfo != null)
-				{
-					return eventInfo;
-				}
-
-				foreach (var implementedType in GetAncestorTypes(currentType))
-				{
-					depthFirstProgress.Enqueue(implementedType);
-				}
-			}
-			return GetNonPublicEventFromName(eventName);
+			return GetEventFromName(eventName, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public) ??
+				GetEventFromName(eventName, BindingFlags.Instance | BindingFlags.NonPublic);
 		}
 
 		/// <summary>
 		/// Get an eventInfo for a given event name.  Search type ancestors depth first if necessary.
-		/// Searches also in non public events.
+		/// Searches events using the specified binding constraints.
 		/// </summary>
 		/// <param name="eventName">Name of the event, with the set_ or get_ prefix already removed</param>
-		private EventInfo GetNonPublicEventFromName(string eventName)
+		/// <param name="bindingAttr">Specifies how the search for events is conducted</param>
+		private EventInfo GetEventFromName(string eventName, BindingFlags bindingAttr)
 		{
-			var depthFirstProgress = new Queue<Type>(ctx.Mock.ImplementedInterfaces.Skip(1));
+			// Ignore internally implemented interfaces
+			var depthFirstProgress = new Queue<Type>(ctx.Mock.ImplementedInterfaces.Skip(ctx.Mock.InternallyImplementedInterfaceCount));
 			depthFirstProgress.Enqueue(ctx.TargetType);
 			while (depthFirstProgress.Count > 0)
 			{
 				var currentType = depthFirstProgress.Dequeue();
-				var eventInfo = currentType.GetEvent(eventName, BindingFlags.Instance | BindingFlags.NonPublic);
+				var eventInfo = currentType.GetEvent(eventName, bindingAttr);
 				if (eventInfo != null)
 				{
 					return eventInfo;
@@ -253,7 +240,6 @@ namespace Moq
 
 			return null;
 		}
-
 
 		/// <summary>
 		/// Given a type return all of its ancestors, both types and interfaces.
@@ -269,6 +255,7 @@ namespace Moq
 
 			return initialType.GetInterfaces();
 		}
+
 		InterceptorContext ctx;
 		public InterceptionAction HandleIntercept(ICallContext invocation, InterceptorContext ctx, CurrentInterceptContext localctx)
 		{

--- a/Source/Mock.Generic.cs
+++ b/Source/Mock.Generic.cs
@@ -116,6 +116,7 @@ namespace Moq
 			this.constructorArguments = args;
 			this.ImplementedInterfaces.AddRange(typeof(T).GetInterfaces().Where(i => (i.IsPublic || i.IsNestedPublic) && !i.IsImport));
 			this.ImplementedInterfaces.Add(typeof(IMocked<T>));
+			this.InternallyImplementedInterfaceCount = this.ImplementedInterfaces.Count;
 
 			this.CheckParameters();
 		}

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -108,8 +108,8 @@ namespace Moq
 				var types = string.Join(
 					", ",
 					new[] {mockedType}
-						// Skip first interface which is always our internal IMocked<T>
-						.Concat(mock.ImplementedInterfaces.Skip(1))
+						// Ignore internally defined IMocked<T>
+						.Concat(mock.ImplementedInterfaces.Where(t => t != imockedType))
 						.Select(t => t.Name)
 						.ToArray());
 
@@ -223,6 +223,12 @@ namespace Moq
 		/// Exposes the list of extra interfaces implemented by the mock.
 		/// </summary>
 		internal List<Type> ImplementedInterfaces { get; private set; }
+
+		/// <summary>
+		/// Indicates the number of interfaces in <see cref="ImplementedInterfaces"/> that were
+		/// defined internally, rather than through calls to <see cref="As{TInterface}"/>.
+		/// </summary>
+		internal protected int InternallyImplementedInterfaceCount { get; protected set; }
 
 		#region Verify
 

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -1523,6 +1523,59 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region #228
+
+		public class _228
+		{
+			[Fact]
+			public void Test()
+			{
+				var mock = new Mock<FooBar>() { CallBase = true };
+				IFoo foo = mock.Object;
+				IBar bar = mock.Object;
+
+				bool fooRaised = false;
+				bool barRaised = false;
+				foo.Foo += (s, e) => fooRaised = true;
+				bar.Bar += (s, e) => barRaised = true;
+
+				mock.Object.RaiseMyEvents();
+
+				Assert.True(fooRaised);
+				Assert.True(barRaised);
+			}
+
+			public interface IFoo
+			{
+				event EventHandler Foo;
+			}
+
+			public interface IBar
+			{
+				event EventHandler Bar;
+			}
+
+			public class FooBar : IFoo, IBar
+			{
+				public event EventHandler Foo;
+				public event EventHandler Bar;
+
+				public void RaiseMyEvents()
+				{
+					if (this.Foo != null)
+					{
+						this.Foo(this, EventArgs.Empty);
+					}
+					if (this.Bar != null)
+					{
+						this.Bar(this, EventArgs.Empty);
+					}
+				}
+			}
+		}
+
+		#endregion
+
 		#region #229
 
 		public class _229


### PR DESCRIPTION
The ImplementedInterfaces list on Mock contains the public interfaces of our mocked type, the internally defined IMocked<T> type, and anything else added to the mock via calls to As<T>.  When looking for events, only the last of these (and the concrete mocked type) should be looked at.

Previously the assumption was that ImplementedInterfaces' first entry was the IMocked<T> type, and that the rest were always needed.  This meant the first entry in that list could be skipped, and the rest were always taken.  After 162a54379026a42bbc746335d63316819d078b56 added more interfaces to the list, however, this logic needs to change to count all internally implemented entries in the list and skip them all.

Fixing this will fix #228 which was caused when the EventInfo from an interface was intercepted, but the EventInfo from the underlying concrete type was actually expected.