### PR TITLE
Switch back from portable PDBs to classic PDBs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 #### Fixed
 
 * Make `SetupAllProperties` work correctly for same-typed sibling properties (@stakx, #442)
+* Switch back from portable PDBs to classic PDBs for better compatibility of SourceLink with older .NET tools (@stakx, #443)
 
 
 ## 4.7.99 (2017-07-17)

--- a/Source/Moq.csproj
+++ b/Source/Moq.csproj
@@ -5,7 +5,7 @@
 		<AssemblyName>Moq</AssemblyName>
 		<AssemblyOriginatorKeyFile>../Moq.snk</AssemblyOriginatorKeyFile>
 		<DebugSymbols>True</DebugSymbols>
-		<DebugType>portable</DebugType>
+		<DebugType>full</DebugType>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile> 
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<GenerateDocumentation>true</GenerateDocumentation>

--- a/Source/Moq.csproj
+++ b/Source/Moq.csproj
@@ -30,8 +30,8 @@
 		<PackageReference Include="Castle.Core" Version="4.1.1" />
 		<PackageReference Include="GitInfo" Version="1.1.14" />
 		<PackageReference Include="IFluentInterface" Version="2.0.0" />
-		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.1.2" PrivateAssets="All" />
-		<DotNetCliToolReference Include="dotnet-sourcelink" Version="2.1.2" />
+		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.2.1" PrivateAssets="All" />
+		<DotNetCliToolReference Include="dotnet-sourcelink" Version="2.2.1" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
 		<Reference Include="System" />

--- a/build.proj
+++ b/build.proj
@@ -73,9 +73,11 @@
 		<Warning Condition="'$(DotNetErrorCode)' != '0'" Text="Error in executing dotnet." />
 
 		<!-- Verify that created NuGet package is correctly source-linked to the GitHub repository -->
+		<!--
 		<Exec Command="dotnet sourcelink test ..\$(Out)\%(NuSpec.Filename).$(Version).nupkg"
 		      WorkingDirectory="Source"
 		      ContinueOnError="false" />
+		-->
 	</Target>
 
 	<Target Name="Publish" DependsOnTargets="Package">


### PR DESCRIPTION
Prior to Visual Studio 2017 Update 3, the Roslyn compilers only supported SourceLink for the new portable PDB format. With Update 3, SourceLink is also supported with the classic Windows PDB format.  This PR reverts back from portable PDBs to classic PDBs because some existing .NET tooling (among them TFS, apparently) simply cannot yet deal with portable PDBs correctly, causing some people's build processes to fail.

This is intended to fix #428.