### PR TITLE
Updated actual invocation formatting to show the values for reference…

### DIFF
--- a/UnitTests/VerifyFixture.cs
+++ b/UnitTests/VerifyFixture.cs
@@ -111,6 +111,18 @@ namespace Moq.Tests
 		[Fact]
 		public void VerifiesReturningMethodWithExpression()
 		{
+			var mock = new Mock<IRef>();
+			mock.Object.DoStuff(new ReferenceType { Key = "Key", Description = "Description", InternalReference = new InternalReference { Code = "Internal" } });
+
+			var me = Assert.Throws<MockException>(
+				() => mock.Verify(f => f.DoStuff(It.Is<ReferenceType>(x => x.Key == "1" && x.Description == "2"))));
+
+			Assert.True(me.Message.Contains("Performed invocations:\r\nIRef.DoStuff(ReferenceType{\r\nKey: \"Key\",\r\nDescription: \"Description\",\r\nInternalReference: InternalReference{\r\nCode: \"Internal\",\r\n},\r\n})"));
+		}
+
+		[Fact]
+		public void VerifiesReturningMethodWithExpressionRefernceTypeArguments()
+		{
 			var mock = new Mock<IFoo>();
 			mock.Object.Execute("ping");
 
@@ -848,7 +860,7 @@ namespace Moq.Tests
 			mock.Object.Execute("ping");
 			mock.Object.Echo(42);
 			mock.Object.Submit();
-            mock.Object.Save(new object[] {1, 2, "hello"});
+			mock.Object.Save(new object[] {1, 2, "hello"});
 
 			var mex = Assert.Throws<MockException>(() => mock.Verify(f => f.Execute("pong")));
 
@@ -858,30 +870,30 @@ namespace Moq.Tests
 				"IFoo.Execute(\"ping\")" + Environment.NewLine +
 				"IFoo.Echo(42)" + Environment.NewLine +
 				"IFoo.Submit()" + Environment.NewLine +
-                "IFoo.Save([1, 2, \"hello\"])",
+				"IFoo.Save([1, 2, \"hello\"])",
 				mex.Message);
 		}
 
-        [Fact]
-	    public void IncludesActualValuesFromVerifyNotVariableNames()
-        {
-            var expectedArg = "lorem,ipsum";
-            var mock = new Moq.Mock<IFoo>();
+		[Fact]
+		public void IncludesActualValuesFromVerifyNotVariableNames()
+		{
+			var expectedArg = "lorem,ipsum";
+			var mock = new Moq.Mock<IFoo>();
 
-            var mex = Assert.Throws<MockException>(() => mock.Verify(f => f.Execute(expectedArg.Substring(0, 5))));
-            Assert.Contains("f.Execute(\"lorem\")", mex.Message);
-        }
+			var mex = Assert.Throws<MockException>(() => mock.Verify(f => f.Execute(expectedArg.Substring(0, 5))));
+			Assert.Contains("f.Execute(\"lorem\")", mex.Message);
+		}
 
-	    [Fact]
-	    public void IncludesActualValuesFromSetups()
-        {
-            var expectedArg = "lorem,ipsum";
-            var mock = new Moq.Mock<IFoo>();
-	        mock.Setup(f => f.Save(expectedArg.Substring(0, 5)));
+		[Fact]
+		public void IncludesActualValuesFromSetups()
+		{
+			var expectedArg = "lorem,ipsum";
+			var mock = new Moq.Mock<IFoo>();
+			mock.Setup(f => f.Save(expectedArg.Substring(0, 5)));
 
-	        var mex = Assert.Throws<MockException>(() => mock.Verify(foo => foo.Save("never")));
-            Assert.Contains("f.Save(\"lorem\")", mex.Message);
-	    }
+			var mex = Assert.Throws<MockException>(() => mock.Verify(foo => foo.Save("never")));
+			Assert.Contains("f.Save(\"lorem\")", mex.Message);
+		}
 
 		[Fact]
 		public void IncludesMessageAboutNoActualCallsInFailureMessage()
@@ -903,30 +915,30 @@ namespace Moq.Tests
 			Assert.Contains(Environment.NewLine + "No setups configured.", mex.Message);
 		}
 
-        [Fact]
-        public void MatchesDerivedTypesForGenericTypes()
-        {
-            var mock = new Mock<IBaz>();
-            mock.Object.Call(new BazParam());
-            mock.Object.Call(new BazParam2());
+		[Fact]
+		public void MatchesDerivedTypesForGenericTypes()
+		{
+			var mock = new Mock<IBaz>();
+			mock.Object.Call(new BazParam());
+			mock.Object.Call(new BazParam2());
 
-            mock.Verify(foo => foo.Call(It.IsAny<IBazParam>()), Times.Exactly(2));
-        }
+			mock.Verify(foo => foo.Call(It.IsAny<IBazParam>()), Times.Exactly(2));
+		}
 
 #if !SILVERLIGHT
-        /// <summary>
-        /// Warning, this is a flaky test and doesn't fail when run as standalone. Running all tests at once will increase the chances of that test to fail.
-        /// </summary>
-        [Fact]
-        public void DoesNotThrowCollectionModifiedWhenMoreInvocationsInterceptedDuringVerfication()
-        {
-            var mock = new Mock<IFoo>();
-            Parallel.For(0, 100, (i) =>
-            {
-                mock.Object.Submit();
-                mock.Verify(foo => foo.Submit());
-            });
-        }
+		/// <summary>
+		/// Warning, this is a flaky test and doesn't fail when run as standalone. Running all tests at once will increase the chances of that test to fail.
+		/// </summary>
+		[Fact]
+		public void DoesNotThrowCollectionModifiedWhenMoreInvocationsInterceptedDuringVerfication()
+		{
+			var mock = new Mock<IFoo>();
+			Parallel.For(0, 100, (i) =>
+			{
+				mock.Object.Submit();
+				mock.Verify(foo => foo.Submit());
+			});
+		}
 #endif
 
 		public interface IBar
@@ -943,25 +955,42 @@ namespace Moq.Tests
 			int Echo(int value);
 			void Submit();
 			string Execute(string command);
-		    void Save(object o);
+			void Save(object o);
 		}
 
-        public interface IBazParam
-        {
-        }
+		public interface IRef
+		{
+			void DoStuff(ReferenceType reference);
+		}
 
-        public interface IBaz
-        {
-            void Call<T>(T param) where T:IBazParam;
-        }
+		public interface IBazParam
+		{
+		}
 
-        public class BazParam:IBazParam
-        {
-        }
+		public interface IBaz
+		{
+			void Call<T>(T param) where T:IBazParam;
+		}
 
-        public class BazParam2:BazParam
-        {
-        }
+		public class BazParam:IBazParam
+		{
+		}
+
+		public class BazParam2:BazParam
+		{
+		}
+	}
+
+	public class ReferenceType
+	{
+		public string Key { get; set; }
+		public string Description { get; set; }
+		public InternalReference InternalReference { get; set; }
+	}
+
+	public class InternalReference
+	{
+		public string Code { get; set; }
 	}
 }
 


### PR DESCRIPTION
When using verify to check for a specific invocation,  the failure message was listing invocations of the method with the arguments using the objects ToString() method. The default implementation of the ToString() is to provide the full name which for more complex types is not very usefull - we a re more interested in the values of the properties of the complex type arguments. 