### PR TITLE
Fix bug in HasMatchingParameterTypes

### DIFF
--- a/Source/Extensions.cs
+++ b/Source/Extensions.cs
@@ -269,7 +269,7 @@ namespace Moq
 		}
 #endif
 
-		public static bool HasMatchingParameterTypes(this MethodInfo method, Type[] paramTypes)
+		public static bool HasCompatibleParameterTypes(this MethodInfo method, Type[] paramTypes)
 		{
 			var types = method.GetParameterTypes().ToArray();
 			if (types.Length != paramTypes.Length)
@@ -279,7 +279,12 @@ namespace Moq
 
 			for (int i = 0; i < types.Length; i++)
 			{
-				if (types[i] != paramTypes[i])
+				var parameterType = paramTypes[i];
+				if (parameterType == typeof(object))
+				{
+					continue;
+				}
+				else if (!types[i].IsAssignableFrom(parameterType))
 				{
 					return false;
 				}

--- a/Source/Protected/ProtectedMock.cs
+++ b/Source/Protected/ProtectedMock.cs
@@ -192,7 +192,7 @@ namespace Moq.Protected
 		{
 			var argTypes = ToArgTypes(args);
 			return typeof(T).GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
-				.SingleOrDefault(m => m.Name == methodName && m.HasMatchingParameterTypes(argTypes));
+				.SingleOrDefault(m => m.Name == methodName && m.HasCompatibleParameterTypes(argTypes));
 		}
 
 		private static Expression<Func<T, TResult>> GetMethodCall<TResult>(MethodInfo method, object[] args)


### PR DESCRIPTION
The bug was introduced when replacing the `Type.GetMethod(...)` call
to the overload with a `Type[]` parameter since that overload is not
supported in .NET CORE.  The correct behavior should be checking for
compatible argument types, instead of strict matching argument types.

Fixes #334 and the test failure in recent build.