### PR TITLE
Add `ThrowsAsync` overload for non-generic `Task`

### DIFF
--- a/Source/ReturnsExtensions.cs
+++ b/Source/ReturnsExtensions.cs
@@ -39,6 +39,20 @@ namespace Moq
         /// Specifies the exception to throw when the asynchronous method is invoked.
         /// </summary>
         /// <typeparam name="TMock">Mocked type.</typeparam>
+        /// <param name="mock">Returns verb which represents the mocked type and the task return type</param>
+        /// <param name="exception">Exception instance to throw.</param>
+        public static IReturnsResult<TMock> ThrowsAsync<TMock>(this IReturns<TMock, Task> mock, Exception exception) where TMock : class
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            tcs.SetException(exception);
+
+            return mock.Returns(tcs.Task);
+        }
+
+        /// <summary>
+        /// Specifies the exception to throw when the asynchronous method is invoked.
+        /// </summary>
+        /// <typeparam name="TMock">Mocked type.</typeparam>
         /// <typeparam name="TResult">Type of the return value.</typeparam>
         /// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
         /// <param name="exception">Exception instance to throw.</param>

--- a/UnitTests/ReturnsExtensionsFixture.cs
+++ b/UnitTests/ReturnsExtensionsFixture.cs
@@ -9,6 +9,8 @@ namespace Moq.Tests
     {
         public interface IAsyncInterface
         {
+            Task NoParametersNonGenericTaskReturnType();
+
             Task<string> NoParametersRefReturnType();
             
             Task<int> NoParametersValueReturnType();
@@ -190,6 +192,19 @@ namespace Moq.Tests
             string secondEvaluationResult = mock.Object.ValueParameterRefReturnType(36).Result;
 
             Assert.NotSame(firstEvaluationResult, secondEvaluationResult);
+        }
+
+        [Fact]
+        public void ThrowsAsync_on_NoParametersNonGenericTaskReturnType()
+        {
+            var mock = new Mock<IAsyncInterface>();
+            var exception = new InvalidOperationException();
+            mock.Setup(x => x.NoParametersNonGenericTaskReturnType()).ThrowsAsync(exception);
+
+            var task = mock.Object.NoParametersNonGenericTaskReturnType();
+
+            Assert.True(task.IsFaulted);
+            Assert.Equal(exception, task.Exception.InnerException);
         }
 
         [Fact]


### PR DESCRIPTION
This fixes #294.