### PR TITLE
Make `It.IsAny`, `It.IsNotNull` work for COM types

### DIFF
--- a/Source/It.cs
+++ b/Source/It.cs
@@ -45,6 +45,9 @@ using System.Linq.Expressions;
 using System.Text.RegularExpressions;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+#if !NETCORE
+using static System.Runtime.InteropServices.Marshal;
+#endif
 
 namespace Moq
 {
@@ -55,7 +58,12 @@ namespace Moq
 		public static TValue IsAny<TValue>()
 		{
 			return Match<TValue>.Create(
+#if !NETCORE
+				value => value == null || (IsComObject(value) ? value is TValue
+				                                              : typeof(TValue).IsAssignableFrom(value.GetType())),
+#else
 				value => value == null || typeof(TValue).IsAssignableFrom(value.GetType()),
+#endif
 				() => It.IsAny<TValue>());
 		}
 
@@ -63,7 +71,12 @@ namespace Moq
 		public static TValue IsNotNull<TValue>()
 		{
 			return Match<TValue>.Create(
+#if !NETCORE
+				value => value != null && (IsComObject(value) ? value is TValue
+				                                              : typeof(TValue).IsAssignableFrom(value.GetType())),
+#else
 				value => value != null && typeof(TValue).IsAssignableFrom(value.GetType()),
+#endif
 				() => It.IsNotNull<TValue>());
 		}
 


### PR DESCRIPTION
This fixes #269:

Testing a COM object's type using `IsAssignableFrom` can report false negatives because .NET might only see the generic RCW type `__ComObject` instead of the actual COM interface type. The `is` operator on the other hand appears to be performing `QueryInterface` for COM objects to get the right result.

This commit introduces an additional branch in `It.IsAny<>` that runs an `is`-based check for COM objects, and the as-is reflection-based check for everything else. The added logic takes effect only in builds targeting the full .NET Framework, since COM is not available on all .NET Core platforms.

I have successfully verified the new behaviour against a COM object, but am reluctant to add any permanent test code involving COM to Moq. That would tie the unit test project to a Windows platform-specific facility. (It's possible to work around this by running a test conditionally, depending on the value of `Environment.OSVersion.Platform`, but that seems a little hacky.)