### PR TITLE
IEnumerable mocks shouldn't cause NullReferenceException

### DIFF
--- a/Source/ExpressionStringBuilder.cs
+++ b/Source/ExpressionStringBuilder.cs
@@ -259,8 +259,11 @@ namespace Moq
 				{
 					builder.Append("\"").Append(value).Append("\"");
 				}
-				else if (value is IEnumerable enumerable)
-				{
+				else if (value is IEnumerable enumerable && enumerable.GetEnumerator() != null)
+				{                                        // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+					// This second check ensures that we have a usable implementation of IEnumerable.
+					// If value is a mocked object, its IEnumerable implementation might very well
+					// not work correctly.
 					builder.Append("[");
 					bool addComma = false;
 					const int maxCount = 10;

--- a/Source/Extensions.cs
+++ b/Source/Extensions.cs
@@ -90,8 +90,11 @@ namespace Moq
 			{
 				return "\"" + typedValue + "\"";
 			}
-			if (value is IEnumerable enumerable)
-			{
+			if (value is IEnumerable enumerable && enumerable.GetEnumerator() != null)
+			{                                   // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+				// This second check ensures that we have a usable implementation of IEnumerable.
+				// If value is a mocked object, its IEnumerable implementation might very well
+				// not work correctly.
 				const int maxCount = 10;
 				var objs = enumerable.Cast<object>().Take(maxCount + 1);
 				var more = objs.Count() > maxCount ? ", ..." : string.Empty;

--- a/Source/Matchers/ConstantMatcher.cs
+++ b/Source/Matchers/ConstantMatcher.cs
@@ -68,7 +68,11 @@ namespace Moq.Matchers
 				return true;
 			}
 
-			if (this.constantValue is IEnumerable && value is IEnumerable)
+			if (this.constantValue is IEnumerable constantEnumerable && value is IEnumerable enumerable &&
+				constantEnumerable.GetEnumerator() != null && enumerable.GetEnumerator() != null)
+				// the above checks on the second line are necessary to ensure we have usable
+				// implementations of IEnumerable, which might very well not be the case for
+				// mocked objects.
 			{
 				return this.MatchesEnumerable(value);
 			}

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -600,6 +600,54 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 169
+
+		public class Issue169
+		{
+			[Fact]
+			public void Mocks_that_implement_IEnumerable_which_is_not_set_up_can_be_used_without_NullReferenceException()
+			{
+				// This test makes sure that a mock is usable when it implements IEnumerable,
+				// but that interface isn't set up to correctly work. (Moq will attempt to use
+				// IEnumerable to generate an ExpressionKey, for example.)
+
+				var mocks = new MockRepository(MockBehavior.Loose);
+				var service = mocks.Create<IDependency>();
+
+				var input = mocks.OneOf<IInput>();
+				service.Setup(x => x.Run(input)).Returns(1);
+
+				var foo = new Foo(service.Object);
+				foo.Calculate(input);
+			}
+
+			public interface IDependency
+			{
+				decimal Run(IInput input);
+			}
+
+			public interface IInput : IEnumerable<int>
+			{
+			}
+
+			public class Foo
+			{
+				private readonly IDependency dependency;
+
+				public Foo(IDependency dependency)
+				{
+					this.dependency = dependency;
+				}
+
+				public void Calculate(IInput input)
+				{
+					this.dependency.Run(input);
+				}
+			}
+		}
+
+		#endregion
+
 		#region 175
 
 		public class Issue175


### PR DESCRIPTION
This fixes #169.