### PR TITLE
Fix typo in summary of Mock<T>.Setup docs

### DIFF
--- a/Source/Mock.Generic.xdoc
+++ b/Source/Mock.Generic.xdoc
@@ -119,7 +119,7 @@
 	</doc>
 	<doc for="Mock{T}.Setup">
 		<summary>
-			Specifies a setup on the mocked type for a call to
+			Specifies a setup on the mocked type for a call
 			to a void method.
 		</summary>
 		<remarks>


### PR DESCRIPTION
Before: 
`Specifies a setup on the mocked type for a call to to a void method.`

After: 
`Specifies a setup on the mocked type for a call to a void method.`