### PR TITLE
Can specify Times a verifiable expectation must be met

### DIFF
--- a/Source/IProxyCall.cs
+++ b/Source/IProxyCall.cs
@@ -50,7 +50,7 @@ namespace Moq
 		bool IsConditional { get; }
 		string FailMessage { get; set; }
 		bool Invoked { get; set; }
-		bool IsVerifiable { get; set; }
+		Times? VerifiableTimes { get; set; }
 		Expression SetupExpression { get; }
 		MethodInfo Method { get; }
 		void EvaluatedSuccessfully();

--- a/Source/Interceptor.cs
+++ b/Source/Interceptor.cs
@@ -65,12 +65,12 @@ namespace Moq
 
 		internal void Verify()
 		{
-			VerifyOrThrow(call => call.IsVerifiable && !call.Invoked);
+			VerifyOrThrow(call => !(call.VerifiableTimes?.Verify(call.CallCount) ?? true));
 		}
 
 		internal void VerifyAll()
 		{
-			VerifyOrThrow(call => !call.Invoked);
+			VerifyOrThrow(call => !(call.VerifiableTimes?.Verify(call.CallCount) ?? call.Invoked));
 		}
 
 		private void VerifyOrThrow(Func<IProxyCall, bool> match)

--- a/Source/Language/IVerifies.cs
+++ b/Source/Language/IVerifies.cs
@@ -66,6 +66,22 @@ namespace Moq.Language
 		/// <summary>
 		/// Marks the expectation as verifiable, meaning that a call 
 		/// to <see cref="Mock.Verify()"/> will check if this particular 
+		/// expectation was met by the expected number of invocataions.
+		/// </summary>
+		/// <example>
+		/// The following example marks the expectation as verifiable
+		/// and requiring at least one call:
+		/// <code>
+		/// mock.Expect(x => x.Execute("ping"))
+		///     .Returns(true)
+		///     .Verifiable(Times.AtLeastOnce());
+		/// </code>
+		/// </example>
+		void Verifiable(Times times);
+
+		/// <summary>
+		/// Marks the expectation as verifiable, meaning that a call 
+		/// to <see cref="Mock.Verify()"/> will check if this particular 
 		/// expectation was met, and specifies a message for failures.
 		/// </summary>
 		/// <example>
@@ -77,5 +93,22 @@ namespace Moq.Language
 		/// </code>
 		/// </example>
 		void Verifiable(string failMessage);
+
+		/// <summary>
+		/// Marks the expectation as verifiable, meaning that a call 
+		/// to <see cref="Mock.Verify()"/> will check if this particular 
+		/// expectation was metby the expected number of invocataions,
+		/// and specifies a message for failures.
+		/// </summary>
+		/// <example>
+		/// The following example marks the expectation as verifiable
+		/// and requiring at least one call:
+		/// <code>
+		/// mock.Expect(x => x.Execute("ping"))
+		///     .Returns(true)
+		///     .Verifiable(Times.AtLeastOnce(), "Ping should be executed always!");
+		/// </code>
+		/// </example>
+		void Verifiable(Times times, string failMessage);
 	}
 }

--- a/Source/MethodCall.cs
+++ b/Source/MethodCall.cs
@@ -159,7 +159,7 @@ namespace Moq
 			get { return condition != null; }
 		}
 
-		public bool IsVerifiable { get; set; }
+		public Times? VerifiableTimes { get; set; }
 
 		public bool Invoked { get; set; }
 
@@ -357,12 +357,23 @@ namespace Moq
 
 		public void Verifiable()
 		{
-			this.IsVerifiable = true;
+			this.VerifiableTimes = Times.AtLeastOnce();
+		}
+
+		public void Verifiable(Times times)
+		{
+			this.VerifiableTimes = times;
 		}
 
 		public void Verifiable(string failMessage)
 		{
-			this.IsVerifiable = true;
+			this.VerifiableTimes = Times.AtLeastOnce();
+			this.FailMessage = failMessage;
+		}
+
+		public void Verifiable(Times times, string failMessage)
+		{
+			this.VerifiableTimes = times;
 			this.FailMessage = failMessage;
 		}
 

