### PR TITLE
Allow `Mock<T>.Raise` to raise events on child mocks

### DIFF
--- a/Source/Extensions.cs
+++ b/Source/Extensions.cs
@@ -193,12 +193,14 @@ namespace Moq
 			return false;
 		}
 
-		public static EventInfo GetEvent<TMock>(this Action<TMock> eventExpression, TMock mock)
+		public static MemberInfoWithTarget<EventInfo, Mock> GetEvent<TMock>(this Action<TMock> eventExpression, TMock mock)
 			where TMock : class
 		{
 			Guard.NotNull(() => eventExpression, eventExpression);
 
-			MethodBase addRemove = null;
+			MethodBase addRemove;
+			Mock target;
+
 			using (var context = new FluentMockContext())
 			{
 				eventExpression(mock);
@@ -209,6 +211,7 @@ namespace Moq
 				}
 
 				addRemove = context.LastInvocation.Invocation.Method;
+				target = context.LastInvocation.Mock;
 			}
 
 			var ev = addRemove.DeclaringType.GetEvent(
@@ -222,7 +225,7 @@ namespace Moq
 					addRemove));
 			}
 
-			return ev;
+			return new MemberInfoWithTarget<EventInfo, Mock>(ev, target);
 		}
 
 #if !NETCORE

--- a/Source/MemberInfoWithTarget.cs
+++ b/Source/MemberInfoWithTarget.cs
@@ -1,0 +1,61 @@
+﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//https://github.com/moq/moq4
+//All rights reserved.
+
+//Redistribution and use in source and binary forms,
+//with or without modification, are permitted provided
+//that the following conditions are met:
+
+//    * Redistributions of source code must retain the
+//    above copyright notice, this list of conditions and
+//    the following disclaimer.
+
+//    * Redistributions in binary form must reproduce
+//    the above copyright notice, this list of conditions
+//    and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
+//    names of its contributors may be used to endorse
+//    or promote products derived from this software
+//    without specific prior written permission.
+
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+//SUCH DAMAGE.
+
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System;
+using System.Reflection;
+
+namespace Moq
+{
+	internal struct MemberInfoWithTarget<TMemberInfo, TTarget> where TMemberInfo : MemberInfo
+	{
+		private TMemberInfo memberInfo;
+		private TTarget target;
+
+		public MemberInfoWithTarget(TMemberInfo memberInfo, TTarget target)
+		{
+			this.memberInfo = memberInfo ?? throw new ArgumentNullException(nameof(memberInfo));
+			this.target = target;
+		}
+
+		public TMemberInfo MemberInfo => this.memberInfo;
+
+		public TTarget Target => this.target;
+	}
+}

--- a/Source/MethodCall.cs
+++ b/Source/MethodCall.cs
@@ -409,7 +409,8 @@ namespace Moq
 		protected IVerifies RaisesImpl<TMock>(Action<TMock> eventExpression, Delegate func)
 			where TMock : class
 		{
-			this.mockEvent = eventExpression.GetEvent((TMock)Mock.Object);
+			var ev = eventExpression.GetEvent((TMock)Mock.Object);
+			this.mockEvent = ev.MemberInfo;
 			this.mockEventArgsFunc = func;
 			return this;
 		}
@@ -417,7 +418,8 @@ namespace Moq
 		protected IVerifies RaisesImpl<TMock>(Action<TMock> eventExpression, params object[] args)
 			where TMock : class
 		{
-			this.mockEvent = eventExpression.GetEvent((TMock)Mock.Object);
+			var ev = eventExpression.GetEvent((TMock)Mock.Object);
+			this.mockEvent = ev.MemberInfo;
 			this.mockEventArgsParams = args;
 			return this;
 		}

