### PR TITLE
Move hardcoded message strings to `Resources.resx`

### DIFF
--- a/Source/ExpressionStringBuilder.cs
+++ b/Source/ExpressionStringBuilder.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Collections.ObjectModel;
+using Moq.Properties;
 
 namespace Moq
 {
@@ -127,7 +128,7 @@ namespace Moq
 					ToStringListInit((ListInitExpression)exp);
 					return;
 				default:
-					throw new Exception(string.Format("Unhandled expression type: '{0}'", exp.NodeType));
+					throw new Exception(string.Format(Resources.UnhandledExpressionType, exp.NodeType));
 			}
 		}
 
@@ -145,7 +146,7 @@ namespace Moq
 					ToStringMemberListBinding((MemberListBinding)binding);
 					return;
 				default:
-					throw new Exception(string.Format("Unhandled binding type '{0}'", binding.BindingType));
+					throw new Exception(string.Format(Resources.UnhandledBindingType, binding.BindingType));
 			}
 		}
 

--- a/Source/Extensions.cs
+++ b/Source/Extensions.cs
@@ -208,7 +208,7 @@ namespace Moq
 
 				if (context.LastInvocation == null)
 				{
-					throw new ArgumentException("Expression is not an event attach or detach, or the event is declared in a class but not marked virtual.");
+					throw new ArgumentException(Resources.ExpressionIsNotEventAttachOrDetachOrIsNotVirtual);
 				}
 
 				addRemove = context.LastInvocation.Invocation.Method;

--- a/Source/Linq/MockSetupsBuilder.cs
+++ b/Source/Linq/MockSetupsBuilder.cs
@@ -197,7 +197,7 @@ namespace Moq.Linq
 			// We need to go back one level, to the target expression of the Setup call, 
 			// which would be the Mock.Get(foo), where we will actually invoke SetupProperty instead.
 			if (propertySetup.NodeType != ExpressionType.Call)
-				throw new NotSupportedException("Unexpected translation of a member access: " + propertySetup.ToStringFixed());
+				throw new NotSupportedException(string.Format(Resources.UnexpectedTranslationOfMemberAccess, propertySetup.ToStringFixed()));
 
 			var propertyCall = (MethodCallExpression)propertySetup;
 			var mockExpression = propertyCall.Object;

--- a/Source/Linq/Mocks.cs
+++ b/Source/Linq/Mocks.cs
@@ -194,7 +194,7 @@ namespace Moq
 			}
 			else
 			{
-				throw new NotSupportedException("Unsupported expression: " + setup.ToStringFixed());
+				throw new NotSupportedException(string.Format(Resources.UnsupportedExpression, setup.ToStringFixed()));
 			}
 
 			info.ReturnType.ThrowIfNotMockeable();

--- a/Source/MethodCall.cs
+++ b/Source/MethodCall.cs
@@ -349,7 +349,7 @@ namespace Moq
 		{
 			throw new ArgumentException(string.Format(
 				CultureInfo.CurrentCulture,
-				"Invalid callback. Setup on method with parameters ({0}) cannot invoke callback with parameters ({1}).",
+				Resources.InvalidCallbackParameterMismatch,
 				string.Join(",", expected.Select(p => p.ParameterType.Name).ToArray()),
 				string.Join(",", actual.Select(p => p.ParameterType.Name).ToArray())
 			));

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -405,8 +405,8 @@ namespace Moq
 				.ToArray();
 
 			return expressionSetups.Length == 0 ?
-				"No setups configured." :
-				Environment.NewLine + "Configured setups:" + Environment.NewLine + string.Join(Environment.NewLine, expressionSetups);
+				Resources.NoSetupsConfigured :
+				Environment.NewLine + string.Format(Resources.ConfiguredSetups, Environment.NewLine + string.Join(Environment.NewLine, expressionSetups));
 		}
 
 		private static string FormatCallCount(int callCount)
@@ -431,8 +431,8 @@ namespace Moq
 				.ToArray();
 
 			return formattedInvocations.Length == 0 ?
-				"No invocations performed." :
-				Environment.NewLine + "Performed invocations:" + Environment.NewLine + string.Join(Environment.NewLine, formattedInvocations);
+				Resources.NoInvocationsPerformed :
+				Environment.NewLine + string.Format(Resources.PerformedInvocations, Environment.NewLine + string.Join(Environment.NewLine, formattedInvocations));
 		}
 
 		#endregion

--- a/Source/Properties/Resources.Designer.cs
+++ b/Source/Properties/Resources.Designer.cs
@@ -97,6 +97,15 @@ namespace Moq.Properties {
 		}
 		
 		/// <summary>
