### PR TITLE
Fix for the #409

### DIFF
--- a/Source/FluentMockContext.cs
+++ b/Source/FluentMockContext.cs
@@ -90,6 +90,7 @@ namespace Moq
 
 		public void Dispose()
 		{
+			invocations.Reverse();
 			foreach (var invocation in invocations)
 			{
 				invocation.Dispose();

--- a/UnitTests/MockDefaultValueProviderFixture.cs
+++ b/UnitTests/MockDefaultValueProviderFixture.cs
@@ -93,6 +93,15 @@ namespace Moq.Tests
 			Assert.Throws<MockVerificationException>(() => mock.Verify());
 		}
 
+		[Fact]
+		public void DefaultValueIsNotChangedWhenPerformingInternalInvocation()
+		{
+			var mockBar = new Mock<IBar> { DefaultValue = DefaultValue.Empty };
+			var mockFoo = new Mock<IFoo>();
+			mockFoo.SetupSet(m => m.Bar = mockBar.Object);
+			Assert.Equal(DefaultValue.Empty, mockBar.DefaultValue);
+		}
+
 		public interface IFoo
 		{
 			IBar Bar { get; set; }


### PR DESCRIPTION
Ok, trying again. I hope that this PR is now OK - there are only 2 files changed.

The fix for #409 is to revert the order of the items of the invocations list in he FluentMockContext before disposing the items. The new test runs into a situation, that there are at least 2 MockInvocations created on the mock which is constructed with DefaultValue.Empty. The first one remembers the original DefalutValue (Empty) and sets it to Mock. The second one remembers the current value of DefaultValue (Mock) and sets it to the Mock, too. Now, if the MockInvocations are disposed in the same order as they were created, the first MockInvocation will set the DefaultValue of the mock back to the value it remembered - Empty. Then the second MockInvocation is disposed and sets the DefaultValue to the Mock, as this is the one that it remembered. By reverting the disposal order we make sure that the DefaultValue is reverted back to the original value before the first MockInvocation was constructed.