### PR TITLE
Ensure default mock names are (more) unique

### DIFF
--- a/Source/Mock.Generic.cs
+++ b/Source/Mock.Generic.cs
@@ -46,6 +46,7 @@ using Moq.Language.Flow;
 using Moq.Proxy;
 using Moq.Language;
 using System.Reflection;
+using System.Threading;
 
 #if !NETCORE
 using System.CodeDom;
@@ -58,6 +59,7 @@ namespace Moq
     public partial class Mock<T> : Mock, IMock<T> where T : class
 	{
 		private static IProxyFactory proxyFactory = new CastleProxyFactory();
+		private static int serialNumberCounter = 0;
 		private T instance;
 		private object[] constructorArguments;
 
@@ -123,7 +125,7 @@ namespace Moq
 
 		private string GenerateMockName()
 		{
-			var randomId = Guid.NewGuid().ToString("N").Substring(0, 4);
+			var serialNumber = Interlocked.Increment(ref serialNumberCounter).ToString("x8");
 
 			var typeName = typeof (T).FullName;
 
@@ -138,7 +140,7 @@ namespace Moq
 			}
 #endif
 
-			return "Mock<" + typeName + ":" + randomId + ">";
+			return "Mock<" + typeName + ":" + serialNumber + ">";
 		}
 
 		private void CheckParameters()


### PR DESCRIPTION
Default mock object names are built from the type name and a hex  number. Instead of building that number from the first 4 digits of a GUID &mdash; a whole GUID is in practice unique, but the same does not hold true for only 4 of its digits &mdash;, create 8 unique (but non-random) hex digits in the simplest possible way: using a thread-safe ever-increasing counter.

It is still possible that the same number is used more than once, but this is now far less likely to happen in real-world scenarios: it would require the generation of more than 2<sup>32</sup> mock objects.

This fixes #348.