### PR TITLE
Added overload to enforce old behavior of exact parameter matching

### DIFF
--- a/Source/Extensions.cs
+++ b/Source/Extensions.cs
@@ -269,7 +269,7 @@ namespace Moq
 		}
 #endif
 
-		public static bool HasCompatibleParameterTypes(this MethodInfo method, Type[] paramTypes)
+		public static bool HasCompatibleParameterTypes(this MethodInfo method, Type[] paramTypes, bool exactParameterMatch)
 		{
 			var types = method.GetParameterTypes().ToArray();
 			if (types.Length != paramTypes.Length)
@@ -283,6 +283,10 @@ namespace Moq
 				if (parameterType == typeof(object))
 				{
 					continue;
+				}
+				else if (exactParameterMatch && types[i] != parameterType)
+				{
+					return false;
 				}
 				else if (!types[i].IsAssignableFrom(parameterType))
 				{

--- a/Source/Protected/IProtectedMock.cs
+++ b/Source/Protected/IProtectedMock.cs
@@ -73,6 +73,17 @@ namespace Moq.Protected
 		ISetup<TMock, TResult> Setup<TResult>(string methodOrPropertyName, params object[] args);
 
 		/// <summary>
+		/// Specifies a setup for an invocation on a property or a non void method with the given 
+		/// <paramref name="methodOrPropertyName"/>, optionally specifying arguments for the method call.
+		/// </summary>
+		/// <param name="methodOrPropertyName">The name of the method or property to be invoked.</param>
+		/// <param name="args">The optional arguments for the invocation. If argument matchers are used, 
+		/// remember to use <see cref="ItExpr"/> rather than <see cref="It"/>.</param>
+		/// <param name="exactParameterMatch">Should the parameter types match exactly types that were provided</param>
+		/// <typeparam name="TResult">The return type of the method or property.</typeparam>
+		ISetup<TMock, TResult> Setup<TResult>(string methodOrPropertyName, bool exactParameterMatch, params object[] args);
+
+		/// <summary>
 		/// Specifies a setup for an invocation on a property getter with the given 
 		/// <paramref name="propertyName"/>.
 		/// </summary>

--- a/Source/Protected/ProtectedMock.cs
+++ b/Source/Protected/ProtectedMock.cs
@@ -76,6 +76,13 @@ namespace Moq.Protected
 		{
 			Guard.NotNullOrEmpty(() => methodName, methodName);
 
+			return Setup<TResult>(methodName, false, args);
+		}
+
+		public ISetup<T, TResult> Setup<TResult>(string methodName, bool exactParameterMatch, params object[] args)
+		{
+			Guard.NotNullOrEmpty(() => methodName, methodName);
+
 			var property = GetProperty(methodName);
 			if (property != null)
 			{
@@ -84,7 +91,7 @@ namespace Moq.Protected
 				return Mock.SetupGet(mock, GetMemberAccess<TResult>(property), null);
 			}
 
-			var method = GetMethod(methodName, args);
+			var method = GetMethod(methodName, exactParameterMatch, args);
 			ThrowIfMemberMissing(methodName, method);
 			ThrowIfVoidMethod(method);
 			ThrowIfPublicMethod(method, typeof(T).Name);
@@ -190,9 +197,14 @@ namespace Moq.Protected
 
 		private static MethodInfo GetMethod(string methodName, params object[] args)
 		{
+			return GetMethod(methodName, false, args);
+		}
+
+		private static MethodInfo GetMethod(string methodName, bool exactParameterMatch, params object[] args)
+		{
 			var argTypes = ToArgTypes(args);
 			return typeof(T).GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
-				.SingleOrDefault(m => m.Name == methodName && m.HasCompatibleParameterTypes(argTypes));
+				.SingleOrDefault(m => m.Name == methodName && m.HasCompatibleParameterTypes(argTypes, exactParameterMatch));
 		}
 
 		private static Expression<Func<T, TResult>> GetMethodCall<TResult>(MethodInfo method, object[] args)

--- a/UnitTests/ProtectedMockFixture.cs
+++ b/UnitTests/ProtectedMockFixture.cs
@@ -377,6 +377,26 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public void SetupResultDefaulTwoOverloadsWithDerivedClassThrowsInvalidOperationException()
+		{
+			var mock = new Mock<MethodOverloads>();
+			Assert.Throws<InvalidOperationException>(() => mock.Protected()
+				.Setup<FooBase>("OverloadWithDerived", ItExpr.IsAny<MyDerived>())
+				.Returns(new FooBase()));
+
+		}
+
+		[Fact]
+		public void SetupResultExactParameterMatchTwoOverloadsWithDerivedClassShouldNotThrow()
+		{
+			var mock = new Mock<MethodOverloads>();
+			var fooBase = new FooBase();
+			mock.Protected()
+				.Setup<FooBase>("OverloadWithDerived", true, ItExpr.IsAny<MyDerived>())
+				.Returns(fooBase);
+		}
+
+		[Fact]
 		public void ThrowsIfVerifyNullVoidMethodName()
 		{
 			Assert.Throws<ArgumentNullException>(() => new Mock<FooBase>().Protected().Verify(null, Times.Once()));
@@ -751,6 +771,16 @@ namespace Moq.Tests
 			protected virtual void SameFirstParameter(object a) { }
 
 			protected virtual void SameFirstParameter(object a, object b) { }
+
+			protected virtual FooBase OverloadWithDerived(MyBase myBase)
+			{
+				return null;
+			}
+
+			protected virtual FooBase OverloadWithDerived(MyDerived myBase)
+			{
+				return null;
+			}
 		}
 
 		public class FooBase
@@ -869,5 +899,9 @@ namespace Moq.Tests
 		public class FooDerived : FooBase
 		{
 		}
+
+		public class MyBase { }
+
+		public class MyDerived : MyBase { }
 	}
 }


### PR DESCRIPTION
To make old behavior possible again i added an overload to Setup<T> in ProtectedMock which makes an enforcement of exact parameter matching possible again.