### PR TITLE
Ensure that `null` never matches `It.IsRegex`

### DIFF
--- a/Source/It.cs
+++ b/Source/It.cs
@@ -138,21 +138,25 @@ namespace Moq
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsRegex(regex)"]/*'/>
 		public static string IsRegex(string regex)
 		{
+			Guard.NotNull(() => regex, regex);
+
 			// The regex is constructed only once.
 			var re = new Regex(regex);
 
 			// But evaluated every time :)
-			return Match<string>.Create(value => re.IsMatch(value), () => It.IsRegex(regex));
+			return Match<string>.Create(value => value != null && re.IsMatch(value), () => It.IsRegex(regex));
 		}
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsRegex(regex,options)"]/*'/>
 		public static string IsRegex(string regex, RegexOptions options)
 		{
+			Guard.NotNull(() => regex, regex);
+
 			// The regex is constructed only once.
 			var re = new Regex(regex, options);
 
 			// But evaluated every time :)
-			return Match<string>.Create(value => re.IsMatch(value), () => It.IsRegex(regex, options));
+			return Match<string>.Create(value => value != null && re.IsMatch(value), () => It.IsRegex(regex, options));
 		}
 	}
 }

--- a/UnitTests/MatchersFixture.cs
+++ b/UnitTests/MatchersFixture.cs
@@ -184,6 +184,34 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public void RegexMustNotBeNull()
+		{
+			Assert.Throws<ArgumentNullException>(() => It.IsRegex(null));
+		}
+
+		[Fact]
+		public void RegexMustNotBeNullWithOptions()
+		{
+			Assert.Throws<ArgumentNullException>(() => It.IsRegex(null, RegexOptions.None));
+		}
+
+		[Fact]
+		public void NullNeverMatchesRegex()
+		{
+			var mock = new Mock<IFoo>();
+			mock.Setup(foo => foo.Execute(It.IsRegex(".*"))).Returns("foo");
+			Assert.NotEqual("foo", mock.Object.Execute(null));
+		}
+
+		[Fact]
+		public void NullNeverMatchesRegexWithOptions()
+		{
+			var mock = new Mock<IFoo>();
+			mock.Setup(foo => foo.Execute(It.IsRegex(".*", RegexOptions.None))).Returns("foo");
+			Assert.NotEqual("foo", mock.Object.Execute(null));
+		}
+
+		[Fact]
 		public void MatchesEvenNumbersWithLambdaMatching()
 		{
 			var mock = new Mock<IFoo>();


### PR DESCRIPTION
Currently, matching `null` against any `It.IsRegex` placeholder will result in an `ArgumentNullException` being thrown by the framework. This is unintuitive.

This changes Moq behavior so that `null` will simply never match any `It.IsRegex`.

This fixes #266.