### PR TITLE
Fix misreported setup `Times` in `Verify` messages

### DIFF
--- a/Source/IProxyCall.cs
+++ b/Source/IProxyCall.cs
@@ -63,5 +63,7 @@ namespace Moq
 		string FileName { get; }
 		int FileLine { get; }
 		MethodBase TestMethod { get; }
+
+		string Format();
 	}
 }

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -401,27 +401,12 @@ namespace Moq
 		private static string FormatSetupsInfo(IEnumerable<IProxyCall> setups)
 		{
 			var expressionSetups = setups
-				.Select(s => s.SetupExpression.PartialMatcherAwareEval().ToLambda().ToStringFixed() + ", " + FormatCallCount(s.CallCount))
+				.Select(s => s.Format())
 				.ToArray();
 
 			return expressionSetups.Length == 0 ?
 				Resources.NoSetupsConfigured :
 				Environment.NewLine + string.Format(Resources.ConfiguredSetups, Environment.NewLine + string.Join(Environment.NewLine, expressionSetups));
-		}
-
-		private static string FormatCallCount(int callCount)
-		{
-			if (callCount == 0)
-			{
-				return "Times.Never";
-			}
-
-			if (callCount == 1)
-			{
-				return "Times.Once";
-			}
-
-			return string.Format(CultureInfo.CurrentCulture, "Times.Exactly({0})", callCount);
 		}
 
 		private static string FormatInvocations(IEnumerable<ICallContext> invocations)

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -2428,8 +2428,8 @@ namespace Moq.Tests.Regressions
 				var e = Assert.Throws<MockException>(() => mock.Verify(m => m.Execute(0)));
 				Assert.Contains(
 					Environment.NewLine + "Configured setups: " +
-					Environment.NewLine + "m => m.Execute(1), Times.Never" +
-					Environment.NewLine + "m => m.Execute(It.IsInRange<Int32>(2, 20, Range.Exclusive)), Times.Exactly(3)",
+					Environment.NewLine + "m => m.Execute(1)" +
+					Environment.NewLine + "m => m.Execute(It.IsInRange<Int32>(2, 20, Range.Exclusive))",
 					e.Message);
 			}
 
@@ -2445,7 +2445,7 @@ namespace Moq.Tests.Regressions
 				var e = Assert.Throws<MockException>(() => mock.Verify(m => m.Execute<int>(1, 1)));
 				Assert.Contains(
 					Environment.NewLine + "Configured setups: " +
-					Environment.NewLine + "m => m.Execute<Int32>(1, 10), Times.Once",
+					Environment.NewLine + "m => m.Execute<Int32>(1, 10)",
 					e.Message);
 			}
 


### PR DESCRIPTION
This is a fix for #211.
 
When `mock.Verify` fails, it lists the mock's setups in the exception message. However, it reports actual invocation counts as the number of expected calls set up, which is misleading at best and incorrect at worst.
 
Moq currently allows only two kinds of expected call count setups (both of which have been obsoleted): `.AtMostOnce()` and `.AtMost(n)`. The current logic for formatting a setup is moved to `MethodCall` (the class representing a setup) where it rightly belongs, and where the expected call count limit is accessible.
 
This change will also make it easier to introduce the ability to specify any `Times` on a setup, if that's what gets decided in #373.