--- a/UnitTests/VerifyFixture.cs
+++ b/UnitTests/VerifyFixture.cs
@@ -3,6 +3,7 @@ using Moq;
 using Xunit;
 
 using System.Threading.Tasks;
+using System.Text;
 
 namespace Moq.Tests
 {
@@ -67,7 +68,7 @@ namespace Moq.Tests
 
 			mock.Verify();
 		}
-
+		
 		[Fact]
 		public void ThrowsIfVerifyAllNotMet()
 		{
@@ -104,6 +105,95 @@ namespace Moq.Tests
 
 			var mex = Assert.Throws<MockException>(() => mock.Verify(f => f.Execute("ping")));
 			Assert.Equal(MockException.ExceptionReason.VerificationFailed, mex.Reason);
+		}
+
+		[Fact]
+		public void ThrowsWithExpressionIfVerifiableTimesOnceNotCalled()
+		{
+			var mock = new Mock<IFoo>();
+
+			mock.Setup(x => x.Execute(It.Is<string>(s => string.IsNullOrEmpty(s))))
+				.Returns("ack")
+				.Verifiable(Times.Once());
+
+			var mex = Assert.Throws<MockVerificationException>(() => mock.Verify());
+			Assert.Equal(MockException.ExceptionReason.VerificationFailed, mex.Reason);
+			Assert.Contains(@".Execute(It.Is<String>(s => String.IsNullOrEmpty(s)))", mex.Message);
+		}
+
+		[Fact]
+		public void ThrowsWithExpressionIfVerifiableTimesOnceCalledMore()
+		{
+			var mock = new Mock<IFoo>();
+
+			mock.Setup(x => x.Execute(It.Is<string>(s => string.IsNullOrEmpty(s))))
+				.Returns("ack")
+				.Verifiable(Times.Once());
+
+			mock.Object.Execute("");
+			mock.Object.Execute("");
+
+			var mex = Assert.Throws<MockVerificationException>(() => mock.Verify());
+			Assert.Equal(MockException.ExceptionReason.VerificationFailed, mex.Reason);
+			Assert.Contains(@".Execute(It.Is<String>(s => String.IsNullOrEmpty(s)))", mex.Message);
+		}
+
+		[Fact]
+		public void VerifiesIfVerifiableTimesOnceCalledOnce()
+		{
+			var mock = new Mock<IFoo>();
+
+			mock.Setup(x => x.Execute(It.Is<string>(s => string.IsNullOrEmpty(s))))
+				.Returns("ack")
+				.Verifiable(Times.Once());
+
+			mock.Object.Execute("");
+
+			mock.Verify();
+		}
+
+		[Fact]
+		public void ThrowsWithExpressionIfVerifiableTimesNeverCalled()
+		{
+			var mock = new Mock<IFoo>();
+
+			mock.Setup(x => x.Execute(It.Is<string>(s => string.IsNullOrEmpty(s))))
+				.Returns("ack")
+				.Verifiable(Times.Never());
+
+			mock.Object.Execute("");
+
+			var mex = Assert.Throws<MockVerificationException>(() => mock.Verify());
+			Assert.Equal(MockException.ExceptionReason.VerificationFailed, mex.Reason);
+			Assert.Contains(@".Execute(It.Is<String>(s => String.IsNullOrEmpty(s)))", mex.Message);
+		}
+
+		[Fact]
+		public void VerifiesIfVerifiableTimesNeverNotCalled()
+		{
+			var mock = new Mock<IFoo>();
+
+			mock.Setup(x => x.Execute(It.Is<string>(s => string.IsNullOrEmpty(s))))
+				.Returns("ack")
+				.Verifiable(Times.Never());
+
+			mock.Verify();
+		}
+
+		[Fact]
+		public void ThrowsWithExpressionAndMessageIfVerifiableTimesNeverCalled()
+		{
+			var mock = new Mock<IFoo>();
+
+			mock.Setup(x => x.Execute(It.Is<string>(s => string.IsNullOrEmpty(s))))
+				.Returns("ack")
+				.Verifiable(Times.Never(), "Should never be called");
+
+			mock.Object.Execute("");
+
+			var mex = Assert.Throws<MockVerificationException>(() => mock.Verify());
+			Assert.Equal(MockException.ExceptionReason.VerificationFailed, mex.Reason);
+			Assert.Contains("Should never be called", mex.Message);
 		}
 
 		[Fact]
