### PR TITLE
Fix failing AppVeyor build

### DIFF
--- a/UnitTests/ReturnsExtensionsFixture.cs
+++ b/UnitTests/ReturnsExtensionsFixture.cs
@@ -432,12 +432,13 @@ namespace Moq.Tests
 
             Action setup = () =>
             {
+                var anyException = new Exception();
                 var minDelay = TimeSpan.FromMilliseconds(1);
                 var maxDelay = TimeSpan.FromMilliseconds(2);
 
                 mock
                     .Setup(x => x.RefParameterValueReturnType("test"))
-                    .ThrowsAsync(new InternalBufferOverflowException(), minDelay, maxDelay, null);
+                    .ThrowsAsync(anyException, minDelay, maxDelay, null);
             };
 
             var paramName = Assert.Throws<ArgumentNullException>(setup).ParamName;


### PR DESCRIPTION
One unit tests uses `System.IO.InternalBufferOverflowException` as a placeholder. This type does not exist in .NET Standard 1.3 (it looks like it will be reintroduced with .NET Standard 2.0 in the `System.IO.FileSystem.Watcher` package) and so the .NET Standard build fails. This unit test can be safely rewritten to use a different exception type.