### PR TITLE
Push to NuGet on tag, not on commit to master branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ deploy:
       secure: 7MS5+XWaFchMXFqzgneQCqo9U0DlxiPXe/KWWUnbCBDEizVn06EjdQZkWu1gbNOJ
     artifact: Package
     on:
-      branch: master
+      appveyor_repo_tag: true
 
 nuget:
   project_feed: true


### PR DESCRIPTION
Working on a separate `develop` branch rather than directly on `master` has had one big benefit, namely that not every PR merge or other commit immediately triggered a new NuGet package release. We could prepare the next release on `develop`, and then merge into `master` to publish. However, maintaining two branches introduced its own problems, e.g.:

* It is hard to predict the version number to be put into `CHANGELOG.md`, since `master` has additional merge commits that `develop` doesn't have, so [GitInfo](https://github.com/kzu/GitInfo) arrives at a different (later) version number on `master`.

* The `master` branch is still set up as default, so PRs are often made against the wrong branch.

This PR is a first step towards a different publish procedure: If all goes as planned, we can permanently merge `develop` into `master` and abandon it. Commits on `master` will no longer automatically trigger a NuGet push, only pushing a tag will have that effect. This is especially nice since we're already tagging release commits.