### PR TITLE
Fix formatting inconsistencies for array values in MockException.Message

### DIFF
--- a/Source/ExpressionStringBuilder.cs
+++ b/Source/ExpressionStringBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -256,6 +257,29 @@ namespace Moq
 				if (value is string)
 				{
 					builder.Append("\"").Append(value).Append("\"");
+				}
+				else if (value is IEnumerable enumerable)
+				{
+					builder.Append("[");
+					bool addComma = false;
+					const int maxCount = 10;
+					int count = 0;
+					foreach (var obj in enumerable.Cast<object>())
+					{
+						if (addComma)
+						{
+							builder.Append(", ");
+						}
+						if (count >= maxCount)
+						{
+							builder.Append("...");
+							break;
+						}
+						ToStringConstant(Expression.Constant(obj));
+						addComma = true;
+						++count;
+					}
+					builder.Append("]");
 				}
 				else if (value.ToString() == value.GetType().ToString())
 				{

--- a/Source/Extensions.cs
+++ b/Source/Extensions.cs
@@ -89,9 +89,12 @@ namespace Moq
 			{
 				return "\"" + typedValue + "\"";
 			}
-			if (value is IEnumerable)
+			if (value is IEnumerable enumerable)
 			{
-				return "[" + string.Join(", ", ((IEnumerable) value).OfType<object>().Select(GetValue)) + "]";
+				const int maxCount = 10;
+				var objs = enumerable.Cast<object>().Take(maxCount + 1);
+				var more = objs.Count() > maxCount ? ", ..." : string.Empty;
+				return "[" + string.Join(", ", objs.Take(maxCount).Select(GetValue)) + more + "]";
 			}
 			return value.ToString();
 		}

--- a/UnitTests/VerifyFixture.cs
+++ b/UnitTests/VerifyFixture.cs
@@ -911,6 +911,75 @@ namespace Moq.Tests
 			mock.Verify(foo => foo.Call(It.IsAny<IBazParam>()), Times.Exactly(2));
 		}
 
+		[Fact]
+		public void NullArrayValuesForActualInvocationArePrintedAsNullInMockExeptionMessage()
+		{
+			var strings = new string[] { "1", null, "3" };
+			var mock = new Mock<IArrays>();
+			mock.Object.Method(strings);
+			var mex = Assert.Throws<MockException>(() => mock.Verify(_ => _.Method(null)));
+			Assert.Contains(
+				@"Performed invocations:" + Environment.NewLine +
+				@"IArrays.Method([""1"", null, ""3""])",
+				mex.Message);
+		}
+
+		[Fact]
+		public void LargeEnumerablesInActualInvocationAreNotCutOffFor10Elements()
+		{
+			var strings = new string[] { "1", null, "3", "4", "5", "6", "7", "8", "9", "10" };
+			var mock = new Mock<IArrays>();
+			mock.Object.Method(strings);
+			var mex = Assert.Throws<MockException>(() => mock.Verify(_ => _.Method(null)));
+			Assert.Contains(
+				@"Performed invocations:" + Environment.NewLine +
+				@"IArrays.Method([""1"", null, ""3"", ""4"", ""5"", ""6"", ""7"", ""8"", ""9"", ""10""])",
+				mex.Message);
+		}
+
+		[Fact]
+		public void LargeEnumerablesInActualInvocationAreCutOffAfter10Elements()
+		{
+			var strings = new string[] { "1", null, "3", "4", "5", "6", "7", "8", "9", "10", "11" };
+			var mock = new Mock<IArrays>();
+			mock.Object.Method(strings);
+			var mex = Assert.Throws<MockException>(() => mock.Verify(_ => _.Method(null)));
+			Assert.Contains(
+				@"Performed invocations:" + Environment.NewLine +
+				@"IArrays.Method([""1"", null, ""3"", ""4"", ""5"", ""6"", ""7"", ""8"", ""9"", ""10"", ...])",
+				mex.Message);
+		}
+
+		[Fact]
+		public void NullArrayValuesForExpectedInvocationArePrintedAsNullInMockExeptionMessage()
+		{
+			var strings = new string[] { "1", null, "3" };
+			var mock = new Mock<IArrays>();
+			mock.Object.Method(null);
+			var mex = Assert.Throws<MockException>(() => mock.Verify(_ => _.Method(strings)));
+			Assert.Contains(@"Expected invocation on the mock at least once, but was never performed: _ => _.Method([""1"", null, ""3""])", mex.Message);
+		}
+
+		[Fact]
+		public void LargeEnumerablesInExpectedInvocationAreNotCutOffFor10Elements()
+		{
+			var strings = new string[] { "1", null, "3", "4", "5", "6", "7", "8", "9", "10" };
+			var mock = new Mock<IArrays>();
+			mock.Object.Method(null);
+			var mex = Assert.Throws<MockException>(() => mock.Verify(_ => _.Method(strings)));
+			Assert.Contains(@"Expected invocation on the mock at least once, but was never performed: _ => _.Method([""1"", null, ""3"", ""4"", ""5"", ""6"", ""7"", ""8"", ""9"", ""10""])", mex.Message);
+		}
+
+		[Fact]
+		public void LargeEnumerablesInExpectedInvocationAreCutOffAfter10Elements()
+		{
+			var strings = new string[] { "1", null, "3", "4", "5", "6", "7", "8", "9", "10", "11" };
+			var mock = new Mock<IArrays>();
+			mock.Object.Method(null);
+			var mex = Assert.Throws<MockException>(() => mock.Verify(_ => _.Method(strings)));
+			Assert.Contains(@"Expected invocation on the mock at least once, but was never performed: _ => _.Method([""1"", null, ""3"", ""4"", ""5"", ""6"", ""7"", ""8"", ""9"", ""10"", ...])", mex.Message);
+		}
+
 		/// <summary>
 		/// Warning, this is a flaky test and doesn't fail when run as standalone. Running all tests at once will increase the chances of that test to fail.
 		/// </summary>
@@ -957,6 +1026,11 @@ namespace Moq.Tests
 
 		public class BazParam2:BazParam
 		{
+		}
+
+		public interface IArrays
+		{
+			void Method(string[] strings);
 		}
 	}
 }


### PR DESCRIPTION
This fixes #321.

Two inconsistencies have been reported in how arrays and arrays containing null references are reported in the "expected invocation" and "performed invocations" part of a `MockException` message:

 1. In "expected invocation", arrays are completely omitted in the message.

 2. In "performed invocations", null references are omitted in an array value dump.

This commit fixes both issues, and additionally ensures that in case of non-terminating or long sequences, only the first 10 elements are printed and the rest gets abbreviated as `", ..."`.