### PR TITLE
Fix typo in summary of Mock<T>.Setup docs

### DIFF
--- a/Source/Mock.Generic.xdoc
+++ b/Source/Mock.Generic.xdoc
@@ -119,7 +119,7 @@
 	</doc>
 	<doc for="Mock{T}.Setup">
 		<summary>
-			Specifies a setup on the mocked type for a call to
+			Specifies a setup on the mocked type for a call
 			to a void method.
 		</summary>
 		<remarks>


### PR DESCRIPTION
Replaces https://github.com/moq/moq4/pull/322

Before: 
`Specifies a setup on the mocked type for a call to to a void method.`

After: 
`Specifies a setup on the mocked type for a call to a void method.`