### PR TITLE
Allow setting up null return values using `Mock.Of`

### DIFF
--- a/Source/Linq/MockSetupsBuilder.cs
+++ b/Source/Linq/MockSetupsBuilder.cs
@@ -226,6 +226,11 @@ namespace Moq.Linq
 				.MakeGenericType(sourceType, returnType)
 				.GetMethod("Returns", new[] { returnType });
 
+			if (right is ConstantExpression constExpr && constExpr.Value == null)
+			{
+				right = Expression.Constant(null, left.Type);
+			}
+
 			return Expression.NotEqual(
 				Expression.Call(FluentMockVisitor.Accept(left), returnsMethod, right),
 				Expression.Constant(null));

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -1130,6 +1130,33 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 337
+
+		public class Issue337
+		{
+			[Fact]
+			public void Mock_Of_can_setup_null_return_value()
+			{
+				// The following mock setup might appear redundant; after all, `null` is
+				// the default value returned for most reference types. However, this test
+				// becomes relevant once Moq starts supporting custom implementations of
+				// `IDefaultValueProvider`. Then it might no longer be a given that `null`
+				// is the default return value that noone would want to explicitly set up.
+				var userProvider = Mock.Of<IUserProvider>(p => p.GetUserByEmail("alice@example.com") == null);
+				var user = userProvider.GetUserByEmail("alice@example.com");
+				Assert.Null(user);
+			}
+
+			public class User { }
+
+			public interface IUserProvider
+			{
+				User GetUserByEmail(string email);
+			}
+		}
+
+		#endregion
+
 		#region 340
 
 #if FEATURE_SERIALIZATION


### PR DESCRIPTION
This fixes #337.