### PR TITLE
 Record calls to methods with event accessor-like names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 #### Fixed
 
 * Update a method's invocation count correctly, even when it is set up to throw an exception (@stakx, #473)
+* Record calls to methods that are named like event accessors (`add_X`, `remove_X`) so they can be verified (@stakx, #488)
 
 
 ## 4.7.142 (2017-10-11)

--- a/Moq.Tests/VerifyFixture.cs
+++ b/Moq.Tests/VerifyFixture.cs
@@ -981,6 +981,22 @@ namespace Moq.Tests
 			});
 		}
 
+		[Fact]
+		public void CanVerifyMethodThatIsNamedLikeEventAddAccessor()
+		{
+			var mock = new Mock<IHaveMethodsNamedLikeEventAccessors>();
+			mock.Object.add_Something();
+			mock.Verify(m => m.add_Something(), Times.Once);
+		}
+
+		[Fact]
+		public void CanVerifyMethodThatIsNamedLikeEventRemoveAccessor()
+		{
+			var mock = new Mock<IHaveMethodsNamedLikeEventAccessors>();
+			mock.Object.remove_Something();
+			mock.Verify(m => m.remove_Something(), Times.Once);
+		}
+
 		public interface IBar
 		{
 			int? Value { get; set; }
@@ -1018,6 +1034,12 @@ namespace Moq.Tests
 		public interface IArrays
 		{
 			void Method(string[] strings);
+		}
+
+		public interface IHaveMethodsNamedLikeEventAccessors
+		{
+			void add_Something();
+			void remove_Something();
 		}
 	}
 }

--- a/Source/InterceptorStrategies.cs
+++ b/Source/InterceptorStrategies.cs
@@ -255,9 +255,6 @@ namespace Moq
 							return InterceptionAction.Stop;
 						}
 					}
-
-					// wasn't an event attach accessor after all
-					return InterceptionAction.Continue;
 				}
 				else if (invocation.Method.LooksLikeEventDetach())
 				{
@@ -279,9 +276,6 @@ namespace Moq
 							return InterceptionAction.Stop;
 						}
 					}
-
-					// wasn't an event detach accessor after all
-					return InterceptionAction.Continue;
 				}
 
 				// Save to support Verify[expression] pattern.


### PR DESCRIPTION
This resolves #487. Should have been fixed back with #376.