### PR TITLE
Update Castle.Core to version 4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
+## Unreleased
+
+#### Changed
+
+* Update package reference to `Castle.Core` (DynamicProxy) from version 4.2.0 to 4.2.1 due to a regression; see castleproject/Core#309 for details (@stakx, #482)
+
+#### Fixed
+
+* `TypeLoadException`s ("Method does not have an implementation") caused by the regression above, see e.g. #469 (@stakx, #482)
+
+
 ## 4.7.137 (2017-09-30)
 
 #### Changed

--- a/Moq.VisualBasicTests/project.json
+++ b/Moq.VisualBasicTests/project.json
@@ -1,6 +1,6 @@
 ﻿{
 	"dependencies": {
-		"Castle.Core": "4.2.0",
+		"Castle.Core": "4.2.1",
 		"xunit": "2.3.0-beta3-build3705",
 		"xunit.runner.visualstudio": "2.3.0-beta3-build3705"
 	},

--- a/Moq.nuspec
+++ b/Moq.nuspec
@@ -14,13 +14,13 @@
 		<releaseNotes>A changelog is available at https://github.com/moq/moq4/blob/master/CHANGELOG.md.</releaseNotes>
 		<dependencies>
 			<group targetFramework=".NETFramework4.5">
-				<dependency id="Castle.Core" version="4.2.0" />
+				<dependency id="Castle.Core" version="4.2.1" />
 			</group>
 			<group targetFramework=".NETStandard1.3">
 				<dependency id="NETStandard.Library" version="1.6.1" />
 				<dependency id="System.Linq.Queryable" version="4.3.0" />
 				<dependency id="System.Reflection.TypeExtensions" version="4.3.0" />
-				<dependency id="Castle.Core" version="4.2.0" />
+				<dependency id="Castle.Core" version="4.2.1" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/Source/Moq.csproj
+++ b/Source/Moq.csproj
@@ -27,7 +27,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Castle.Core" Version="4.2.0" />
+		<PackageReference Include="Castle.Core" Version="4.2.1" />
 		<PackageReference Include="GitInfo" Version="1.1.14" />
 		<PackageReference Include="IFluentInterface" Version="2.0.0" />
 		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.2.1" PrivateAssets="All" />

--- a/UnitTests/Moq.Tests.csproj
+++ b/UnitTests/Moq.Tests.csproj
@@ -19,7 +19,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Castle.Core" Version="4.2.0" />
+		<PackageReference Include="Castle.Core" Version="4.2.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
 		<PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -1603,8 +1603,7 @@ namespace Moq.Tests.Regressions
 
 		public class Issue469
 		{
-			[Fact(Skip =
-				"Temporarily disabled due to a regression in Castle Core, see https://github.com/castleproject/Core/issues/309.")]
+			[Fact]
 			public void Mock_Object_should_be_able_to_mock_interface_with_overloaded_generic_methods_with_generic_parameters()
 			{
 				object dummy = new Mock<IHaveOverloadedGenericMethod>().Object;

--- a/UnitTests/Regressions/IssueReportsFixture.cs
+++ b/UnitTests/Regressions/IssueReportsFixture.cs
@@ -1599,6 +1599,38 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 469
+
+		public class Issue469
+		{
+			[Fact(Skip =
+				"Temporarily disabled due to a regression in Castle Core, see https://github.com/castleproject/Core/issues/309.")]
+			public void Mock_Object_should_be_able_to_mock_interface_with_overloaded_generic_methods_with_generic_parameters()
+			{
+				object dummy = new Mock<IHaveOverloadedGenericMethod>().Object;
+			}
+
+			public interface IHaveOverloadedGenericMethod
+			{
+				void GenericMethod<T>(GenericClass1<T> a);
+				void GenericMethod<T>(GenericClass2<T> a);
+			}
+
+			public abstract class BaseType<T>
+			{
+			}
+
+			public class GenericClass1<T> : BaseType<T>
+			{
+			}
+
+			public class GenericClass2<T> : BaseType<T>
+			{
+			}
+		}
+
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47


### PR DESCRIPTION
This new version of Castle DynamicProxy is a "hotfix" release for a regression; see castleproject/Core#309.

This closes #469 and #470.