### PR TITLE
Docs: Fix 4 typos (fixes #260)

### DIFF
--- a/Source/Mock.Generic.xdoc
+++ b/Source/Mock.Generic.xdoc
@@ -136,7 +136,7 @@
 	</doc>
 	<doc for="Mock{T}.Setup{TResult}">
 		<summary>
-			Specifies a setup on the mocked type for a call to
+			Specifies a setup on the mocked type for a call
 			to a value returning method.
 		</summary>
 		<typeparam name="TResult">Type of the return value. Typically omitted as it can be inferred from the expression.</typeparam>
@@ -153,7 +153,7 @@
 	</doc>
 	<doc for="Mock{T}.SetupGet">
 		<summary>
-			Specifies a setup on the mocked type for a call to
+			Specifies a setup on the mocked type for a call
 			to a property getter.
 		</summary>
 		<remarks>
@@ -171,7 +171,7 @@
 	</doc>
 	<doc for="Mock{T}.SetupSet{TProperty}">
 		<summary>
-			Specifies a setup on the mocked type for a call to
+			Specifies a setup on the mocked type for a call
 			to a property setter.
 		</summary>
 		<remarks>
@@ -192,7 +192,7 @@
 	</doc>
 	<doc for="Mock{T}.SetupSet">
 		<summary>
-			Specifies a setup on the mocked type for a call to
+			Specifies a setup on the mocked type for a call
 			to a property setter.
 		</summary>
 		<remarks>


### PR DESCRIPTION
This fixes #260 (4&times; duplicated word "to" in `Source/Mock.Generic.xdoc`).