--- a/Source/Mock.Generic.cs
+++ b/Source/Mock.Generic.cs
@@ -503,7 +503,7 @@ namespace Moq
 
 			try
 			{
-				this.DoRaise(ev, args);
+				ev.Target.DoRaise(ev.MemberInfo, args);
 			}
 			catch (Exception e)
 			{
@@ -521,7 +521,7 @@ namespace Moq
 
 			try
 			{
-				this.DoRaise(ev, args);
+				ev.Target.DoRaise(ev.MemberInfo, args);
 			}
 			catch (Exception e)
 			{

--- a/Source/Moq.csproj
+++ b/Source/Moq.csproj
@@ -45,6 +45,7 @@
 		<Compile Include="Capture.cs" />
 		<Compile Include="CaptureMatch.cs" />
 		<Compile Include="ConditionalContext.cs" />
+		<Compile Include="MemberInfoWithTarget.cs" />
 		<Compile Include="IInterceptStrategy.cs" />
 		<Compile Include="IMock.cs" />
 		<Compile Include="InterceptorStrategies.cs" />

--- a/UnitTests/MockedEventsFixture.cs
+++ b/UnitTests/MockedEventsFixture.cs
@@ -341,7 +341,7 @@ namespace Moq.Tests
 		}
 
 		[Fact]
-		public void DoesNotRaiseEventOnSubObject()
+		public void CanRaiseEventOnSubObject()
 		{
 			var mock = new Mock<IParent> { DefaultValue = DefaultValue.Mock };
 
@@ -352,7 +352,7 @@ namespace Moq.Tests
 
 			mock.Raise(p => p.Adder.Added += null, EventArgs.Empty);
 
-			Assert.False(raised);
+			Assert.True(raised);
 		}
 
 		[Fact]

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -522,6 +522,84 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 166
+
+		public class Issue166
+		{
+			[Fact]
+			public void Events_with_same_name_in_object_graph_can_both_be_raised()
+			{
+				var mock = new Mock<IFoo> { DefaultValue = DefaultValue.Mock };
+
+				var fooEventRaiseCount = 0;
+				mock.Object.Event += (s, e) => ++fooEventRaiseCount;
+
+				var barEventRaiseCount = 0;
+				mock.Object.Bar.Event += (s, e) => ++barEventRaiseCount;
+
+				mock.Raise(x => x.Event += null, EventArgs.Empty);
+				mock.Raise(x => x.Bar.Event += null, EventArgs.Empty);
+
+				Assert.Equal(1, fooEventRaiseCount);
+				Assert.Equal(1, barEventRaiseCount);
+			}
+
+			[Fact]
+			public void Events_with_different_names_in_object_graph_can_both_be_raised()
+			{
+				var mock = new Mock<IFoo> { DefaultValue = DefaultValue.Mock };
+
+				var fooEventRaiseCount = 0;
+				mock.Object.Event += (s, e) => ++fooEventRaiseCount;
+
+				var barAnotherEventRaiseCount = 0;
+				mock.Object.Bar.AnotherEvent += (s, e) => ++barAnotherEventRaiseCount;
+
+				mock.Raise(x => x.Event += null, EventArgs.Empty);
+				mock.Raise(x => x.Bar.AnotherEvent += null, EventArgs.Empty);
+
+				Assert.Equal(1, fooEventRaiseCount);
+				Assert.Equal(1, barAnotherEventRaiseCount);
+			}
+
+			[Fact]
+			public void Event_in_child_mock_can_be_raised_if_parent_object_has_no_events()
+			{
+				var mock = new Mock<IQux>() { DefaultValue = DefaultValue.Mock };
+
+				var quuxEventRaiseCount = 0;
+				mock.Object.Quux.Event += (s, e) => ++quuxEventRaiseCount;
+
+				mock.Raise(x => x.Quux.Event += null, EventArgs.Empty);
+
+				Assert.Equal(1, quuxEventRaiseCount);
+			}
+
+			public interface IFoo
+			{
+				IBar Bar { get; }
+				event EventHandler Event;
+			}
+
+			public interface IBar
+			{
+				event EventHandler Event;
+				event EventHandler AnotherEvent;
+			}
+
+			public interface IQux
+			{
+				IQuux Quux { get; }
+			}
+
+			public interface IQuux : IQux
+			{
+				event EventHandler Event;
+			}
+		}
+
+		#endregion
+
 		#region 175
 
 		public class Issue175


### PR DESCRIPTION
This fixes #166.