@@ -992,6 +1082,67 @@ namespace Moq.Tests
 				mock.Object.Submit();
 				mock.Verify(foo => foo.Submit());
 			});
+		}
+
+		[Fact]
+		public void CannotPostVerifyCallsByExpressionForModifiedReferenceTypeArgument()
+		{
+			// Any reference type
+			var sb = new StringBuilder();
+			sb.Append("call 1");
+
+			var mock = new Mock<IFoo>();
+
+			var rtm = new ReferenceTypeModifier(mock.Object);
+			rtm.Work(sb);
+
+			mock.Verify(m => m.Save(It.IsAny<StringBuilder>()), Times.Exactly(2)); // Pass
+			mock.Verify(m => m.Save(It.Is<StringBuilder>(s => s.ToString() == "call 2"))); // Pass
+
+			var mex = Assert.Throws<MockException>(() => mock.Verify(m => m.Save(It.Is<StringBuilder>(s => s.ToString() == "call 1")))); // Fail due to reference change
+			Assert.Equal(MockException.ExceptionReason.VerificationFailed, mex.Reason);
+			Assert.Contains(@".Save(It.Is<StringBuilder>(s => s.ToString() == ""call 1""))", mex.Message);
+		}
+
+		[Fact]
+		public void CanPreVerifyExactCallsByExpressionForModifiedReferenceTypeArgument()
+		{
+			// Any reference type
+			var sb = new StringBuilder();
+			sb.Append("call 1");
+
+			var mock = new Mock<IFoo>();
+			mock.Setup(m => m.Save(It.Is<StringBuilder>(s => s.ToString() == "call 1")))
+				.Verifiable(Times.Once());
+			mock.Setup(m => m.Save(It.Is<StringBuilder>(s => s.ToString() == "call 2")))
+				.Verifiable(Times.Once());
+			mock.Setup(m => m.Save(It.Is<StringBuilder>(s => s.ToString() != "call 1" && s.ToString() != "call 2")))
+				.Verifiable(Times.Never());
+
+			var rtm = new ReferenceTypeModifier(mock.Object);
+			rtm.Work(sb);
+
+			mock.Verify();
+		}
+
+		public class ReferenceTypeModifier
+		{
+			private readonly IFoo _dep;
+
+			public ReferenceTypeModifier(IFoo dep)
+			{
+				_dep = dep;
+			}
+
+			public void Work(StringBuilder sb)
+			{
+				_dep.Save(sb);
+
+				sb.Clear();
+				sb.Append("call 2");
+
+				_dep.Save(sb);
+			}
 		}
 
 		public interface IBar


### PR DESCRIPTION
Defaults to `AtLeastOnce` to match current functionality.

We had an issue testing a method modified properties within a reference type shared to a dependency. The current "Verify" checks can only compare against the current reference type state (see new `CannotPostVerifyCallsByExpressionForModifiedReferenceTypeArgument` fact).
The approach that we came up with was to support the "Times" concept directly in the "Verifiable" setup.

Given that the change is non-breaking by default and pretty clean, I thought it worth pushing back.

Full example in `CanPreVerifyExactCallsByExpressionForModifiedReferenceTypeArgument` fact, but in short:
```
mock.Setup(m => m.Method()).Verifiable(Times.Once()); // Require method to be called only once
// act
mock.Verify(); // Verify invocations match expected
```