### PR TITLE
ReturnsAsync() lazy evaluation issue fix #303

### DIFF
--- a/Source/ReturnsExtensions.Generated.cs
+++ b/Source/ReturnsExtensions.Generated.cs
@@ -11,138 +11,157 @@ namespace Moq
     /// </summary>
 	public static class GeneratedReturnsExtensions
 	{
-        /// <summary>
-		/// Allows to specify the return value of an asynchronous method.
-		/// </summary>
-		public static IReturnsResult<TMock> ReturnsAsync<T, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T, TResult> value) where TMock : class
+		/// <summary>
+        /// Specifies a function that will calculate the value to return from the asynchronous method.
+        /// </summary>
+		/// <typeparam name="T">Type of the function parameter.</typeparam>
+        /// <typeparam name="TMock">Mocked type.</typeparam>
+        /// <typeparam name="TResult">Type of the return value.</typeparam>
+        /// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+        /// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T, TResult> valueFunction) where TMock : class
 		{
-			return mock.Returns((T t) => Task.FromResult(value(t)));
+			return mock.Returns((T t) => Task.FromResult(valueFunction(t)));
 		}	
 		 
-        /// <summary>
-		/// Specifies a function that will calculate the value to return from the method, 
-		/// retrieving the arguments for the invocation.
-		/// </summary>
-		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, TResult> value) where TMock : class
+		/// <summary>
+        /// Specifies a function that will calculate the value to return from the asynchronous method.
+        /// </summary>		
+        /// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+        /// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, TResult> valueFunction) where TMock : class
 		{
-			return mock.Returns((T1 t1, T2 t2) => Task.FromResult(value(t1, t2)));
+			return mock.Returns((T1 t1, T2 t2) => Task.FromResult(valueFunction(t1, t2)));
 		}
  
-        /// <summary>
-		/// Specifies a function that will calculate the value to return from the method, 
-		/// retrieving the arguments for the invocation.
-		/// </summary>
-		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, TResult> value) where TMock : class
+		/// <summary>
+        /// Specifies a function that will calculate the value to return from the asynchronous method.
+        /// </summary>		
+        /// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+        /// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, TResult> valueFunction) where TMock : class
 		{
-			return mock.Returns((T1 t1, T2 t2, T3 t3) => Task.FromResult(value(t1, t2, t3)));
+			return mock.Returns((T1 t1, T2 t2, T3 t3) => Task.FromResult(valueFunction(t1, t2, t3)));
 		}
  
-        /// <summary>
-		/// Specifies a function that will calculate the value to return from the method, 
-		/// retrieving the arguments for the invocation.
-		/// </summary>
-		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, TResult> value) where TMock : class
+		/// <summary>
+        /// Specifies a function that will calculate the value to return from the asynchronous method.
+        /// </summary>		
+        /// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+        /// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, TResult> valueFunction) where TMock : class
 		{
-			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4) => Task.FromResult(value(t1, t2, t3, t4)));
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4) => Task.FromResult(valueFunction(t1, t2, t3, t4)));
 		}
  
-        /// <summary>
-		/// Specifies a function that will calculate the value to return from the method, 
-		/// retrieving the arguments for the invocation.
-		/// </summary>
-		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, TResult> value) where TMock : class
+		/// <summary>
+        /// Specifies a function that will calculate the value to return from the asynchronous method.
+        /// </summary>		
+        /// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+        /// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, TResult> valueFunction) where TMock : class
 		{
-			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5) => Task.FromResult(value(t1, t2, t3, t4, t5)));
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5)));
 		}
  
-        /// <summary>
-		/// Specifies a function that will calculate the value to return from the method, 
-		/// retrieving the arguments for the invocation.
-		/// </summary>
-		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, TResult> value) where TMock : class
+		/// <summary>
+        /// Specifies a function that will calculate the value to return from the asynchronous method.
+        /// </summary>		
+        /// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+        /// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, TResult> valueFunction) where TMock : class
 		{
-			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) => Task.FromResult(value(t1, t2, t3, t4, t5, t6)));
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6)));
 		}
  
