### PR TITLE
Fix equality check bug in ExpressionKey

### DIFF
--- a/Source/Interceptor.cs
+++ b/Source/Interceptor.cs
@@ -173,7 +173,9 @@ namespace Moq
 				var index = 0;
 				while (eq && index < this.values.Count)
 				{
-					eq &= this.values[index] == key.values[index];
+					// using `object.Equals` instead of == ensures that we get the correct
+					// comparison result for boxed value types:
+					eq &= object.Equals(this.values[index], key.values[index]);
 					index++;
 				}
 
@@ -182,20 +184,17 @@ namespace Moq
 
 			public override int GetHashCode()
 			{
-				unchecked
+				var hash = fixedString.GetHashCode();
+
+				foreach (var value in values)
 				{
-					var hash = fixedString.GetHashCode();
-
-					foreach (var value in values)
+					if (value != null)
 					{
-						if (value != null)
-						{
-							hash = (hash * 397) ^ value.GetHashCode();
-						}
+						hash = unchecked((hash * 397) ^ value.GetHashCode());
 					}
-
-					return hash;
 				}
+
+				return hash;
 			}
 		}
 

--- a/Source/Interceptor.cs
+++ b/Source/Interceptor.cs
@@ -170,15 +170,10 @@ namespace Moq
 
 				var eq = key.fixedString == this.fixedString && key.values.Count == this.values.Count;
 
-				//the code below is broken as it uses an OR when checking the arguments, this means that if any pair of arguments match 
-				//the result is a match.
-				//This is only going to hit some edge cases as for the most part the fixed string above spots arguments correctly.
-				//Fixing this really needs a reworking of the GetHashCode, and also some sorting out of how to compare value types that have been
-				//boxed correctly (another problem this code has)
 				var index = 0;
 				while (eq && index < this.values.Count)
 				{
-					eq |= this.values[index] == key.values[index];
+					eq &= this.values[index] == key.values[index];
 					index++;
 				}
 
@@ -187,22 +182,20 @@ namespace Moq
 
 			public override int GetHashCode()
 			{
-				var hash = fixedString.GetHashCode();
-
-				var factor = 1;
-				foreach (var value in values)
+				unchecked
 				{
-					if (value != null)
-					{
-						// we use a factor that increases with each following value (argument)
-						// so that if the values are in a different order, we get a different hash code
-						// see GitHub issue #252
-						hash ^= value.GetHashCode() / factor;
-					}
-					factor *= 3;
-				}
+					var hash = fixedString.GetHashCode();
 
-				return hash;
+					foreach (var value in values)
+					{
+						if (value != null)
+						{
+							hash = (hash * 397) ^ value.GetHashCode();
+						}
+					}
+
+					return hash;
+				}
 			}
 		}
 

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -381,8 +381,11 @@ namespace Moq.Tests.Regressions
 				aMock.Setup(m => m.Foo(i1, i2));
 				aMock.Setup(m => m.Foo(i2, i1));
 
-				Assert.DoesNotThrow(() => aMock.Object.Foo(i1, i2));
-				Assert.DoesNotThrow(() => aMock.Object.Foo(i2, i1));
+				aMock.Object.Foo(i1, i2);
+				aMock.Object.Foo(i2, i1);
+
+				aMock.Verify(m => m.Foo(i1, i2), Times.Once());
+				aMock.Verify(m => m.Foo(i2, i1), Times.Once());
 			}
 		}
 

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -391,6 +391,93 @@ namespace Moq.Tests.Regressions
 
 		#endregion // #135
 
+		#region 328
+
+		public class Issue328
+		{
+			public struct BadlyHashed<T> : IEquatable<BadlyHashed<T>>
+			{
+				public static implicit operator BadlyHashed<T>(T value)
+				{
+					return new BadlyHashed<T>(value);
+				}
+
+				private T value;
+
+				public BadlyHashed(T value)
+				{
+					this.value = value;
+				}
+
+				public bool Equals(BadlyHashed<T> other)
+				{
+					return this.value.Equals(other.value);
+				}
+
+				public override bool Equals(object obj)
+				{
+					return obj is BadlyHashed<T> other && this.Equals(other);
+				}
+
+				public override int GetHashCode()
+				{
+					// This is legal: Equal objects must have equal hashcodes,
+					// but objects with equal hashcodes are not necessarily equal.
+					// We are essentially rendering GetHashCode useless for equality
+					// comparison, so whoever compares instances of this type will
+					// (or should!) end up using the more precise Equals.
+					return 0;
+				}
+			}
+
+			[Fact]
+			public void Two_BadlyHashed_instances_with_equal_values_are_equal()
+			{
+				BadlyHashed<string> a1 = "a", a2 = "a";
+				Assert.Equal(a1, a2);
+				Assert.Equal(a2, a1);
+			}
+
+			[Fact]
+			public void Two_BadlyHashed_instances_with_nonequal_values_are_not_equal()
+			{
+				BadlyHashed<string> a = "a", b = "b";
+				Assert.NotEqual(a, b);
+				Assert.NotEqual(b, a);
+			}
+
+			public interface IMockableService
+			{
+				void Use(BadlyHashed<string> wrappedString);
+			}
+
+			[Fact]
+			public void Strict_mock_expecting_calls_with_nonequal_BadlyHashed_values_should_verify_when_called_properly()
+			{
+				// The above test has already established that `a` and `b` are not equal.
+				BadlyHashed<string> a = "a", b = "b";
+
+				// We are setting up two calls in Strict mode, i.e. both calls must happen.
+				var mock = new Mock<IMockableService>(MockBehavior.Strict);
+				{
+					mock.Setup(service => service.Use(a));
+					mock.Setup(service => service.Use(b));
+				}
+
+				// And they do happen!
+				{
+					var service = mock.Object;
+					service.Use(a);
+					service.Use(b);
+				}
+
+				// So the following verification should succeed.
+				mock.VerifyAll();
+			}
+		}
+
+		#endregion // #328
+
 		// Old @ Google Code
 
 		#region #47

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -356,6 +356,38 @@ namespace Moq.Tests.Regressions
 
 		#endregion 311
 
+		#region #135
+
+		public class Issue135
+		{
+			public interface IDoer
+			{
+				void Foo(Item x, Item y);
+			}
+
+			public class Item
+			{
+				public int Id { get; set; }
+			}
+
+			[Fact]
+			public void strict_mock_differenciates_multiple_setups_with_same_arguments_in_different_order()
+			{
+				var aMock = new Mock<IDoer>(MockBehavior.Strict);
+
+				var i1 = new Item { Id = 1 };
+				var i2 = new Item { Id = 2 };
+
+				aMock.Setup(m => m.Foo(i1, i2));
+				aMock.Setup(m => m.Foo(i2, i1));
+
+				Assert.DoesNotThrow(() => aMock.Object.Foo(i1, i2));
+				Assert.DoesNotThrow(() => aMock.Object.Foo(i2, i1));
+			}
+		}
+
+		#endregion // #135
+
 		// Old @ Google Code
 
 		#region #47


### PR DESCRIPTION
This PR is a cleaned-up version of #134. It fixes the buggy `Equals` and `GetHashCode` implementations in `Interceptor.ExpressionKey`. 

This closes #135, and closes #328. 