### PR TITLE
Improve method match accuracy in `ExtractProxyCall`

### DIFF
--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -210,6 +210,46 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 131
+
+		public class Issue131
+		{
+			[Fact]
+			public void Order_of_setups_should_not_matter_when_setting_up_methods_in_a_hierarchy_of_interfaces()
+			{
+				var mock = new Mock<Derived>();
+
+				mock.Setup(x => x.Method())
+					.Returns("Derived");
+				mock.As<BaseA>().Setup(x => x.Method())
+					.Returns("BaseA");
+				mock.As<BaseB>().Setup(x => x.Method())
+					.Returns("BaseB");
+
+				var derived = mock.Object;
+				Assert.Equal("Derived", derived.Method());
+				Assert.Equal("BaseA", (derived as BaseA).Method());
+				Assert.Equal("BaseB", (derived as BaseB).Method());
+			}
+
+			public interface BaseA
+			{
+				string Method();
+			}
+
+			public interface BaseB
+			{
+				string Method();
+			}
+
+			public interface Derived : BaseA, BaseB
+			{
+				new string Method();
+			}
+		}
+
+		#endregion
+
 		#region 141
 
 		public class Issue141


### PR DESCRIPTION
If you're setting up methods in a type hierarchy (e.g. `Base.Method` and `Derived.Method`), the setup order currently matters, even though two different methods are set up.

This commits is a first step in making Moq associate the "right" setup with a proxy method invocation. This will make sure that if there are several setups that potentially match an invocation, it will attempt to pick the one for the exact same method.

This is only a start, but probably still not good enough in all situations (for example, for overridden methods, the distance of the inheritance relationship is not taken into account).

This should fix #131.

/cc @dcastro, @pjquirk