### PR TITLE
Make event accessor recognition logic more correct

### DIFF
--- a/Source/MemberInfoExtensions.cs
+++ b/Source/MemberInfoExtensions.cs
@@ -61,12 +61,12 @@ namespace Moq
 		}
 
 
-		public static bool IsEventAttach(this MethodBase method)
+		public static bool LooksLikeEventAttach(this MethodBase method)
 		{
 			return method.Name.StartsWith("add_", StringComparison.Ordinal);
 		}
 
-		public static bool IsEventDetach(this MethodBase method)
+		public static bool LooksLikeEventDetach(this MethodBase method)
 		{
 			return method.Name.StartsWith("remove_", StringComparison.Ordinal);
 		}

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -170,6 +170,44 @@ namespace Moq.Tests.Regressions
 #endif
 		#endregion
 
+		#region 82
+
+		public class Issue82
+		{
+			public interface ILogger
+			{
+				event Action info;
+				void add_info(string info);
+				void Add_info(string info);
+				void remove_info(string info);
+				void Remove_info(string info);
+			}
+
+			[Fact]
+			public void MethodWithAddUnderscoreNamePrefixDoesNotGetMisrecognizedAsEventAccessor()
+			{
+				var mock = new Mock<ILogger>();
+				mock.Setup(x => x.add_info(It.IsAny<string>()));
+				mock.Setup(x => x.Add_info(It.IsAny<string>()));
+
+				mock.Object.add_info(string.Empty);
+				mock.Object.Add_info(string.Empty);
+			}
+
+			[Fact]
+			public void MethodWithRemoveUnderscoreNamePrefixDoesNotGetMisrecognizedAsEventAccessor()
+			{
+				var mock = new Mock<ILogger>();
+				mock.Setup(x => x.remove_info(It.IsAny<string>()));
+				mock.Setup(x => x.Remove_info(It.IsAny<string>()));
+
+				mock.Object.remove_info(string.Empty);
+				mock.Object.Remove_info(string.Empty);
+			}
+		}
+
+		#endregion
+
 		#region 163
 
 #if !NETCORE


### PR DESCRIPTION
Up until now, if Moq encounters a method named `add_X` or `remove_X` it will assume that it's found an specialname event accessor method without performing any further checks.

This commits adds some trivial type checks and null reference checks to improve that logic somewhat. I hesitate to make this too perfect since that just might break things for F# or COM (see commit 44070a9).

This partially fixes #82.