+		///   Looks up a localized string similar to Configured setups: {0}.
+		/// </summary>
+		internal static string ConfiguredSetups {
+			get {
+				return ResourceManager.GetString("ConfiguredSetups", resourceCulture);
+			}
+		}
+
+		/// <summary>
 		///   Looks up a localized string similar to Constructor arguments cannot be passed for delegate mocks..
 		/// </summary>
 		internal static string ConstructorArgsForDelegate {
@@ -124,6 +133,15 @@ namespace Moq.Properties {
 		}
 		
 		/// <summary>
+		///   Looks up a localized string similar to Delays have to be greater than zero to ensure an async callback is used..
+		/// </summary>
+		internal static string DelaysMustBeGreaterThanZero {
+			get {
+				return ResourceManager.GetString("DelaysMustBeGreaterThanZero", resourceCulture);
+			}
+		}
+
+		/// <summary>
 		///   Looks up a localized string similar to Could not locate event for attach or detach method {0}..
 		/// </summary>
 		internal static string EventNofFound {
@@ -133,6 +151,15 @@ namespace Moq.Properties {
 		}
 		
 		/// <summary>
+		///   Looks up a localized string similar to Expression is not an event attach or detach, or the event is declared in a class but not marked virtual..
+		/// </summary>
+		internal static string ExpressionIsNotEventAttachOrDetachOrIsNotVirtual {
+			get {
+				return ResourceManager.GetString("ExpressionIsNotEventAttachOrDetachOrIsNotVirtual", resourceCulture);
+			}
+		}
+
+		/// <summary>
 		///   Looks up a localized string similar to Expression {0} involves a field access, which is not supported. Use properties instead..
 		/// </summary>
 		internal static string FieldsNotSupported {
@@ -141,6 +168,15 @@ namespace Moq.Properties {
 			}
 		}
 		
+		/// <summary>
+		///   Looks up a localized string similar to Invalid callback. Setup on method with parameters ({0}) cannot invoke callback with parameters ({1})..
+		/// </summary>
+		internal static string InvalidCallbackParameterMismatch {
+			get {
+				return ResourceManager.GetString("InvalidCallbackParameterMismatch", resourceCulture);
+			}
+		}
+
 		/// <summary>
 		///   Looks up a localized string similar to Type to mock must be an interface or an abstract or non-sealed class. .
 		/// </summary>
@@ -209,6 +245,15 @@ namespace Moq.Properties {
 		}
 		
 		/// <summary>
+		///   Looks up a localized string similar to Mininum delay has to be lower than maximum delay..
+		/// </summary>
+		internal static string MinDelayMustBeLessThanMaxDelay {
+			get {
+				return ResourceManager.GetString("MinDelayMustBeLessThanMaxDelay", resourceCulture);
+			}
+		}
+
+		/// <summary>
 		///   Looks up a localized string similar to {0} invocation failed with mock behavior {1}.
 		///{2}.
 		/// </summary>
@@ -236,6 +281,15 @@ namespace Moq.Properties {
 			}
 		}
 		
+		/// <summary>
+		///   Looks up a localized string similar to No invocations performed..
+		/// </summary>
+		internal static string NoInvocationsPerformed {
+			get {
+				return ResourceManager.GetString("NoInvocationsPerformed", resourceCulture);
+			}
+		}
+
 		/// <summary>
 		///   Looks up a localized string similar to {0}
 		///Expected invocation on the mock at least {2} times, but was {4} times: {1}.
@@ -336,6 +390,15 @@ namespace Moq.Properties {
 		}
 		
 		/// <summary>
+		///   Looks up a localized string similar to No setups configured..
+		/// </summary>
+		internal static string NoSetupsConfigured {
+			get {
+				return ResourceManager.GetString("NoSetupsConfigured", resourceCulture);
+			}
+		}
+
+		/// <summary>
 		///   Looks up a localized string similar to Object instance was not created by Moq..
 		/// </summary>
 		internal static string ObjectInstanceNotMock {
@@ -353,6 +416,15 @@ namespace Moq.Properties {
 			}
 		}
 		
+		/// <summary>
+		///   Looks up a localized string similar to Performed invocations: {0}.
+		/// </summary>
+		internal static string PerformedInvocations {
+			get {
+				return ResourceManager.GetString("PerformedInvocations", resourceCulture);
+			}
+		}
+
 		/// <summary>
 		///   Looks up a localized string similar to Property {0}.{1} does not have a getter..
 		/// </summary>
@@ -529,6 +601,33 @@ namespace Moq.Properties {
 		}
 		
 		/// <summary>
+		///   Looks up a localized string similar to Unexpected translation of a member access: {0}.
+		/// </summary>
+		internal static string UnexpectedTranslationOfMemberAccess {
+			get {
+				return ResourceManager.GetString("UnexpectedTranslationOfMemberAccess", resourceCulture);
+			}
+		}
+
+		/// <summary>
+		///   Looks up a localized string similar to Unhandled binding type: {0}.
+		/// </summary>
+		internal static string UnhandledBindingType {
+			get {
+				return ResourceManager.GetString("UnhandledBindingType", resourceCulture);
+			}
+		}
+
+		/// <summary>
+		///   Looks up a localized string similar to Unhandled expression type: {0}.
+		/// </summary>
+		internal static string UnhandledExpressionType {
+			get {
+				return ResourceManager.GetString("UnhandledExpressionType", resourceCulture);
+			}
+		}
+
+		/// <summary>
 		///   Looks up a localized string similar to Unsupported expression: {0}.
 		/// </summary>
 		internal static string UnsupportedExpression {
@@ -582,6 +681,15 @@ namespace Moq.Properties {
 			}
 		}
 		
+		/// <summary>
+		///   Looks up a localized string similar to Use ItExpr.IsNull&lt;TValue&gt; rather than a null argument value, as it prevents proper method lookup..
+		/// </summary>
+		internal static string UseItExprIsNullRatherThanNullArgumentValue {
+			get {
+				return ResourceManager.GetString("UseItExprIsNullRatherThanNullArgumentValue", resourceCulture);
+			}
+		}
+
 		/// <summary>
 		///   Looks up a localized string similar to The following setups were not matched:
 		///{0}.

--- a/Source/Properties/Resources.resx
+++ b/Source/Properties/Resources.resx
@@ -316,4 +316,40 @@ Expected invocation on the mock once, but was {4} times: {1}</value>
 	<data name="VerifyOnExtensionMethod" xml:space="preserve">
 		<value>Invalid verify on an extension method: {0}</value>
 	</data>
+	<data name="UnhandledBindingType" xml:space="preserve">
+		<value>Unhandled binding type: {0}</value>
+	</data>
+	<data name="UnhandledExpressionType" xml:space="preserve">
+		<value>Unhandled expression type: {0}</value>
+	</data>
+	<data name="ConfiguredSetups" xml:space="preserve">
+		<value>Configured setups: {0}</value>
+	</data>
+	<data name="DelaysMustBeGreaterThanZero" xml:space="preserve">
+		<value>Delays have to be greater than zero to ensure an async callback is used.</value>
+	</data>
+	<data name="ExpressionIsNotEventAttachOrDetachOrIsNotVirtual" xml:space="preserve">
+		<value>Expression is not an event attach or detach, or the event is declared in a class but not marked virtual.</value>
+	</data>
+	<data name="InvalidCallbackParameterMismatch" xml:space="preserve">
+		<value>Invalid callback. Setup on method with parameters ({0}) cannot invoke callback with parameters ({1}).</value>
+	</data>
+	<data name="MinDelayMustBeLessThanMaxDelay" xml:space="preserve">
+		<value>Mininum delay has to be lower than maximum delay.</value>
+	</data>
+	<data name="NoInvocationsPerformed" xml:space="preserve">
+		<value>No invocations performed.</value>
+	</data>
+	<data name="NoSetupsConfigured" xml:space="preserve">
+		<value>No setups configured.</value>
+	</data>
+	<data name="PerformedInvocations" xml:space="preserve">
+		<value>Performed invocations: {0}</value>
+	</data>
+	<data name="UnexpectedTranslationOfMemberAccess" xml:space="preserve">
+		<value>Unexpected translation of a member access: {0}</value>
+	</data>
+	<data name="UseItExprIsNullRatherThanNullArgumentValue" xml:space="preserve">
+		<value>Use ItExpr.IsNull&lt;TValue&gt; rather than a null argument value, as it prevents proper method lookup.</value>
+	</data>
 </root>

--- a/Source/Protected/ProtectedMock.cs
+++ b/Source/Protected/ProtectedMock.cs
@@ -307,7 +307,7 @@ namespace Moq.Protected
 		{
 			if (args == null)
 			{
-				throw new ArgumentException("Use ItExpr.IsNull<TValue> rather than a null argument value, as it prevents proper method lookup.");
+				throw new ArgumentException(Resources.UseItExprIsNullRatherThanNullArgumentValue);
 			}
 
 			var types = new Type[args.Length];
@@ -315,7 +315,7 @@ namespace Moq.Protected
 			{
 				if (args[index] == null)
 				{
-					throw new ArgumentException("Use ItExpr.IsNull<TValue> rather than a null argument value, as it prevents proper method lookup.");
+					throw new ArgumentException(Resources.UseItExprIsNullRatherThanNullArgumentValue);
 				}
 
 				var expr = args[index] as Expression;

--- a/Source/ReturnsExtensions.cs
+++ b/Source/ReturnsExtensions.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Moq.Language;
 using Moq.Language.Flow;
+using Moq.Properties;
 
 namespace Moq
 {
@@ -138,7 +139,7 @@ namespace Moq
 		private static TimeSpan GetDelay(TimeSpan minDelay, TimeSpan maxDelay, Random random)
 		{
 			if (!(minDelay < maxDelay))
-				throw new ArgumentException("Mininum delay has to be lower than maximum delay.");
+				throw new ArgumentException(Resources.MinDelayMustBeLessThanMaxDelay);
 
 			var min = (int)minDelay.Ticks;
 			var max = (int)maxDelay.Ticks;
@@ -149,7 +150,7 @@ namespace Moq
 		private static void GuardPositiveDelay(TimeSpan delay)
 		{
 			if (!(delay > TimeSpan.Zero))
-				throw new ArgumentException("Delays have to be greater than zero to ensure an async callback is used.");
+				throw new ArgumentException(Resources.DelaysMustBeGreaterThanZero);
 		}
 
 		private static IReturnsResult<TMock> DelayedResult<TMock, TResult>(IReturns<TMock, Task<TResult>> mock,

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -2319,9 +2319,9 @@ namespace Moq.Tests.Regressions
 
 				var e = Assert.Throws<MockException>(() => mock.Verify(m => m.Execute(0)));
 				Assert.Contains(
-					"\r\nConfigured setups:" +
-					"\r\nm => m.Execute(1), Times.Never" +
-					"\r\nm => m.Execute(It.IsInRange<Int32>(2, 20, Range.Exclusive)), Times.Exactly(3)",
+					Environment.NewLine + "Configured setups: " +
+					Environment.NewLine + "m => m.Execute(1), Times.Never" +
+					Environment.NewLine + "m => m.Execute(It.IsInRange<Int32>(2, 20, Range.Exclusive)), Times.Exactly(3)",
 					e.Message);
 			}
 
@@ -2336,7 +2336,8 @@ namespace Moq.Tests.Regressions
 
 				var e = Assert.Throws<MockException>(() => mock.Verify(m => m.Execute<int>(1, 1)));
 				Assert.Contains(
-					"\r\nConfigured setups:\r\nm => m.Execute<Int32>(1, 10), Times.Once",
+					Environment.NewLine + "Configured setups: " +
+					Environment.NewLine + "m => m.Execute<Int32>(1, 10), Times.Once",
 					e.Message);
 			}
 
@@ -2346,7 +2347,9 @@ namespace Moq.Tests.Regressions
 				var mock = new Mock<IFoo>();
 
 				var e = Assert.Throws<MockException>(() => mock.Verify(m => m.Execute(1)));
-				Assert.Contains("\r\nNo setups configured.", e.Message);
+				Assert.Contains(
+					Environment.NewLine + "No setups configured.",
+					e.Message);
 
 			}
 

--- a/UnitTests/VerifyFixture.cs
+++ b/UnitTests/VerifyFixture.cs
@@ -852,7 +852,7 @@ namespace Moq.Tests
 
 			Assert.Contains(
 				Environment.NewLine +
-				"Performed invocations:" + Environment.NewLine +
+				"Performed invocations: " + Environment.NewLine +
 				"IFoo.Execute(\"ping\")" + Environment.NewLine +
 				"IFoo.Echo(42)" + Environment.NewLine +
 				"IFoo.Submit()" + Environment.NewLine +
@@ -919,7 +919,7 @@ namespace Moq.Tests
 			mock.Object.Method(strings);
 			var mex = Assert.Throws<MockException>(() => mock.Verify(_ => _.Method(null)));
 			Assert.Contains(
-				@"Performed invocations:" + Environment.NewLine +
+				@"Performed invocations: " + Environment.NewLine +
 				@"IArrays.Method([""1"", null, ""3""])",
 				mex.Message);
 		}
@@ -932,7 +932,7 @@ namespace Moq.Tests
 			mock.Object.Method(strings);
 			var mex = Assert.Throws<MockException>(() => mock.Verify(_ => _.Method(null)));
 			Assert.Contains(
-				@"Performed invocations:" + Environment.NewLine +
+				@"Performed invocations: " + Environment.NewLine +
 				@"IArrays.Method([""1"", null, ""3"", ""4"", ""5"", ""6"", ""7"", ""8"", ""9"", ""10""])",
 				mex.Message);
 		}
@@ -945,7 +945,7 @@ namespace Moq.Tests
 			mock.Object.Method(strings);
 			var mex = Assert.Throws<MockException>(() => mock.Verify(_ => _.Method(null)));
 			Assert.Contains(
-				@"Performed invocations:" + Environment.NewLine +
+				@"Performed invocations: " + Environment.NewLine +
 				@"IArrays.Method([""1"", null, ""3"", ""4"", ""5"", ""6"", ""7"", ""8"", ""9"", ""10"", ...])",
 				mex.Message);
 		}


### PR DESCRIPTION
This closes #399.