### PR TITLE
Let `.As<T>` mocks generate same proxy as the uncast mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 * Update package reference to `Castle.Core` (DynamicProxy) from version 4.1.1 to 4.2.0, which uses a new assembly versioning scheme that should eventually reduce assembly version conflicts and the need for assembly binding redirects (@stakx, #459)
 
+#### Fixed
+
+* `mock.Object` should always return the exact same proxy object, regardless of whether the mock has been cast to an interface via `.As<T>()` or not (@stakx, #460)
+
 
 ## 4.7.127 (2017-09-26)
 

--- a/Source/AsInterface.cs
+++ b/Source/AsInterface.cs
@@ -99,5 +99,10 @@ namespace Moq
 		{
 			return this.owner.As<TNewInterface>();
 		}
+
+		protected override object OnGetObject()
+		{
+			return this.owner.Object;
+		}
 	}
 }

--- a/UnitTests/AsInterfaceFixture.cs
+++ b/UnitTests/AsInterfaceFixture.cs
@@ -169,6 +169,8 @@ namespace Moq.Tests
 			bag.Get("test");
 		}
 
+		// see also test fixture `Issue458` in `IssueReportsFixture`
+
 		public interface IFoo
 		{
 			void Execute();

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -1577,6 +1577,28 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 458
+
+		public class Issue458
+		{
+			[Fact]
+			public void Mock_Object_always_returns_same_object_even_when_first_instantiated_through_AsInterface_cast()
+			{
+				Mock<IFoo> mock = new Mock<Foo>().As<IFoo>();
+
+				object o1 = ((Mock)mock).Object;
+				object o2 = mock.Object;
+
+				Assert.Same(o1, o2);
+			}
+
+			public interface IFoo { }
+
+			public class Foo : IFoo { }
+		}
+
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47


### PR DESCRIPTION
This closes #458.