### PR TITLE
Fix `Moq.nuspec` and package references

### DIFF
--- a/Moq.nuspec
+++ b/Moq.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
 	<metadata>
 		<id>Moq</id>
-		<version>4.6</version>
+		<version>4.7</version>
 		<title>Moq: an enjoyable mocking library</title>
 		<authors>Daniel Cazzulino, kzu</authors>
 		<owners>Daniel Cazzulino, Clarius Labs, kzu</owners>
@@ -176,30 +176,12 @@ Version 1.0
 		</releaseNotes>
 		<dependencies>
 			<group targetFramework=".NETFramework4.5">
-				<dependency id="Castle.Core" version="4.0.0" />
+				<dependency id="Castle.Core" version="4.1.0" />
 			</group>
 			<group targetFramework=".NETStandard1.3">
-				<dependency id="Castle.Core" version="4.0.0" />
-				<dependency id="System.Collections" version="4.0.11" />
-				<dependency id="System.Collections.Concurrent" version="4.0.12" />
-				<dependency id="System.Diagnostics.Debug" version="4.0.11" />
-				<dependency id="System.Diagnostics.Tools" version="4.0.1" />
-				<dependency id="System.Globalization" version="4.0.11" />
-				<dependency id="System.Linq" version="4.1.0" />
-				<dependency id="System.Linq.Expressions" version="4.1.0" />
-				<dependency id="System.Linq.Queryable" version="4.0.1" />
-				<dependency id="System.Reflection" version="4.1.0" />
-				<dependency id="System.Reflection.Emit" version="4.0.1" />
-				<dependency id="System.Reflection.Emit.ILGeneration" version="4.0.1" />
-				<dependency id="System.Reflection.Extensions" version="4.0.1" />
-				<dependency id="System.Reflection.Primitives" version="4.0.1" />
-				<dependency id="System.Reflection.TypeExtensions" version="4.1.0" />
-				<dependency id="System.Resources.ResourceManager" version="4.0.1" />
-				<dependency id="System.Runtime" version="4.1.0" />
-				<dependency id="System.Runtime.Extensions" version="4.1.0" />
-				<dependency id="System.Text.RegularExpressions" version="4.1.0" />
-				<dependency id="System.Threading" version="4.0.11" />
-				<dependency id="System.Threading.Tasks" version="4.0.11" />
+				<dependency id="NETStandard.Library" version="1.6.1" />
+				<dependency id="System.Linq.Queryable" version="4.3.0" />
+				<dependency id="Castle.Core" version="4.1.0" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/Source/Moq.NetCore.csproj
+++ b/Source/Moq.NetCore.csproj
@@ -27,12 +27,7 @@
 		<PackageReference Include="Castle.Core" Version="4.1.0" />
 		<PackageReference Include="IFluentInterface" Version="2.0.0" />
 		<PackageReference Include="GitInfo" Version="1.1.14" />
-		<PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
-		<PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
 		<PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
-		<PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
-		<PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
-		<PackageReference Include="System.Reflection.TypeExtensions" Version="4.3.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This is an amendment to 77db8c88fd8f1b075ddbed0b5baec93fa67a18f3 and e67faa9fddc85037e91e96c36f96ba7000e77dfd, which updated `System.*` package references to versions 4.3.0 and Castle.Core to version 4.1.0 but forgot to adjust the version numbers in `Moq.nuspec`.

It seems that `Moq.nuspec` is currently referencing many more packages than it needs to (most are added indirectly via `NETStandard.Library`). Remove superfluous references.