### PR TITLE
Add new method `Times.Matching` to `Times`

### DIFF
--- a/Source/Moq.csproj
+++ b/Source/Moq.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Protected\ProtectedMock.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Range.cs" />
+    <Compile Include="TimesEvaluator.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Properties\Resources.resx">

--- a/Source/Properties/Resources.Designer.cs
+++ b/Source/Properties/Resources.Designer.cs
@@ -238,7 +238,16 @@ namespace Moq.Properties {
         
         /// <summary>
         ///   Looks up a localized string similar to {0}
-        ///Expected invocation on the mock at least {2} times, but was {4} times: {1}.
+        ///{1}: {2}.
+        /// </summary>
+        internal static string NoMatchingCalls {
+            get {
+                return ResourceManager.GetString("NoMatchingCalls", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Expected invocation on the mock at least {0} times, but was {2} times.
         /// </summary>
         internal static string NoMatchingCallsAtLeast {
             get {
@@ -247,8 +256,7 @@ namespace Moq.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}
-        ///Expected invocation on the mock at least once, but was never performed: {1}.
+        ///   Looks up a localized string similar to Expected invocation on the mock at least once, but was never performed.
         /// </summary>
         internal static string NoMatchingCallsAtLeastOnce {
             get {
@@ -257,8 +265,7 @@ namespace Moq.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}
-        ///Expected invocation on the mock at most {3} times, but was {4} times: {1}.
+        ///   Looks up a localized string similar to Expected invocation on the mock at most {1} times, but was {2} times.
         /// </summary>
         internal static string NoMatchingCallsAtMost {
             get {
@@ -267,8 +274,7 @@ namespace Moq.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}
-        ///Expected invocation on the mock at most once, but was {4} times: {1}.
+        ///   Looks up a localized string similar to Expected invocation on the mock at most once, but was {2} times.
         /// </summary>
         internal static string NoMatchingCallsAtMostOnce {
             get {
@@ -277,8 +283,7 @@ namespace Moq.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}
-        ///Expected invocation on the mock between {2} and {3} times (Exclusive), but was {4} times: {1}.
+        ///   Looks up a localized string similar to Expected invocation on the mock between {0} and {1} times (Exclusive), but was {2} times.
         /// </summary>
         internal static string NoMatchingCallsBetweenExclusive {
             get {
@@ -287,8 +292,7 @@ namespace Moq.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}
-        ///Expected invocation on the mock between {2} and {3} times (Inclusive), but was {4} times: {1}.
+        ///   Looks up a localized string similar to Expected invocation on the mock between {0} and {1} times (Inclusive), but was {2} times.
         /// </summary>
         internal static string NoMatchingCallsBetweenInclusive {
             get {
@@ -297,8 +301,7 @@ namespace Moq.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}
-        ///Expected invocation on the mock exactly {2} times, but was {4} times: {1}.
+        ///   Looks up a localized string similar to Expected invocation on the mock exactly {0} times, but was {2} times.
         /// </summary>
         internal static string NoMatchingCallsExactly {
             get {
@@ -307,8 +310,7 @@ namespace Moq.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}
-        ///Expected invocation on the mock should never have been performed, but was {4} times: {1}.
+        ///   Looks up a localized string similar to Expected invocation on the mock should never have been performed, but was {2} times.
         /// </summary>
         internal static string NoMatchingCallsNever {
             get {
@@ -317,8 +319,7 @@ namespace Moq.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}
-        ///Expected invocation on the mock once, but was {4} times: {1}.
+        ///   Looks up a localized string similar to Expected invocation on the mock once, but was {2} times.
         /// </summary>
         internal static string NoMatchingCallsOnce {
             get {

--- a/Source/Properties/Resources.resx
+++ b/Source/Properties/Resources.resx
@@ -201,8 +201,7 @@ mock.SetupSet(x =&gt; x.{1}).Callback(callbackDelegate);
     <value>Expression is not a method invocation: {0}</value>
   </data>
   <data name="NoMatchingCallsAtLeastOnce" xml:space="preserve">
-    <value>{0}
-Expected invocation on the mock at least once, but was never performed: {1}</value>
+    <value>Expected invocation on the mock at least once, but was never performed</value>
   </data>
   <data name="AlreadyInitialized" xml:space="preserve">
     <value>Mock type has already been initialized by accessing its Object property. Adding interfaces must be done before that.</value>
@@ -246,36 +245,28 @@ Remember that there's no generics covariance in the CLR, so your object must be 
     <value>Type {0} does not from required type {1}</value>
   </data>
   <data name="NoMatchingCallsAtLeast" xml:space="preserve">
-    <value>{0}
-Expected invocation on the mock at least {2} times, but was {4} times: {1}</value>
+    <value>Expected invocation on the mock at least {0} times, but was {2} times</value>
   </data>
   <data name="NoMatchingCallsAtMost" xml:space="preserve">
-    <value>{0}
-Expected invocation on the mock at most {3} times, but was {4} times: {1}</value>
+    <value>Expected invocation on the mock at most {1} times, but was {2} times</value>
   </data>
   <data name="NoMatchingCallsAtMostOnce" xml:space="preserve">
-    <value>{0}
-Expected invocation on the mock at most once, but was {4} times: {1}</value>
+    <value>Expected invocation on the mock at most once, but was {2} times</value>
   </data>
   <data name="NoMatchingCallsBetweenInclusive" xml:space="preserve">
-    <value>{0}
-Expected invocation on the mock between {2} and {3} times (Inclusive), but was {4} times: {1}</value>
+    <value>Expected invocation on the mock between {0} and {1} times (Inclusive), but was {2} times</value>
   </data>
   <data name="NoMatchingCallsExactly" xml:space="preserve">
-    <value>{0}
-Expected invocation on the mock exactly {2} times, but was {4} times: {1}</value>
+    <value>Expected invocation on the mock exactly {0} times, but was {2} times</value>
   </data>
   <data name="NoMatchingCallsNever" xml:space="preserve">
-    <value>{0}
-Expected invocation on the mock should never have been performed, but was {4} times: {1}</value>
+    <value>Expected invocation on the mock should never have been performed, but was {2} times</value>
   </data>
   <data name="NoMatchingCallsBetweenExclusive" xml:space="preserve">
-    <value>{0}
-Expected invocation on the mock between {2} and {3} times (Exclusive), but was {4} times: {1}</value>
+    <value>Expected invocation on the mock between {0} and {1} times (Exclusive), but was {2} times</value>
   </data>
   <data name="NoMatchingCallsOnce" xml:space="preserve">
-    <value>{0}
-Expected invocation on the mock once, but was {4} times: {1}</value>
+    <value>Expected invocation on the mock once, but was {2} times</value>
   </data>
   <data name="SetupOnNonMemberMethod" xml:space="preserve">
     <value>Expression references a method that does not belong to the mocked object: {0}</value>
@@ -306,5 +297,9 @@ Expected invocation on the mock once, but was {4} times: {1}</value>
   </data>
   <data name="PropertyGetNotFound" xml:space="preserve">
     <value>Property {0}.{1} does not have a getter.</value>
+  </data>
+  <data name="NoMatchingCalls" xml:space="preserve">
+    <value>{0}
+{1}: {2}</value>
   </data>
 </root>

--- a/Source/Times.xdoc
+++ b/Source/Times.xdoc
@@ -50,6 +50,13 @@
 		<param name="callCount">The times that a method or property can be called.</param>
 		<returns>An object defining the allowed number of invocations.</returns>
 	</doc>
+	<doc for="Times.Matching">
+		<summary>
+			Specifies that a mocked method should be invoked as defined by the given evaluator.
+		</summary>
+		<param name="evaluator">A <see cref="TimesEvaluator"/> object that will verify the expected number of invocations.</param>
+		<returns>An object defining the allowed number of invocations.</returns>
+	</doc>
 	<doc for="Times.Never">
 		<summary>
 			Specifies that a mocked method should not be invoked.

--- a/Source/TimesEvaluator.cs
+++ b/Source/TimesEvaluator.cs
@@ -1,0 +1,71 @@
+﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//http://code.google.com/p/moq/
+//All rights reserved.
+
+//Redistribution and use in source and binary forms,
+//with or without modification, are permitted provided
+//that the following conditions are met:
+
+//    * Redistributions of source code must retain the
+//    above copyright notice, this list of conditions and
+//    the following disclaimer.
+
+//    * Redistributions in binary form must reproduce
+//    the above copyright notice, this list of conditions
+//    and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
+//    names of its contributors may be used to endorse
+//    or promote products derived from this software
+//    without specific prior written permission.
+
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+//SUCH DAMAGE.
+
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System;
+
+namespace Moq
+{
+	/// <include file='TimesEvaluator.xdoc' path='docs/doc[@for="TimesEvaluator"]/*'/>
+	public abstract class TimesEvaluator : IEquatable<TimesEvaluator>
+	{
+		/// <include file='TimesEvaluator.xdoc' path='docs/doc[@for="TimesEvaluator.Equals(object)"]/*'/>
+		public override bool Equals(object obj)
+		{
+			return Equals(obj as TimesEvaluator);
+		}
+
+		/// <include file='TimesEvaluator.xdoc' path='docs/doc[@for="TimesEvaluator.Equals(TimesEvaluator)"]/*'/>
+		public abstract bool Equals(TimesEvaluator other);
+
+		/// <include file='TimesEvaluator.xdoc' path='docs/doc[@for="TimesEvaluator.GetExceptionMessage"]/*'/>
+		public abstract string GetExceptionMessage(int callCount);
+
+		/// <include file='TimesEvaluator.xdoc' path='docs/doc[@for="TimesEvaluator.GetHashCode"]/*'/>
+		public override int GetHashCode()
+		{
+			// Putting a 'TimesEvaluator' inside a hash container is not expected usage, so
+			// all that is required is a correct hash function (even if it isn't a good one).
+			return this.GetType().GetHashCode();
+		}
+
+		/// <include file='TimesEvaluator.xdoc' path='docs/doc[@for="TimesEvaluator.Verify"]/*'/>
+		public abstract bool Verify(int callCount);
+	}
+}

--- a/Source/TimesEvaluator.xdoc
+++ b/Source/TimesEvaluator.xdoc
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<docs xml:space="preserve">
+	<doc for="TimesEvaluator">
+		<summary>
+			Types derived from this abstract base class verify an invocation call count against some criterion.
+		</summary>
+	</doc>
+	<doc for="TimesEvaluator.Verify">
+		<summary>
+			Checks whether the specified call count meets the criterion represented by this evaluator.
+		</summary>
+		<param name="callCount">The invocation call count to verify.</param>
+		<returns><c>true</c> if the specified call count meets the criterion; otherwise, <c>false</c>.</returns>
+	</doc>
+	<doc for="TimesEvaluator.GetExceptionMessage">
+		<summary>
+			Gets an exception message describing why the specified call count did not meet the
+            criterion represented by this evaluator. The standard message format is:
+            <c>"Expected invocation on the mock …, but was {callCount} times."</c>
+		</summary>
+		<param name="callCount">The call count for which to produce an exception message.</param>
+		<returns>
+			An exception message describing why the specified call count did not meet
+			the criterion represented by this evaluator.
+		</returns>
+	</doc>
+	<doc for="Times.Equals(TimesEvaluator)">
+		<summary>
+			Determines whether the specified <see cref="TimesEvaluator"/> is equal (by value) to this evaluator.
+		</summary>
+		<param name="other">The <see cref="TimesEvaluator"/> to compare with this evaluator.</param>
+		<returns><c>true</c> if the specified evaluator is equal to this evaluator; otherwise, <c>false</c>.</returns>
+	</doc>
+	<doc for="Times.Equals(object)">
+		<summary>
+			Determines whether the specified object is equal (by value) to this evaluator.
+		</summary>
+		<param name="obj">The object to compare with this evaluator.</param>
+		<returns><c>true</c> if the specified object is equal to this evaluator; otherwise, <c>false</c>.</returns>
+	</doc>
+	<doc for="Times.GetHashCode">
+		<summary>
+			Computes an an approximate hash based on this evaluator's runtime type.
+		</summary>
+		<returns>The type-based hash code for this evaluator.</returns>
+	</doc>
+</docs>


### PR DESCRIPTION
This is a response to #307. A new method `Times.Matching(TimesEvaluator)` is added that represents an extension point for custom invocation call count checks. To make this possible, a new abstract base class `TimesEvaluator` is introduced for which `Times` becomes a thin wrapper. (This is necessary to preserve the publicly visible surface of `Times`.)

### Why a new type `TimesEvaluator`? Why not `Func<int, bool>`? ### 

Implementing a delegate-based `Times.Matching(Func<int, bool>)` would be difficult for at least two reasons:

1. The private fields `from` and `to` cannot be assigned any sensible values when all we have is a delegate. There is no guarantee that some arbitrary `Func<int, bool>` represents / works with a continuous interval of the form [`callCountFrom`..`callCountTo`], so these two fields don't even make sense in the general case of `Times.Matching`. They are however (currently) needed for equality comparison.

2. Speaking of which, how can equality comparison be done with only a delegate at hand? Object reference equality is too imprecise, and invoking the delegate for all possible `int` values and comparing return values is way too inefficient.

One possible solution for the second problem would be to use an `Expression<Func<int, bool>>`, but this introduces some complexity and overhead that probably isn't warranted; and equality comparisons like `Exactly(1) == Once()` are hard to do; and expression trees & expression tree compilation might not be available on all of Moq's target platforms.

Thus I chose to define a new abstract base class `TimesEvaluator` with the following responsibilities: 

* verifying a call count against some arbitrary criterion,
* providing an exception message when the criterion isn't met,
* comparing the evaluator with another one by value (where possible).

### Example for a custom evaluator: ###

What @orenh1122 originally asked for in #307 could be implemented as follows:

```csharp
class MultipleOfTimesEvaluator : TimesEvaluator
{
    private int n;

    public MultipleOfTimesEvaluator(int n)
    {
        this.n = n;
    }

    public override bool Verify(int callCount)
        => callCount % this.n == 0;

    public override string GetExceptionMessage(int callCount)
        => $"Expected invocation on the mock a multiple of {this.n} times, " + 
           $"but was {callCount} times";

    public override bool Equals(TimesEvaluator other)
        => other is MultipleOfTimesEvaluator mo && this.n == mo.n:
}

…
var multipleOf5 = new MultipleOfTimesEvaluator(5);
var times = Times.Matching(multipleOf5);
```