-        /// <summary>
-		/// Specifies a function that will calculate the value to return from the method, 
-		/// retrieving the arguments for the invocation.
-		/// </summary>
-		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, TResult> value) where TMock : class
+		/// <summary>
+        /// Specifies a function that will calculate the value to return from the asynchronous method.
+        /// </summary>		
+        /// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+        /// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, TResult> valueFunction) where TMock : class
 		{
-			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) => Task.FromResult(value(t1, t2, t3, t4, t5, t6, t7)));
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7)));
 		}
  
-        /// <summary>
-		/// Specifies a function that will calculate the value to return from the method, 
-		/// retrieving the arguments for the invocation.
-		/// </summary>
-		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> value) where TMock : class
+		/// <summary>
+        /// Specifies a function that will calculate the value to return from the asynchronous method.
+        /// </summary>		
+        /// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+        /// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> valueFunction) where TMock : class
 		{
-			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) => Task.FromResult(value(t1, t2, t3, t4, t5, t6, t7, t8)));
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8)));
 		}
  
-        /// <summary>
-		/// Specifies a function that will calculate the value to return from the method, 
-		/// retrieving the arguments for the invocation.
-		/// </summary>
-		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> value) where TMock : class
+		/// <summary>
+        /// Specifies a function that will calculate the value to return from the asynchronous method.
+        /// </summary>		
+        /// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+        /// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> valueFunction) where TMock : class
 		{
-			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9) => Task.FromResult(value(t1, t2, t3, t4, t5, t6, t7, t8, t9)));
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9)));
 		}
  
-        /// <summary>
-		/// Specifies a function that will calculate the value to return from the method, 
-		/// retrieving the arguments for the invocation.
-		/// </summary>
-		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> value) where TMock : class
+		/// <summary>
+        /// Specifies a function that will calculate the value to return from the asynchronous method.
+        /// </summary>		
+        /// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+        /// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> valueFunction) where TMock : class
 		{
-			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10) => Task.FromResult(value(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)));
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)));
 		}
  
-        /// <summary>
-		/// Specifies a function that will calculate the value to return from the method, 
-		/// retrieving the arguments for the invocation.
-		/// </summary>
-		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> value) where TMock : class
+		/// <summary>
+        /// Specifies a function that will calculate the value to return from the asynchronous method.
+        /// </summary>		
+        /// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+        /// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> valueFunction) where TMock : class
 		{
-			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11) => Task.FromResult(value(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)));
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)));
 		}
  
-        /// <summary>
-		/// Specifies a function that will calculate the value to return from the method, 
-		/// retrieving the arguments for the invocation.
-		/// </summary>
-		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> value) where TMock : class
+		/// <summary>
+        /// Specifies a function that will calculate the value to return from the asynchronous method.
+        /// </summary>		
+        /// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+        /// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> valueFunction) where TMock : class
 		{
-			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12) => Task.FromResult(value(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)));
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)));
 		}
  
-        /// <summary>
-		/// Specifies a function that will calculate the value to return from the method, 
-		/// retrieving the arguments for the invocation.
-		/// </summary>
-		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> value) where TMock : class
+		/// <summary>
+        /// Specifies a function that will calculate the value to return from the asynchronous method.
+        /// </summary>		
+        /// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+        /// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> valueFunction) where TMock : class
 		{
-			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13) => Task.FromResult(value(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)));
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)));
 		}
  
-        /// <summary>
-		/// Specifies a function that will calculate the value to return from the method, 
-		/// retrieving the arguments for the invocation.
-		/// </summary>
-		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> value) where TMock : class
+		/// <summary>
+        /// Specifies a function that will calculate the value to return from the asynchronous method.
+        /// </summary>		
+        /// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+        /// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> valueFunction) where TMock : class
 		{
-			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14) => Task.FromResult(value(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)));
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)));
 		}
  
-        /// <summary>
-		/// Specifies a function that will calculate the value to return from the method, 
-		/// retrieving the arguments for the invocation.
-		/// </summary>
-		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> value) where TMock : class
+		/// <summary>
+        /// Specifies a function that will calculate the value to return from the asynchronous method.
+        /// </summary>		
+        /// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+        /// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> valueFunction) where TMock : class
 		{
-			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14, T15 t15) => Task.FromResult(value(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)));
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14, T15 t15) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)));
 		}
 	}
 }

