### PR TITLE
Mock.Of<T>(MockBehavior)

### DIFF
--- a/Source/Linq/Mock.cs
+++ b/Source/Linq/Mock.cs
@@ -63,6 +63,17 @@ namespace Moq
 		/// <summary>
 		/// Creates an mock object of the indicated type.
 		/// </summary>
+		/// <typeparam name="T">The type of the mocked object.</typeparam>
+		/// <param name="behavior">Behavior of the mock.</param>
+		/// <returns>The mocked object created.</returns>
+		public static T Of<T>(MockBehavior behavior) where T : class
+		{
+			return new Mock<T>(behavior).Object;
+		}
+
+		/// <summary>
+		/// Creates an mock object of the indicated type.
+		/// </summary>
 		/// <param name="predicate">The predicate with the specification of how the mocked object should behave.</param>
 		/// <typeparam name="T">The type of the mocked object.</typeparam>
 		/// <returns>The mocked object created.</returns>

--- a/UnitTests/Linq/BehaviorFixture.cs
+++ b/UnitTests/Linq/BehaviorFixture.cs
@@ -1,0 +1,71 @@
+﻿namespace Moq.Tests.Linq
+{
+	using Xunit;
+
+	public class BehaviorFixture
+	{
+		[Fact]
+		public void NoQuery_Default()
+		{
+			var target = Mock.Of<IFoo>();
+			Assert.Equal(MockBehavior.Default, Mock.Get(target).Behavior);
+			Assert.False(target.BoolProperty1);
+		}
+
+		[Fact]
+		public void WithQuery_Default()
+		{
+			var target = Mock.Of<IFoo>(x => x.BoolProperty1 == true);
+			Assert.Equal(MockBehavior.Default, Mock.Get(target).Behavior);
+			Assert.True(target.BoolProperty1);
+		}
+
+		[Fact]
+		public void NoQuery_Strict()
+		{
+			var target = Mock.Of<IFoo>(MockBehavior.Strict);
+			Assert.Equal(MockBehavior.Strict, Mock.Get(target).Behavior);
+			var mex = Assert.Throws<MockException>(() => target.BoolProperty1);
+			Assert.Equal(MockException.ExceptionReason.NoSetup, mex.Reason);
+		}
+
+		[Fact]
+		public void NoQuery_Loose()
+		{
+			var target = Mock.Of<IFoo>(MockBehavior.Loose);
+			Assert.Equal(MockBehavior.Loose, Mock.Get(target).Behavior);
+			Assert.False(target.BoolProperty1);
+		}
+
+		[Fact]
+		public void NoQuery_ThrowsWhenStrict()
+		{
+			var target = Mock.Of<IFoo>(MockBehavior.Strict);
+			var mex = Assert.Throws<MockException>(() => target.BoolProperty1);
+			Assert.Equal(MockException.ExceptionReason.NoSetup, mex.Reason);
+
+			mex = Assert.Throws<MockException>(() => target.BoolMethod());
+			Assert.Equal(MockException.ExceptionReason.NoSetup, mex.Reason);
+		}
+
+		[Fact]
+		public void NoQuery_DoesNotThrowWhenLoose()
+		{
+			var target = Mock.Of<IFoo>(MockBehavior.Loose);
+			Assert.Equal(false, target.BoolProperty1);
+			Assert.Equal(false, target.BoolProperty2);
+			Assert.Equal(false, target.BoolMethod());
+
+			// Just checking that calling the void method does not throw.
+			target.VoidMethod();
+		}
+
+		public interface IFoo
+		{
+			bool BoolProperty1 { get; set; }
+			bool BoolProperty2 { get; set; }
+			bool BoolMethod();
+			void VoidMethod();
+		}
+	}
+}

--- a/UnitTests/Moq.Tests.csproj
+++ b/UnitTests/Moq.Tests.csproj
@@ -64,6 +64,7 @@
 		<Compile Include="Linq\MockRepositoryQuerying.cs" />
 		<Compile Include="MockedDelegatesFixture.cs" />
 		<Compile Include="MockSequenceFixture.cs" />
+		<Compile Include="Linq\BehaviorFixture.cs" />
 		<Compile Include="Linq\SupportedQuerying.cs" />
 		<Compile Include="Linq\UnsupportedQuerying.cs" />
 		<Compile Include="PropertiesFixture.cs" />


### PR DESCRIPTION
Enable specifying mock behavior when using Mock.Of<T>(MockBehavior behavior)