### PR TITLE
Make strict mocks recognize that `.CallBase()` can set up a return value, too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 * Make `SetupAllProperties` work correctly for same-typed sibling properties (@stakx, #442)
 * Switch back from portable PDBs to classic PDBs for better compatibility of SourceLink with older .NET tools (@stakx, #443)
+* Make strict mocks recognize that `.CallBase()` can set up a return value, too (@stakx, #450)
 
 
 ## 4.7.99 (2017-07-17)

--- a/Source/InterceptorStrategies.cs
+++ b/Source/InterceptorStrategies.cs
@@ -85,8 +85,7 @@ namespace Moq
 				invocation.Method.ReturnType != null &&
 				invocation.Method.ReturnType != typeof(void))
 			{
-				var methodCall = call as MethodCallReturn;
-				if (methodCall == null || !methodCall.HasReturnValue)
+				if (!(call is IMethodCallReturn methodCallReturn && methodCallReturn.ProvidesReturnValue()))
 				{
 					throw new MockException(
 						MockException.ExceptionReason.ReturnValueRequired,

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -1537,6 +1537,46 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 448
+
+		public class Issue448
+		{
+			// A strict mock requires `SetupGet` to provide a return value.
+			// If none is provided, a strict mock is expected to throw during the Act stage.
+			[Fact]
+			public void SetupGet_StrictMockThrowsIfSetupDoesNotProvideAReturnValue()
+			{
+				var mock = new Mock<Foo>(MockBehavior.Strict);
+				mock.SetupGet(f => f.BooleanProperty);
+				Assert.Throws<MockException>(() => mock.Object.BooleanProperty);
+			}
+
+			// Case 1: Providing a return value directly, via `.Returns(...)`:
+			[Fact]
+			public void SetupGet_StrictMockIdentifiesReturnsAsProvidingAReturnValue()
+			{
+				var mock = new Mock<Foo>(MockBehavior.Strict);
+				mock.SetupGet(f => f.BooleanProperty).Returns(true);
+				Assert.True(mock.Object.BooleanProperty);
+			}
+
+			// Case 2: Providing a return value indirectly, via `.CallBase()`:
+			[Fact]
+			public void SetupGet_StrictMockIdentifiesCallBaseAsProvidingAReturnValue()
+			{
+				var mock = new Mock<Foo>(MockBehavior.Strict);
+				mock.SetupGet(f => f.BooleanProperty).CallBase();
+				Assert.True(mock.Object.BooleanProperty);
+			}
+
+			public class Foo
+			{
+				public virtual bool BooleanProperty => true;
+			}
+		}
+
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47


### PR DESCRIPTION
This fixes #448.