--- a/Source/ReturnsExtensions.cs
+++ b/Source/ReturnsExtensions.cs
@@ -12,25 +12,37 @@ namespace Moq
     public static class ReturnsExtensions
     {
         /// <summary>
-        /// Allows to specify the return value of an asynchronous method.
+        /// Specifies the value to return from an asynchronous method.
         /// </summary>
+        /// <typeparam name="TMock">Mocked type.</typeparam>
+        /// <typeparam name="TResult">Type of the return value.</typeparam>
+        /// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+        /// <param name="value">The value to return, or <see longword="null"/>.</param>
         public static IReturnsResult<TMock> ReturnsAsync<TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, TResult value) where TMock : class
         {
-			return mock.Returns(Task.FromResult(value));
+            return mock.ReturnsAsync(() => value);
         }
 
-		/// <summary>
-		/// Allows to specify the return value of an asynchronous method.
-		/// </summary>
-		public static IReturnsResult<TMock> ReturnsAsync<TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<TResult> value) where TMock : class
+        /// <summary>
+        /// Specifies a function that will calculate the value to return from the asynchronous method.
+        /// </summary>
+        /// <typeparam name="TMock">Mocked type.</typeparam>
+        /// <typeparam name="TResult">Type of the return value.</typeparam>
+        /// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+        /// <param name="valueFunction">The function that will calculate the return value.</param>
+        public static IReturnsResult<TMock> ReturnsAsync<TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<TResult> valueFunction) where TMock : class
 		{
-			return mock.ReturnsAsync(value());
+		    return mock.Returns(() => Task.FromResult(valueFunction()));
 		}
 
