### PR TITLE
Make `SetupAllProperties` work correctly for same-typed sibling properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
+## Unreleased
+
+#### Fixed
+
+* Make `SetupAllProperties` work correctly for same-typed sibling properties (@stakx, #442)
+
+
 ## 4.7.99 (2017-07-17)
 
 #### Added

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -729,6 +729,8 @@ namespace Moq
 					returnsMethod.Invoke(returnsGetter, new[] {initialValue});
 				}
 			}
+
+			mockedTypesStack.Pop();
 		}
 
 		private static object GetInitialValue(IDefaultValueProvider valueProvider, Stack<Type> mockedTypesStack, PropertyInfo property)

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -1474,6 +1474,37 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 438
+
+		public class Issue438
+		{
+			[Fact]
+			public void SetupAllPropertiesCanSetupSeveralSiblingPropertiesOfTheSameType()
+			{
+				var resultMock = new Mock<IResult> { DefaultValue = DefaultValue.Mock };
+				resultMock.SetupAllProperties();
+				var result = resultMock.Object;
+				result.Part1.Name = "Foo";
+				result.Part2.Name = "Bar";
+
+				Assert.Equal("Foo", result.Part1.Name);
+				Assert.Equal("Bar", result.Part2.Name);
+			}
+
+			public interface IResult
+			{
+				ISubResult Part1 { get; }
+				ISubResult Part2 { get; }
+			}
+
+			public interface ISubResult
+			{
+				string Name { get; set; }
+			}
+		}
+
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -1501,6 +1501,38 @@ namespace Moq.Tests.Regressions
 			{
 				string Name { get; set; }
 			}
+
+			[Fact]
+			public void SetupAllPropertiesCanDealWithSelfReferencingTypes()
+			{
+				var mock = new Mock<INode>() { DefaultValue = DefaultValue.Mock };
+				mock.SetupAllProperties();
+				Assert.Null(mock.Object.Parent);
+			}
+
+			public interface INode
+			{
+				INode Parent { get; }
+			}
+
+			[Fact]
+			public void SetupAllPropertiesCanDealWithMutuallyReferencingTypes()
+			{
+				var mock = new Mock<IPing>() { DefaultValue = DefaultValue.Mock };
+				mock.SetupAllProperties();
+				Assert.NotNull(mock.Object.Pong);
+				Assert.Null(mock.Object.Pong.Ping);
+			}
+
+			public interface IPing
+			{
+				IPong Pong { get; }
+			}
+
+			public interface IPong
+			{
+				IPing Ping { get; }
+			}
 		}
 
 		#endregion


### PR DESCRIPTION
`mock.SetupAllProperties` recursively sets up all properties in a whole object graph, and because of this contains some logic that tries to prevent infinite loops due to recursive types. That logic works by putting the types of all encountered / "traversed" / mocked properties onto a stack, but currently forgets to ever pop them off again.

This fixes #438.