### PR TITLE
Update Castle.Core to version 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
+## Unreleased
+
+#### Changed
+
+* Update package reference to `Castle.Core` (DynamicProxy) from version 4.1.1 to 4.2.0, which uses a new assembly versioning scheme that should eventually reduce assembly version conflicts and the need for assembly binding redirects (@stakx, #459)
+
+
 ## 4.7.127 (2017-09-26)
 
 #### Changed
@@ -32,7 +39,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 #### Changed
 
 * Move all hardcoded message strings to `Resources.resx` (@stakx, #403)
-* Update package `Castle.Core` (DynamicProxy) from version 4.1.0 to 4.1.1 (@stakx, #416)
+* Update package reference to `Castle.Core` (DynamicProxy) from version 4.1.0 to 4.1.1 (@stakx, #416)
 * Clean up and simplify the build process by merging separate .NET Framework and .NET Standard projects (@stakx, #417)
 * Replace outdated `ReleaseNotes.md` with new `CHANGELOG.md` (@stakx, #423)
 
@@ -85,7 +92,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 #### Changed
 
 * Extend `EmptyDefaultValueProvider` so it understands multidimensional arrays (return empty multidimensional arrays instead of `null`) (@stakx, #360)
-* Update package `Castle.Core` (DynamicProxy) from version 4.0.0 to 4.1.0, update `System` and `Microsoft` packages from versions 4.0.1 to 4.3.0 (@stakx, #369)
+* Update package reference to `Castle.Core` (DynamicProxy) from version 4.0.0 to 4.1.0, update `System` and `Microsoft` packages from versions 4.0.1 to 4.3.0 (@stakx, #369)
 * Clean up and reduce usage of conditional compilation (`#if`) (@stakx, #378)
 
 #### Fixed
@@ -269,7 +276,7 @@ Minor change only (add `.editorconfig` file)
 #### Changed
 
 * Reference Castle.Core as a NuGet package dependency instead of ILMerge-ing it into Moq's own assembly. (@kzu)
-* Update package GitInfo from version 1.1.14 to 1.1.15 to fix versioning issue with cached Git info (@kzu)
+* Update package reference to `GitInfo` from version 1.1.14 to 1.1.15 to fix versioning issue with cached Git info (@kzu)
 
 #### Removed
 
@@ -313,7 +320,7 @@ This version is the predecessor of 4.5.0.
 #### Changed
 
 * Migrate to .NET 4.5 and NuGet 3 (@kzu)
-* Update package GitInfo from version 1.1.13 to 1.1.14 (@kzu)
+* Update package reference to `GitInfo` from version 1.1.13 to 1.1.14 (@kzu)
 
 ### Removed
 

--- a/Moq.VisualBasicTests/project.json
+++ b/Moq.VisualBasicTests/project.json
@@ -1,6 +1,6 @@
 ﻿{
 	"dependencies": {
-		"Castle.Core": "4.1.1",
+		"Castle.Core": "4.2.0",
 		"xunit": "2.3.0-beta3-build3705",
 		"xunit.runner.visualstudio": "2.3.0-beta3-build3705"
 	},

--- a/Moq.nuspec
+++ b/Moq.nuspec
@@ -14,13 +14,13 @@
 		<releaseNotes>A changelog is available at https://github.com/moq/moq4/blob/master/CHANGELOG.md.</releaseNotes>
 		<dependencies>
 			<group targetFramework=".NETFramework4.5">
-				<dependency id="Castle.Core" version="4.1.1" />
+				<dependency id="Castle.Core" version="4.2.0" />
 			</group>
 			<group targetFramework=".NETStandard1.3">
 				<dependency id="NETStandard.Library" version="1.6.1" />
 				<dependency id="System.Linq.Queryable" version="4.3.0" />
 				<dependency id="System.Reflection.TypeExtensions" version="4.3.0" />
-				<dependency id="Castle.Core" version="4.1.1" />
+				<dependency id="Castle.Core" version="4.2.0" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/Source/Moq.csproj
+++ b/Source/Moq.csproj
@@ -27,7 +27,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Castle.Core" Version="4.1.1" />
+		<PackageReference Include="Castle.Core" Version="4.2.0" />
 		<PackageReference Include="GitInfo" Version="1.1.14" />
 		<PackageReference Include="IFluentInterface" Version="2.0.0" />
 		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.2.1" PrivateAssets="All" />

--- a/UnitTests/Moq.Tests.csproj
+++ b/UnitTests/Moq.Tests.csproj
@@ -19,7 +19,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Castle.Core" Version="4.1.1" />
+		<PackageReference Include="Castle.Core" Version="4.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
 		<PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />


### PR DESCRIPTION
Due to the new versioning scheme adopted by Castle.Core 4.2.0, problems such as #418 should be less likely to happen in the future.

This closes #425.