-		/// <summary>
-		/// Allows to specify the exception thrown by an asynchronous method.
-		/// </summary>
-		public static IReturnsResult<TMock> ThrowsAsync<TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Exception exception) where TMock : class
+        /// <summary>
+        /// Specifies the exception to throw when the asynchronous method is invoked.
+        /// </summary>
+        /// <typeparam name="TMock">Mocked type.</typeparam>
+        /// <typeparam name="TResult">Type of the return value.</typeparam>
+        /// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+        /// <param name="exception">Exception instance to throw.</param>
+        public static IReturnsResult<TMock> ThrowsAsync<TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Exception exception) where TMock : class
         {
             var tcs = new TaskCompletionSource<TResult>();
             tcs.SetException(exception);

--- a/Source/ReturnsExtensions.tt
+++ b/Source/ReturnsExtensions.tt
@@ -15,20 +15,26 @@ namespace Moq
     /// </summary>
 	public static class GeneratedReturnsExtensions
 	{
-        /// <summary>
-		/// Allows to specify the return value of an asynchronous method.
-		/// </summary>
-		public static IReturnsResult<TMock> ReturnsAsync<T, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T, TResult> value) where TMock : class
+		/// <summary>
+        /// Specifies a function that will calculate the value to return from the asynchronous method.
+        /// </summary>
+		/// <typeparam name="T">Type of the function parameter.</typeparam>
+        /// <typeparam name="TMock">Mocked type.</typeparam>
+        /// <typeparam name="TResult">Type of the return value.</typeparam>
+        /// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+        /// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T, TResult> valueFunction) where TMock : class
 		{
-			return mock.Returns((T t) => Task.FromResult(value(t)));
+			return mock.Returns((T t) => Task.FromResult(valueFunction(t)));
 		}	
 		<# 
 		for (var argumentCount = 2; argumentCount <= 15; ++argumentCount)
 		{ #> 
-        /// <summary>
-		/// Specifies a function that will calculate the value to return from the method, 
-		/// retrieving the arguments for the invocation.
-		/// </summary>
+		/// <summary>
+        /// Specifies a function that will calculate the value to return from the asynchronous method.
+        /// </summary>		
+        /// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+        /// <param name="valueFunction">The function that will calculate the return value.</param>
 		public static IReturnsResult<TMock> ReturnsAsync<<#
 			for (var i = 1; i <= argumentCount; ++i)
 			{
@@ -37,13 +43,13 @@ namespace Moq
 			for (var i = 1; i <= argumentCount; ++i)
 			{
 				#>T<#=i#>, <#
-			}#>TResult> value) where TMock : class
+			}#>TResult> valueFunction) where TMock : class
 		{
 			return mock.Returns((<#
 			for (var i = 1; i <= argumentCount; ++i)
 			{ #>T<#=i#> t<#=i#><#
 				if(i != argumentCount) {#>, <#}#><#
-			}#>) => Task.FromResult(value(<#
+			}#>) => Task.FromResult(valueFunction(<#
 			for (var i = 1; i <= argumentCount; ++i)
 			{
 				#>t<#=i#><#

--- a/UnitTests/GeneratedReturnsExtensionsFixture.cs
+++ b/UnitTests/GeneratedReturnsExtensionsFixture.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Moq.Tests
+{
+    public class GeneratedReturnsExtensionsFixture
+    {
+        public interface IAsyncInterface
+        {
+            Task<int> WithSingleParameterAsync(int parameter);
+            Task<string> WithMultiParameterAsync(string firstParameter, string secondParameter);
+            Task<DateTime> WithParamsAsync(params DateTime[] dateTimes);
+        }
+
+        [Fact]
+        public void ReturnsAsync_onSingleParameter_ParameterUsedForCalculationOfTheResult()
+        {
+            var mock = new Mock<IAsyncInterface>();
+            mock.Setup(x => x.WithSingleParameterAsync(It.IsAny<int>())).ReturnsAsync((int x) => x * x);
+
+            int evaluationResult = mock.Object.WithSingleParameterAsync(2).Result;
+
+            Assert.Equal(4, evaluationResult);
+        }
+
+        [Fact]
+        public void ReturnsAsync_onSingleParameter_LazyEvaluationOfTheResult()
+        {
+            int coefficient = 5;
+            var mock = new Mock<IAsyncInterface>();
+            mock.Setup(x => x.WithSingleParameterAsync(It.IsAny<int>())).ReturnsAsync((int x) => x * coefficient);
+
+            int firstEvaluationResult = mock.Object.WithSingleParameterAsync(2).Result;
+
+            coefficient = 10;
+            int secondEvaluationResult = mock.Object.WithSingleParameterAsync(2).Result;
+
+            Assert.NotEqual(firstEvaluationResult, secondEvaluationResult);
+        }
+
+        [Fact]
+        public void ReturnsAsync_onMultiParameter_ParametersUsedForCalculationOfTheResult()
+        {
+            var mock = new Mock<IAsyncInterface>();
+            mock.Setup(x => x.WithMultiParameterAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((string first, string second) => first + second);
+
+            string evaluationResult = mock.Object.WithMultiParameterAsync("Moq", "4").Result;
+
+            Assert.Equal("Moq4", evaluationResult);
+        }
+
+        [Fact]
+        public void ReturnsAsync_onMultiParameter_LazyEvaluationOfTheResult()
+        {
+            var mock = new Mock<IAsyncInterface>();
+            mock.Setup(x => x.WithMultiParameterAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync((string first, string second) => first + second);
+
+            string firstEvaluationResult = mock.Object.WithMultiParameterAsync("Moq", "4").Result;
+            string secondEvaluationResult = mock.Object.WithMultiParameterAsync("Moq", "4").Result;
+
+            Assert.NotSame(firstEvaluationResult, secondEvaluationResult);
+        }
+
+        [Fact]
+        public void ReturnsAsync_onParams_AllParametersUsedForCalculationOfTheResult()
+        {
+            var mock = new Mock<IAsyncInterface>();
+            mock.Setup(x => x.WithParamsAsync(It.IsAny<DateTime[]>()))
+                .ReturnsAsync((DateTime[] dateTimes) => dateTimes.Max());
+
+            DateTime evaluationResult = mock.Object.WithParamsAsync(DateTime.MinValue, DateTime.Now, DateTime.MaxValue).Result;
+
+            Assert.Equal(DateTime.MaxValue, evaluationResult);
+        }
+
+        [Fact]
+        public void ReturnsAsync_onParams_LazyEvaluationOfTheResult()
+        {
+            var mock = new Mock<IAsyncInterface>();
+            mock.Setup(x => x.WithParamsAsync(It.IsAny<DateTime[]>()))
+                .ReturnsAsync((DateTime[] dateTimes) => dateTimes.Max());
+            
+            DateTime firstEvaluationResult = mock.Object.WithParamsAsync(DateTime.MinValue, DateTime.Now).Result;
+            DateTime secondEvaluationResult = mock.Object.WithParamsAsync(DateTime.MinValue, DateTime.Now).Result;
+
+            Assert.NotEqual(firstEvaluationResult, secondEvaluationResult);
+        }
+    }
+}

--- a/UnitTests/GeneratedReturnsExtensionsFixture.cs
+++ b/UnitTests/GeneratedReturnsExtensionsFixture.cs
@@ -78,12 +78,16 @@ namespace Moq.Tests
         [Fact]
         public void ReturnsAsync_onParams_LazyEvaluationOfTheResult()
         {
+            DateTime comparedDateTime = DateTime.MinValue;
             var mock = new Mock<IAsyncInterface>();
             mock.Setup(x => x.WithParamsAsync(It.IsAny<DateTime[]>()))
-                .ReturnsAsync((DateTime[] dateTimes) => dateTimes.Max());
-            
-            DateTime firstEvaluationResult = mock.Object.WithParamsAsync(DateTime.MinValue, DateTime.Now).Result;
-            DateTime secondEvaluationResult = mock.Object.WithParamsAsync(DateTime.MinValue, DateTime.Now).Result;
+                .ReturnsAsync((DateTime[] dateTimes) => dateTimes.Concat(new[] { comparedDateTime }).Max());
+
+            DateTime now = DateTime.Now;
+            DateTime firstEvaluationResult = mock.Object.WithParamsAsync(DateTime.MinValue, now).Result;
+
+            comparedDateTime = DateTime.MaxValue;
+            DateTime secondEvaluationResult = mock.Object.WithParamsAsync(DateTime.MinValue, now).Result;
 
             Assert.NotEqual(firstEvaluationResult, secondEvaluationResult);
         }

--- a/UnitTests/Moq.Tests.csproj
+++ b/UnitTests/Moq.Tests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="CustomMatcherFixture.cs" />
     <Compile Include="ExtensionsFixture.cs" />
     <Compile Include="CaptureMatchFixture.cs" />
+    <Compile Include="GeneratedReturnsExtensionsFixture.cs" />
     <Compile Include="Regressions\FluentMockIssues.cs" />
     <Compile Include="ReturnsExtensionsFixture.cs" />
     <Compile Include="Linq\MockRepositoryQuerying.cs" />

--- a/UnitTests/ReturnsExtensionsFixture.cs
+++ b/UnitTests/ReturnsExtensionsFixture.cs
@@ -19,6 +19,8 @@ namespace Moq.Tests
             Task<string> ValueParameterRefReturnType(int value);
          
             Task<int> ValueParameterValueReturnType(int value);
+
+            Task<Guid> NewGuidAsync();
         }
 
         [Fact]
@@ -165,7 +167,31 @@ namespace Moq.Tests
 			Assert.Equal(37, task.Result);
 		}
 
-		[Fact]
+        [Fact]
+        public void ReturnsAsyncFunc_onEachInvocation_ValueReturnTypeLazyEvaluation()
+        {
+            var mock = new Mock<IAsyncInterface>();
+            mock.Setup(x => x.NewGuidAsync()).ReturnsAsync(Guid.NewGuid);
+
+            Guid firstEvaluationResult = mock.Object.NewGuidAsync().Result;
+            Guid secondEvaluationResult = mock.Object.NewGuidAsync().Result;
+
+            Assert.NotEqual(firstEvaluationResult, secondEvaluationResult);
+        }
+
+        [Fact]
+        public void ReturnsAsyncFunc_onEachInvocation_RefReturnTypeLazyEvaluation()
+        {
+            var mock = new Mock<IAsyncInterface>();
+            mock.Setup(x => x.ValueParameterRefReturnType(36)).ReturnsAsync(() => new string(new[] { 'M', 'o', 'q', '4' }));
+
+            string firstEvaluationResult = mock.Object.ValueParameterRefReturnType(36).Result;
+            string secondEvaluationResult = mock.Object.ValueParameterRefReturnType(36).Result;
+
+            Assert.NotSame(firstEvaluationResult, secondEvaluationResult);
+        }
+
+        [Fact]
         public void ThrowsAsync_on_NoParametersRefReturnType()
         {
             var mock = new Mock<IAsyncInterface>();


### PR DESCRIPTION
##### ReturnsAsync() lazy evaluation issue fix as discussed in #303 
###### Changes:
- `ReturnsAsync()` overload implementation
- Summary standardization for all `ReturnsAsync()` and `ThrowsAsync()` overloads
- Unit tests for lazy evaluation behavior
- New unit test fixture for _GeneratedReturnsExtensions_


