### PR TITLE
Add NeutralResourcesLanguage to Assembly info for portable library use

### DIFF
--- a/Source/Properties/AssemblyInfo.cs
+++ b/Source/Properties/AssemblyInfo.cs
@@ -27,6 +27,7 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2,PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7")]
 
 [assembly: CLSCompliant(true)]
+[assembly: NeutralResourcesLanguage("en-US")]
 
 /// <group name="overview" title="Overview" order="0" />
 /// <group name="setups" title="Specifying setups" order="1" />


### PR DESCRIPTION
This is to remove the following build warning when used in a UWP app.

Moq.dll : warning MSB3817: The assembly "...nuget\packages\Moq\4.7.63\lib\netstandard1.3\Moq.dll" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).