### PR TITLE
Simplify logic in `ExpressionMatcher.Matches`

### DIFF
--- a/Source/Matchers/ExpressionMatcher.cs
+++ b/Source/Matchers/ExpressionMatcher.cs
@@ -58,13 +58,8 @@ namespace Moq.Matchers
 
 		public bool Matches(object value)
 		{
-			var valueExpression = value as Expression;
-			if (value == null)
-			{
-				return false;
-			}
-
-			return ExpressionComparer.Default.Equals(this.expression, valueExpression);
+			return value is Expression valueExpression
+				&& ExpressionComparer.Default.Equals(this.expression, valueExpression);
 		}
 	}
 }


### PR DESCRIPTION
This fixes #237.

The method's previous semantics are preserved, but note that it could be simplified to just:

```csharp
return ExpressionComparer.Default.Equals(this.expression, value as Expression);
//                                                        ^^^^^^^^^^^^^^^^^^^
```

Nothing in `ExpressionMatcher` ensures that `this.expression` cannot be `null`. Therefore, the `null` special case could (and for correctness, probably should) be left entirely up to `ExpressionComparer.Equals`.