### PR TITLE
Fix mocking of redeclared interface methods

### DIFF
--- a/Source/Extensions.cs
+++ b/Source/Extensions.cs
@@ -40,6 +40,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
@@ -321,6 +322,56 @@ namespace Moq
 			catch (AmbiguousMatchException)
 			{
 				return null;
+			}
+		}
+
+		/// <summary>
+		/// Gets all properties of the specified type in depth-first order.
+		/// That is, properties of the furthest ancestors are returned first,
+		/// and the type's own properties are returned last.
+		/// </summary>
+		/// <param name="type">The type whose properties are to be returned.</param>
+		internal static List<PropertyInfo> GetAllPropertiesInDepthFirstOrder(this Type type)
+		{
+			var properties = new List<PropertyInfo>();
+			var none = new HashSet<Type>();
+
+			type.AddPropertiesInDepthFirstOrderTo(properties, typesAlreadyVisited: none);
+
+			return properties;
+		}
+
+		/// <summary>
+		/// This is a helper method supporting <see cref="GetAllPropertiesInDepthFirstOrder(Type)"/>
+		/// and is not supposed to be called directly.
+		/// </summary>
+		private static void AddPropertiesInDepthFirstOrderTo(this Type type, List<PropertyInfo> properties, HashSet<Type> typesAlreadyVisited)
+		{
+			if (!typesAlreadyVisited.Contains(type))
+			{
+				// make sure we do not process properties of the current type twice:
+				typesAlreadyVisited.Add(type);
+
+				//// follow down axis 1: add properties of base class. note that this is currently
+				//// disabled, since it wasn't done previously and this can only result in changed
+				//// behavior.
+				//if (type.GetTypeInfo().BaseType != null)
+				//{
+				//	type.GetTypeInfo().BaseType.AddPropertiesInDepthFirstOrderTo(properties, typesAlreadyVisited);
+				//}
+
+				// follow down axis 2: add properties of inherited / implemented interfaces:
+				var superInterfaceTypes = type.GetInterfaces();
+				foreach (var superInterfaceType in superInterfaceTypes)
+				{
+					superInterfaceType.AddPropertiesInDepthFirstOrderTo(properties, typesAlreadyVisited);
+				}
+
+				// add own properties:
+				foreach (var property in type.GetProperties())
+				{
+					properties.Add(property);
+				}
 			}
 		}
 	}

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -299,6 +299,31 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 162
+
+		public class Issue162
+		{
+			[Fact]
+			public void GetSetPropertyThatOverridesGetPropertyRetainsValueSetUpWithMockOf()
+			{
+				const decimal expectedValue = .14M;
+				var i = Mock.Of<B>(b => b.Value == expectedValue);
+				Assert.Equal(expectedValue, actual: i.Value);
+			}
+
+			public interface A
+			{
+				decimal? Value { get; }
+			}
+
+			public interface B : A
+			{
+				new decimal? Value { get; set; }
+			}
+		}
+
+		#endregion
+
 		#region 163
 
 #if FEATURE_SERIALIZATION
@@ -696,6 +721,50 @@ namespace Moq.Tests.Regressions
 
 		#endregion // #184
 
+		#region 239
+
+		public class Issue239
+		{
+			[Fact]
+			public void PropertyInBaseInterfaceRetainsValueSetUpWitMockOf()
+			{
+				var i1 = Mock.Of<Interface1>(i => i.ABoolean == true);
+				Assert.True(i1.ABoolean);
+			}
+			[Fact]
+			public void RedeclaredPropertyInDerivedInterfaceRetainsValueSetUpWithNewMockAndSetupReturns()
+			{
+				var i2 = new Mock<Interface2>();
+				i2.Setup(i => i.ABoolean).Returns(true);
+				Assert.True(i2.Object.ABoolean);
+			}
+			[Fact]
+			public void RedeclaredPropertyInDerivedInterfaceRetainsValueSetUpWithMockOf()
+			{
+				var i2 = Mock.Of<Interface2>(i => i.ABoolean == true);
+				Assert.True(i2.ABoolean);
+			}
+			[Fact]
+			public void RedeclaredPropertyInDerivedInterfaceRetainsValueSetUpWitSetupAllPropertiesAndSetter()
+			{
+				var i2 = new Mock<Interface2>();
+				i2.SetupAllProperties();
+				i2.Object.ABoolean = true;
+				Assert.True(i2.Object.ABoolean);
+			}
+
+			public interface Interface1
+			{
+				bool ABoolean { get; }
+			}
+			public interface Interface2 : Interface1
+			{
+				new bool ABoolean { get; set; }
+			}
+		}
+
+		#endregion
+
 		#region #252
 
 		public class Issue252
@@ -749,6 +818,87 @@ namespace Moq.Tests.Regressions
 		}
 
 		#endregion // #252
+
+		#region 275
+
+		public class Issue275
+		{
+			private const int EXPECTED = int.MaxValue;
+
+			[Fact]
+			public void Root1Test()
+			{
+				var mock = Mock.Of<IRoot1>(c => c.Value == EXPECTED);
+				Assert.Equal(EXPECTED, mock.Value);
+			}
+
+			[Fact]
+			public void Derived1Test()
+			{
+				var mock = Mock.Of<IDerived1>(c => c.Value == EXPECTED);
+				Assert.Equal(EXPECTED, mock.Value);
+			}
+
+			[Fact]
+			public void Implementation1Test()
+			{
+				var mock = Mock.Of<Implementation1>(c => c.Value == EXPECTED);
+				Assert.Equal(EXPECTED, mock.Value);
+			}
+
+			[Fact]
+			public void Root2Test()
+			{
+				var mock = Mock.Of<IRoot2>(c => c.Value == EXPECTED);
+				Assert.Equal(EXPECTED, mock.Value);
+			}
+
+			[Fact]
+			public void Derived2Test()
+			{
+				var mock = Mock.Of<IDerived2>(c => c.Value == EXPECTED);
+				Assert.Equal(EXPECTED, mock.Value);
+			}
+
+			[Fact]
+			public void Implementation2Test()
+			{
+				var mock = Mock.Of<Implementation2>(c => c.Value == EXPECTED);
+				Assert.Equal(EXPECTED, mock.Value);
+			}
+
+			public interface IRoot1
+			{
+				int Value { get; }
+			}
+
+			public interface IRoot2
+			{
+				int Value { get; set; }
+			}
+
+			public interface IDerived1 : IRoot1
+			{
+				new int Value { get; set; }
+			}
+
+			public interface IDerived2 : IRoot2
+			{
+				new int Value { get; set; }
+			}
+
+			public class Implementation1 : IDerived1
+			{
+				public int Value { get; set; }
+			}
+
+			public class Implementation2 : IDerived1
+			{
+				public int Value { get; set; }
+			}
+		}
+
+		#endregion
 
 		#region 311
 


### PR DESCRIPTION
PR #137 (commit 97a0f14) fixed a regression by changing the behavior of `mock.SetupAllProperties` so that read-only properties could be mocked, too. At the same time, it broke the frequent use case where a read-only property in a base interface is redeclared as a read-write property in a derived interface. Those redeclared properties would no longer be mocked correctly.

This commit reenables that scenario simply by changing the order in which properties are set up: properties in base interfaces (i.e. those furthest down the ancestor line) get set up before properties in more derived interfaces (i.e. those closer to the mocked type).

This fixes #162, #239, and #275.