### PR TITLE
Make abstract events defined in classes work even when `CallBase` is true

### DIFF
--- a/Source/InterceptorStrategies.cs
+++ b/Source/InterceptorStrategies.cs
@@ -271,7 +271,8 @@ namespace Moq
 						// TODO: We could compare `invocation.Method` and `eventInfo.GetAddMethod()` here.
 						// If they are equal, then `invocation.Method` is definitely an event `add` accessor.
 						// Not sure whether this would work with F# and COM; see commit 44070a9.
-						if (ctx.Mock.CallBase && !eventInfo.DeclaringType.GetTypeInfo().IsInterface)
+
+						if (ctx.Mock.CallBase && !invocation.Method.IsAbstract)
 						{
 							invocation.InvokeBase();
 							return InterceptionAction.Stop;
@@ -294,7 +295,8 @@ namespace Moq
 						// TODO: We could compare `invocation.Method` and `eventInfo.GetRemoveMethod()` here.
 						// If they are equal, then `invocation.Method` is definitely an event `remove` accessor.
 						// Not sure whether this would work with F# and COM; see commit 44070a9.
-						if (ctx.Mock.CallBase && !eventInfo.DeclaringType.GetTypeInfo().IsInterface)
+
+						if (ctx.Mock.CallBase && !invocation.Method.IsAbstract)
 						{
 							invocation.InvokeBase();
 							return InterceptionAction.Stop;

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -900,6 +900,33 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 296
+
+		public class Issue296
+		{
+			[Fact]
+			public void Can_subscribe_to_and_raise_abstract_class_event_when_CallBase_true()
+			{
+				var mock = new Mock<Foo>() { CallBase = true };
+
+				var eventHandlerWasCalled = false;
+				mock.Object.SomethingChanged += (object sender, EventArgs e) =>
+				{
+					eventHandlerWasCalled = true;
+				};
+
+				mock.Raise(foo => foo.SomethingChanged += null, EventArgs.Empty);
+				Assert.True(eventHandlerWasCalled);
+			}
+
+			public abstract class Foo
+			{
+				public abstract event EventHandler SomethingChanged;
+			}
+		}
+
+		#endregion
+
 		#region 311
 
 		public sealed class Issue311


### PR DESCRIPTION
Moq does not currently mock an abstract event defined in a class correctly when a mock's `CallBase` is set to true. It will try to invoke the base event accessors (which are defined `abstract` in this case), which leads to DynamicProxy triggering a `NotImplementedException`.

This PR corrects that bug by suppressing the call to `InvokeBase` for event attach / detach accessors when the base accessor methods are abstract. (Up until now, such a check was in place only for events defined in interfaces.)

This fixes #296.