### PR TITLE
Fix mocking of non-virtual methods via interface

### DIFF
--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -1148,6 +1148,44 @@ namespace Moq.Tests.Regressions
 
 #endregion
 
+		#region 383
+
+		public class Issue383
+		{
+			[Fact]
+			public void AsInterface_CanSetupMethodOfInterfaceThatClassDoesNotImplement()
+			{
+				var mock = new Mock<DoesNotImplementI>();
+				mock.As<I>().Setup(x => x.Foo()).Returns(42);
+				Assert.Equal(42, (mock.Object as I).Foo());
+			}
+
+			[Fact]
+			public void AsInterface_CanSetupMethodOfInterfaceThatClassImplementsAsNonVirtual()
+			{
+				var mock = new Mock<ImplementsI>();
+				mock.As<I>().Setup(x => x.Foo()).Returns(42);
+				Assert.Equal(42, (mock.Object as I).Foo());
+			}
+
+			public class DoesNotImplementI
+			{
+				public int Foo() => 13;
+			}
+
+			public interface I
+			{
+				int Foo();
+			}
+
+			public class ImplementsI : I
+			{
+				public int Foo() => 13;
+			}
+		}
+
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47


### PR DESCRIPTION
PR #381 (specifically, commit 0e3eaf3) broke the ability of mocking a non-virtual method if it is set up and called via an interface (`mock.As<TInterface>()`). This commit restores that feature.

This should fix #383.