### PR TITLE
Upgrade Castle.Core dependency to 4.0.0

### DIFF
--- a/Moq.nuspec
+++ b/Moq.nuspec
@@ -178,10 +178,10 @@ Version 1.0
 </releaseNotes>
     <dependencies>
       <group targetFramework=".NETFramework4.5">
-        <dependency id="Castle.Core" version="3.3.3" />
+        <dependency id="Castle.Core" version="4.0.0" />
       </group>
       <group targetFramework=".NETStandard1.3">
-        <dependency id="Castle.Core" version="4.0.0-beta001" />
+        <dependency id="Castle.Core" version="4.0.0" />
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Collections.Concurrent" version="4.0.12" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11" />

--- a/Source.NetCore/project.json
+++ b/Source.NetCore/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Castle.Core": "4.0.0-beta001",
+    "Castle.Core": "4.0.0",
     "IFluentInterface": "2.0.0",
     "GitInfo": "1.1.14",
     "Microsoft.CSharp": "4.0.1",

--- a/Source/project.json
+++ b/Source/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Castle.Core": "3.3.3",
+    "Castle.Core": "4.0.0",
     "IFluentInterface": "2.0.0",
     "GitInfo": "1.1.15"
   },

--- a/UnitTests.NetCore/Moq.NetCore.Tests/project.json
+++ b/UnitTests.NetCore/Moq.NetCore.Tests/project.json
@@ -33,7 +33,7 @@
         "define": [ "NETCORE" ]
       },
       "dependencies": {
-        "Castle.Core": "4.0.0-beta001",
+        "Castle.Core": "4.0.0",
         "ClassLibrary1": {
           "target": "project",
           "version": "1.0.0-*"

--- a/UnitTests/project.json
+++ b/UnitTests/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Castle.Core": "3.3.3",
+    "Castle.Core": "4.0.0",
     "xunit": "2.1.0",
     "xunit.runner.visualstudio": "2.1.0"
   },

--- a/global.json
+++ b/global.json
@@ -1,5 +1,8 @@
 {
   "projects": [
     "wrap"
-  ]
+  ],
+  "sdk": {
+    "version": "1.0.0-preview2-003131"
+  }
 }

--- a/wrap/Moq/project.json
+++ b/wrap/Moq/project.json
@@ -1,7 +1,7 @@
 {
   "version": "99.99.99-wrapped",
   "dependencies": {
-        "Castle.Core": "4.0.0-beta001"
+        "Castle.Core": "4.0.0"
   },
   "frameworks": {
     "netstandard1.3": {


### PR DESCRIPTION
@kzu 

Any plan to get a non-pre release out?

After VS 2017 RTM, we can try switching to the new .csproj for both .NET Full and .NET Core.