### PR TITLE
Introduce `.Protected().As<TDuck>()` to perform duck-typed setup and verification of protected members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * Support for sequential setup of `void` methods (@alexbestul, #463)
 * Support for sequential setups (`SetupSequence`) of protected members (@stakx, #493)
 * Support for callbacks for methods having `ref` or `out` parameters via two new overloads of `Callback` and `Returns` (@stakx, #468)
+* Improved support for setting up and verifying protected members (including generic methods and methods having by-ref parameters) via the new duck-typing `mock.Protected().As<TDuck>()` interface (@stakx, #495)
 
 #### Changed
 

--- a/Moq.Tests/ProtectedAsMockFixture.cs
+++ b/Moq.Tests/ProtectedAsMockFixture.cs
@@ -1,0 +1,145 @@
+﻿using Moq.Protected;
+using System;
+using Xunit;
+
+namespace Moq.Tests
+{
+    public class ProtectedAsMockFixture
+    {
+		private Mock<Foo> mock;
+		private IProtectedAsMock<Foo, Fooish> protectedMock;
+
+		public ProtectedAsMockFixture()
+		{
+			this.mock = new Mock<Foo>();
+			this.protectedMock = this.mock.Protected().As<Fooish>();
+		}
+
+		[Fact]
+		public void Setup_throws_when_expression_null()
+		{
+			var actual = Record.Exception(() =>
+			{
+				this.protectedMock.Setup(null);
+			});
+
+			Assert.IsType<ArgumentNullException>(actual);
+		}
+
+		[Fact]
+		public void Setup_throws_ArgumentException_when_expression_contains_nonexistent_method()
+		{
+			var actual = Record.Exception(() =>
+			{
+				this.protectedMock.Setup(m => m.NonExistentMethod());
+			});
+
+			Assert.IsType<ArgumentException>(actual);
+			Assert.Contains("does not have matching protected member", actual.Message);
+		}
+
+		[Fact]
+		public void Setup_throws_ArgumentException_when_expression_contains_nonexistent_property()
+		{
+			var actual = Record.Exception(() =>
+			{
+				this.protectedMock.Setup(m => m.NonExistentProperty);
+			});
+
+			Assert.IsType<ArgumentException>(actual);
+			Assert.Contains("does not have matching protected member", actual.Message);
+		}
+
+		[Fact]
+		public void Setup_TResult_throws_when_expression_null()
+		{
+			var actual = Record.Exception(() => this.protectedMock.Setup<object>(null));
+
+			Assert.IsType<ArgumentNullException>(actual);
+		}
+
+		[Fact]
+		public void Setup_can_setup_simple_method()
+		{
+			bool doSomethingImplInvoked = false;
+			this.protectedMock.Setup(m => m.DoSomethingImpl()).Callback(() => doSomethingImplInvoked = true);
+
+			this.mock.Object.DoSomething();
+
+			Assert.True(doSomethingImplInvoked);
+		}
+
+		[Fact]
+		public void Setup_TResult_can_setup_simple_method_with_return_value()
+		{
+			this.protectedMock.Setup(m => m.GetSomethingImpl()).Returns(() => 42);
+
+			var actual = this.mock.Object.GetSomething();
+
+			Assert.Equal(42, actual);
+		}
+
+		[Fact]
+		public void Setup_can_match_exact_arguments()
+		{
+			bool doSomethingImplInvoked = false;
+			this.protectedMock.Setup(m => m.DoSomethingImpl(1)).Callback(() => doSomethingImplInvoked = true);
+
+			this.mock.Object.DoSomething(0);
+			Assert.False(doSomethingImplInvoked);
+
+			this.mock.Object.DoSomething(1);
+			Assert.True(doSomethingImplInvoked);
+		}
+
+		[Fact]
+		public void Setup_can_involve_matchers()
+		{
+			bool doSomethingImplInvoked = false;
+			this.protectedMock.Setup(m => m.DoSomethingImpl(It.Is<int>(i => i == 1))).Callback(() => doSomethingImplInvoked = true);
+
+			this.mock.Object.DoSomething(0);
+			Assert.False(doSomethingImplInvoked);
+
+			this.mock.Object.DoSomething(1);
+			Assert.True(doSomethingImplInvoked);
+		}
+
+		public abstract class Foo
+		{
+			protected Foo()
+			{
+			}
+
+			public void DoSomething()
+			{
+				this.DoSomethingImpl();
+			}
+
+			public void DoSomething(int arg)
+			{
+				this.DoSomethingImpl(arg);
+			}
+
+			public int GetSomething()
+			{
+				return this.GetSomethingImpl();
+			}
+
+			protected abstract void DoSomethingImpl();
+
+			protected abstract void DoSomethingImpl(int arg);
+
+			protected abstract int GetSomethingImpl();
+		}
+
+		public interface Fooish
+		{
+			int NonExistentProperty { get; }
+			void DoSomethingImpl();
+			void DoSomethingImpl(int arg);
+			int GetSomethingImpl();
+			void NonExistentMethod();
+		}
+    }
+}

--- a/Moq.Tests/ProtectedAsMockFixture.cs
+++ b/Moq.Tests/ProtectedAsMockFixture.cs
@@ -191,6 +191,81 @@ namespace Moq.Tests
 			Assert.IsType<InvalidOperationException>(exception);
 		}
 
+		[Fact]
+		public void Verify_can_verify_method_invocations()
+		{
+			this.mock.Object.DoSomething();
+
+			this.protectedMock.Verify(m => m.DoSomethingImpl());
+		}
+
+		[Fact]
+		public void Verify_throws_if_invocation_not_occurred()
+		{
+			var exception = Record.Exception(() =>
+			{
+				this.protectedMock.Verify(m => m.DoSomethingImpl());
+			});
+
+			Assert.IsType<MockException>(exception);
+		}
+
+		[Fact]
+		public void Verify_can_verify_method_invocations_times()
+		{
+			this.mock.Object.DoSomething();
+			this.mock.Object.DoSomething();
+			this.mock.Object.DoSomething();
+
+			this.protectedMock.Verify(m => m.DoSomethingImpl(), Times.Exactly(3));
+		}
+
+		[Fact]
+		public void Verify_includes_failure_message_in_exception()
+		{
+			this.mock.Object.DoSomething();
+			this.mock.Object.DoSomething();
+
+			var exception = Record.Exception(() =>
+			{
+				this.protectedMock.Verify(m => m.DoSomethingImpl(), Times.Exactly(3), "Wasn't called three times.");
+			});
+
+			Assert.IsType<MockException>(exception);
+			Assert.Contains("Wasn't called three times.", exception.Message);
+		}
+
+		[Fact]
+		public void VerifyGet_can_verify_properties()
+		{
+			var _ = this.mock.Object.ReadOnlyProperty;
+
+			this.protectedMock.VerifyGet(m => m.ReadOnlyPropertyImpl);
+		}
+
+		[Fact]
+		public void VerifyGet_throws_if_property_query_not_occurred()
+		{
+			var _ = this.mock.Object.ReadOnlyProperty;
+
+			var exception = Record.Exception(() =>
+			{
+				this.protectedMock.VerifyGet(m => m.ReadOnlyPropertyImpl, Times.AtLeast(2));
+			});
+		}
+
+		[Fact]
+		public void VerifyGet_includes_failure_message_in_exception()
+		{
+			var exception = Record.Exception(() =>
+			{
+				this.protectedMock.VerifyGet(m => m.ReadOnlyPropertyImpl, Times.Once(), "Was not queried.");
+			});
+
+			Assert.IsType<MockException>(exception);
+			Assert.Contains("Was not queried.", exception.Message);
+		}
+
 		public abstract class Foo
 		{
 			protected Foo()

--- a/Source/Properties/Resources.Designer.cs
+++ b/Source/Properties/Resources.Designer.cs
@@ -11,7 +11,7 @@
 namespace Moq.Properties {
 	using System;
 	using System.Reflection;
-
+	
 	/// <summary>
 	///   A strongly-typed resource class, for looking up localized strings, etc.
 	/// </summary>
@@ -104,7 +104,7 @@ namespace Moq.Properties {
 				return ResourceManager.GetString("ConfiguredSetups", resourceCulture);
 			}
 		}
-
+		
 		/// <summary>
 		///   Looks up a localized string similar to Constructor arguments cannot be passed for delegate mocks..
 		/// </summary>
@@ -140,7 +140,7 @@ namespace Moq.Properties {
 				return ResourceManager.GetString("DelaysMustBeGreaterThanZero", resourceCulture);
 			}
 		}
-
+		
 		/// <summary>
 		///   Looks up a localized string similar to Could not locate event for attach or detach method {0}..
 		/// </summary>
@@ -158,7 +158,7 @@ namespace Moq.Properties {
 				return ResourceManager.GetString("ExpressionIsNotEventAttachOrDetachOrIsNotVirtual", resourceCulture);
 			}
 		}
-
+		
 		/// <summary>
 		///   Looks up a localized string similar to Expression {0} involves a field access, which is not supported. Use properties instead..
 		/// </summary>
@@ -176,7 +176,7 @@ namespace Moq.Properties {
 				return ResourceManager.GetString("InvalidCallbackNotADelegateWithReturnTypeVoid", resourceCulture);
 			}
 		}
-
+		
 		/// <summary>
 		///   Looks up a localized string similar to Invalid callback. Setup on method with parameters ({0}) cannot invoke callback with parameters ({1})..
 		/// </summary>
@@ -185,7 +185,7 @@ namespace Moq.Properties {
 				return ResourceManager.GetString("InvalidCallbackParameterMismatch", resourceCulture);
 			}
 		}
-
+		
 		/// <summary>
 		///   Looks up a localized string similar to Type to mock must be an interface or an abstract or non-sealed class. .
 		/// </summary>
@@ -214,7 +214,7 @@ namespace Moq.Properties {
 				return ResourceManager.GetString("InvalidReturnsCallbackNotADelegateWithReturnType", resourceCulture);
 			}
 		}
-
+		
 		/// <summary>
 		///   Looks up a localized string similar to The equals (&quot;==&quot; or &quot;=&quot; in VB) and the conditional &apos;and&apos; (&quot;&amp;&amp;&quot; or &quot;AndAlso&quot; in VB) operators are the only ones supported in the query specification expression. Unsupported expression: {0}.
 		/// </summary>
@@ -261,7 +261,7 @@ namespace Moq.Properties {
 				return ResourceManager.GetString("MethodIsPublic", resourceCulture);
 			}
 		}
-
+		
 		/// <summary>
 		///   Looks up a localized string similar to Cannot set up {0}.{1} because it is not accessible to the proxy generator used by Moq:
 		///{2}.
@@ -271,7 +271,7 @@ namespace Moq.Properties {
 				return ResourceManager.GetString("MethodNotVisibleToProxyFactory", resourceCulture);
 			}
 		}
-
+		
 		/// <summary>
 		///   Looks up a localized string similar to Mininum delay has to be lower than maximum delay..
 		/// </summary>
@@ -280,7 +280,7 @@ namespace Moq.Properties {
 				return ResourceManager.GetString("MinDelayMustBeLessThanMaxDelay", resourceCulture);
 			}
 		}
-
+		
 		/// <summary>
 		///   Looks up a localized string similar to {0} invocation failed with mock behavior {1}.
 		///{2}.
@@ -317,7 +317,7 @@ namespace Moq.Properties {
 				return ResourceManager.GetString("NoInvocationsPerformed", resourceCulture);
 			}
 		}
-
+		
 		/// <summary>
 		///   Looks up a localized string similar to {0}
 		///Expected invocation on the mock at least {2} times, but was {4} times: {1}.
@@ -425,7 +425,7 @@ namespace Moq.Properties {
 				return ResourceManager.GetString("NoSetupsConfigured", resourceCulture);
 			}
 		}
-
+		
 		/// <summary>
 		///   Looks up a localized string similar to Object instance was not created by Moq..
 		/// </summary>
@@ -452,7 +452,7 @@ namespace Moq.Properties {
 				return ResourceManager.GetString("PerformedInvocations", resourceCulture);
 			}
 		}
-
+		
 		/// <summary>
 		///   Looks up a localized string similar to Property {0}.{1} does not have a getter..
 		/// </summary>
@@ -495,6 +495,15 @@ namespace Moq.Properties {
 		internal static string PropertySetNotFound {
 			get {
 				return ResourceManager.GetString("PropertySetNotFound", resourceCulture);
+			}
+		}
+		
+		/// <summary>
+		///   Looks up a localized string similar to Type {0} does not have matching protected member: {1}.
+		/// </summary>
+		internal static string ProtectedMemberNotFound {
+			get {
+				return ResourceManager.GetString("ProtectedMemberNotFound", resourceCulture);
 			}
 		}
 		
@@ -596,7 +605,7 @@ namespace Moq.Properties {
 				return ResourceManager.GetString("SetupOnStaticMember", resourceCulture);
 			}
 		}
-
+		
 		/// <summary>
 		///   Looks up a localized string similar to Type {0} does not implement required interface {1}.
 		/// </summary>
@@ -636,7 +645,7 @@ namespace Moq.Properties {
 				return ResourceManager.GetString("UnexpectedTranslationOfMemberAccess", resourceCulture);
 			}
 		}
-
+		
 		/// <summary>
 		///   Looks up a localized string similar to Unhandled binding type: {0}.
 		/// </summary>
@@ -645,7 +654,7 @@ namespace Moq.Properties {
 				return ResourceManager.GetString("UnhandledBindingType", resourceCulture);
 			}
 		}
-
+		
 		/// <summary>
 		///   Looks up a localized string similar to Unhandled expression type: {0}.
 		/// </summary>
@@ -654,7 +663,7 @@ namespace Moq.Properties {
 				return ResourceManager.GetString("UnhandledExpressionType", resourceCulture);
 			}
 		}
-
+		
 		/// <summary>
 		///   Looks up a localized string similar to Unsupported expression: {0}.
 		/// </summary>
@@ -717,7 +726,7 @@ namespace Moq.Properties {
 				return ResourceManager.GetString("UseItExprIsNullRatherThanNullArgumentValue", resourceCulture);
 			}
 		}
-
+		
 		/// <summary>
 		///   Looks up a localized string similar to The following setups were not matched:
 		///{0}.
@@ -736,7 +745,7 @@ namespace Moq.Properties {
 				return ResourceManager.GetString("VerifyOnExtensionMethod", resourceCulture);
 			}
 		}
-
+		
 		/// <summary>
 		///   Looks up a localized string similar to Invalid verify on a non-virtual (overridable in VB) member: {0}.
 		/// </summary>
@@ -745,7 +754,7 @@ namespace Moq.Properties {
 				return ResourceManager.GetString("VerifyOnNonVirtualMember", resourceCulture);
 			}
 		}
-
+		
 		/// <summary>
 		///   Looks up a localized string similar to Invalid verify on a static member: {0}.
 		/// </summary>

--- a/Source/Properties/Resources.resx
+++ b/Source/Properties/Resources.resx
@@ -362,4 +362,7 @@ Expected invocation on the mock once, but was {4} times: {1}</value>
 	<data name="InvalidReturnsCallbackNotADelegateWithReturnType" xml:space="preserve">
 		<value>Invalid callback. This overload of the "Returns" method only accepts non-"void" (C#) or "Function" (VB.NET) delegates with parameter types matching those of the set up method.</value>
 	</data>
+	<data name="ProtectedMemberNotFound" xml:space="preserve">
+		<value>Type {0} does not have matching protected member: {1}</value>
+	</data>
 </root>

--- a/Source/Protected/IProtectedAsMock.cs
+++ b/Source/Protected/IProtectedAsMock.cs
@@ -1,0 +1,76 @@
+﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//https://github.com/moq/moq4
+//All rights reserved.
+
+//Redistribution and use in source and binary forms, 
+//with or without modification, are permitted provided 
+//that the following conditions are met:
+
+//    * Redistributions of source code must retain the 
+//    above copyright notice, this list of conditions and 
+//    the following disclaimer.
+
+//    * Redistributions in binary form must reproduce 
+//    the above copyright notice, this list of conditions 
+//    and the following disclaimer in the documentation 
+//    and/or other materials provided with the distribution.
+
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
+//    names of its contributors may be used to endorse 
+//    or promote products derived from this software 
+//    without specific prior written permission.
+
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+//SUCH DAMAGE.
+
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System;
+using System.Linq.Expressions;
+
+using Moq.Language.Flow;
+
+namespace Moq.Protected
+{
+	/// <summary>
+	/// Allows setups to be specified for protected members (methods and properties)
+	/// seen through another type with corresponding members (that is, members
+	/// having identical signatures as the ones to be set up).
+	/// </summary>
+	/// <typeparam name="T">Type of the mocked object.</typeparam>
+	/// <typeparam name="TDuck">
+	/// Any type with members whose signatures are identical to the mock's protected members (except for their accessibility level).
+	/// </typeparam>
+	public interface IProtectedAsMock<T, TDuck> : IFluentInterface
+		where T : class
+		where TDuck : class
+    {
+		/// <summary>
+		/// Specifies a setup on the mocked type for a call to a <see langword="void"/> method.
+		/// </summary>
+		/// <param name="expression">Lambda expression that specifies the expected method invocation.</param>
+		/// <seealso cref="Mock{T}.Setup(Expression{Action{T}})"/>
+		ISetup<T> Setup(Expression<Action<TDuck>> expression);
+
+		/// <summary>
+		/// Specifies a setup on the mocked type for a call to a value-returning method.
+		/// </summary>
+		/// <typeparam name="TResult">Type of the return value. Typically omitted as it can be inferred from the expression.</typeparam>
+		/// <param name="expression">Lambda expression that specifies the expected method invocation.</param>
+		/// <seealso cref="Mock{T}.Setup{TResult}(Expression{Func{T, TResult}})"/>
+		ISetup<T, TResult> Setup<TResult>(Expression<Func<TDuck, TResult>> expression);
+	}
+}

--- a/Source/Protected/IProtectedAsMock.cs
+++ b/Source/Protected/IProtectedAsMock.cs
@@ -39,6 +39,7 @@
 // http://www.opensource.org/licenses/bsd-license.php]
 
 using System;
+using System.ComponentModel;
 using System.Linq.Expressions;
 
 using Moq.Language;
@@ -101,7 +102,47 @@ namespace Moq.Protected
 		/// <summary>
 		/// Performs a sequence of actions, one per call.
 		/// </summary>
-		/// <param name="expression">Lambda expression that specifeid the expected method invocation.</param>
+		/// <param name="expression">Lambda expression that specifies the expected method invocation.</param>
 		ISetupSequentialAction SetupSequence(Expression<Action<TDuck>> expression);
+
+		/// <summary>
+		/// Verifies that a specific invocation matching the given expression was performed on the mock.
+		/// Use in conjunction with the default <see cref="MockBehavior.Loose"/>.
+		/// </summary>
+		/// <param name="expression">Lambda expression that specifies the method invocation.</param>
+		/// <param name="times">
+		/// Number of times that the invocation is expected to have occurred.
+		/// If omitted, assumed to be <see cref="Times.AtLeastOnce"/>.
+		/// </param>
+		/// <param name="failMessage">Message to include in the thrown <see cref="MockException"/> if verification fails.</param>
+		/// <exception cref="MockException">The specified invocation did not occur (or did not occur the specified number of times).</exception>
+		void Verify(Expression<Action<TDuck>> expression, Times? times = null, string failMessage = null);
+
+		/// <summary>
+		/// Verifies that a specific invocation matching the given expression was performed on the mock.
+		/// Use in conjunction with the default <see cref="MockBehavior.Loose"/>.
+		/// </summary>
+		/// <typeparam name="TResult">Type of the return value. Typically omitted as it can be inferred from the expression.</typeparam>
+		/// <param name="expression">Lambda expression that specifies the method invocation.</param>
+		/// <param name="times">
+		/// Number of times that the invocation is expected to have occurred.
+		/// If omitted, assumed to be <see cref="Times.AtLeastOnce"/>.
+		/// </param>
+		/// <param name="failMessage">Message to include in the thrown <see cref="MockException"/> if verification fails.</param>
+		/// <exception cref="MockException">The specified invocation did not occur (or did not occur the specified number of times).</exception>
+		void Verify<TResult>(Expression<Func<TDuck, TResult>> expression, Times? times = null, string failMessage = null);
+
+		/// <summary>
+		/// Verifies that a property was read on the mock.
+		/// </summary>
+		/// <typeparam name="TProperty">Type of the property. Typically omitted as it can be inferred from the expression.</typeparam>
+		/// <param name="expression">Lambda expression that specifies the method invocation.</param>
+		/// <param name="times">
+		/// Number of times that the invocation is expected to have occurred.
+		/// If omitted, assumed to be <see cref="Times.AtLeastOnce"/>.
+		/// </param>
+		/// <param name="failMessage">Message to include in the thrown <see cref="MockException"/> if verification fails.</param>
+		/// <exception cref="MockException">The specified invocation did not occur (or did not occur the specified number of times).</exception>
+		void VerifyGet<TProperty>(Expression<Func<TDuck, TProperty>> expression, Times? times = null, string failMessage = null);
 	}
 }

--- a/Source/Protected/IProtectedAsMock.cs
+++ b/Source/Protected/IProtectedAsMock.cs
@@ -41,6 +41,7 @@
 using System;
 using System.Linq.Expressions;
 
+using Moq.Language;
 using Moq.Language.Flow;
 
 namespace Moq.Protected
@@ -72,5 +73,35 @@ namespace Moq.Protected
 		/// <param name="expression">Lambda expression that specifies the expected method invocation.</param>
 		/// <seealso cref="Mock{T}.Setup{TResult}(Expression{Func{T, TResult}})"/>
 		ISetup<T, TResult> Setup<TResult>(Expression<Func<TDuck, TResult>> expression);
+
+		/// <summary>
+		/// Specifies a setup on the mocked type for a call to a property getter.
+		/// </summary>
+		/// <typeparam name="TProperty">Type of the property. Typically omitted as it can be inferred from the expression.</typeparam>
+		/// <param name="expression">Lambda expression that specifies the property getter.</param>
+		ISetupGetter<T, TProperty> SetupGet<TProperty>(Expression<Func<TDuck, TProperty>> expression);
+
+		/// <summary>
+		/// Specifies that the given property should have "property behavior",
+		/// meaning that setting its value will cause it to be saved and later returned when the property is requested.
+		/// (This is also known as "stubbing".)
+		/// </summary>
+		/// <typeparam name="TProperty">Type of the property. Typically omitted as it can be inferred from the expression.</typeparam>
+		/// <param name="expression">Lambda expression that specifies the property.</param>
+		/// <param name="initialValue">Initial value for the property.</param>
+		Mock<T> SetupProperty<TProperty>(Expression<Func<TDuck, TProperty>> expression, TProperty initialValue = default(TProperty));
+
+		/// <summary>
+		/// Return a sequence of values, once per call.
+		/// </summary>
+		/// <typeparam name="TResult">Type of the return value. Typically omitted as it can be inferred from the expression.</typeparam>
+		/// <param name="expression">Lambda expression that specifies the expected method invocation.</param>
+		ISetupSequentialResult<TResult> SetupSequence<TResult>(Expression<Func<TDuck, TResult>> expression);
+
+		/// <summary>
+		/// Performs a sequence of actions, one per call.
+		/// </summary>
+		/// <param name="expression">Lambda expression that specifeid the expected method invocation.</param>
+		ISetupSequentialAction SetupSequence(Expression<Action<TDuck>> expression);
 	}
 }

--- a/Source/Protected/IProtectedMock.cs
+++ b/Source/Protected/IProtectedMock.cs
@@ -53,6 +53,15 @@ namespace Moq.Protected
 	public interface IProtectedMock<TMock> : IFluentInterface
 		where TMock : class
 	{
+		/// <summary>
+		/// Set up protected members (methods and properties) seen through another type with identical member signatures.
+		/// </summary>
+		/// <typeparam name="TDuck">
+		/// Any type with members whose signatures are identical to the mock's protected members (except for their accessibility level).
+		/// </typeparam>
+		IProtectedAsMock<TMock, TDuck> As<TDuck>()
+			where TDuck : class;
+
 		#region Setup
 
 		/// <summary>

--- a/Source/Protected/ProtectedAsMock.cs
+++ b/Source/Protected/ProtectedAsMock.cs
@@ -44,6 +44,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
+using Moq.Language;
 using Moq.Language.Flow;
 using Moq.Properties;
 
@@ -85,17 +86,85 @@ namespace Moq.Protected
 		{
 			Guard.NotNull(expression, nameof(expression));
 
-			Expression<Func<T, TResult>> rewrittenException;
+			Expression<Func<T, TResult>> rewrittenExpression;
 			try
 			{
-				rewrittenException = (Expression<Func<T, TResult>>)ReplaceDuck(expression);
+				rewrittenExpression = (Expression<Func<T, TResult>>)ReplaceDuck(expression);
 			}
 			catch (ArgumentException ex)
 			{
 				throw new ArgumentException(ex.Message, nameof(expression));
 			}
 
-			return Mock.Setup(this.mock, rewrittenException, null);
+			return Mock.Setup(this.mock, rewrittenExpression, null);
+		}
+
+		public ISetupGetter<T, TProperty> SetupGet<TProperty>(Expression<Func<TDuck, TProperty>> expression)
+		{
+			Guard.NotNull(expression, nameof(expression));
+
+			Expression<Func<T, TProperty>> rewrittenExpression;
+			try
+			{
+				rewrittenExpression = (Expression<Func<T, TProperty>>)ReplaceDuck(expression);
+			}
+			catch (ArgumentException ex)
+			{
+				throw new ArgumentException(ex.Message, nameof(expression));
+			}
+
+			return Mock.SetupGet(this.mock, rewrittenExpression, null);
+		}
+
+		public Mock<T> SetupProperty<TProperty>(Expression<Func<TDuck, TProperty>> expression, TProperty initialValue = default(TProperty))
+		{
+			Guard.NotNull(expression, nameof(expression));
+
+			Expression<Func<T, TProperty>> rewrittenExpression;
+			try
+			{
+				rewrittenExpression = (Expression<Func<T, TProperty>>)ReplaceDuck(expression);
+			}
+			catch (ArgumentException ex)
+			{
+				throw new ArgumentException(ex.Message, nameof(expression));
+			}
+
+			return this.mock.SetupProperty<TProperty>(rewrittenExpression, initialValue);
+		}
+
+		public ISetupSequentialResult<TResult> SetupSequence<TResult>(Expression<Func<TDuck, TResult>> expression)
+		{
+			Guard.NotNull(expression, nameof(expression));
+
+			Expression<Func<T, TResult>> rewrittenExpression;
+			try
+			{
+				rewrittenExpression = (Expression<Func<T, TResult>>)ReplaceDuck(expression);
+			}
+			catch (ArgumentException ex)
+			{
+				throw new ArgumentException(ex.Message, nameof(expression));
+			}
+
+			return Mock.SetupSequence<TResult>(this.mock, rewrittenExpression);
+		}
+
+		public ISetupSequentialAction SetupSequence(Expression<Action<TDuck>> expression)
+		{
+			Guard.NotNull(expression, nameof(expression));
+
+			Expression<Action<T>> rewrittenExpression;
+			try
+			{
+				rewrittenExpression = (Expression<Action<T>>)ReplaceDuck(expression);
+			}
+			catch (ArgumentException ex)
+			{
+				throw new ArgumentException(ex.Message, nameof(expression));
+			}
+
+			return Mock.SetupSequence(this.mock, rewrittenExpression);
 		}
 
 		private static LambdaExpression ReplaceDuck(LambdaExpression expression)

--- a/Source/Protected/ProtectedAsMock.cs
+++ b/Source/Protected/ProtectedAsMock.cs
@@ -167,6 +167,57 @@ namespace Moq.Protected
 			return Mock.SetupSequence(this.mock, rewrittenExpression);
 		}
 
+		public void Verify(Expression<Action<TDuck>> expression, Times? times = null, string failMessage = null)
+		{
+			Guard.NotNull(expression, nameof(expression));
+
+			Expression<Action<T>> rewrittenExpression;
+			try
+			{
+				rewrittenExpression = (Expression<Action<T>>)ReplaceDuck(expression);
+			}
+			catch (ArgumentException ex)
+			{
+				throw new ArgumentException(ex.Message, nameof(expression));
+			}
+
+			Mock.Verify(this.mock, rewrittenExpression, times ?? Times.AtLeastOnce(), failMessage);
+		}
+
+		public void Verify<TResult>(Expression<Func<TDuck, TResult>> expression, Times? times = null, string failMessage = null)
+		{
+			Guard.NotNull(expression, nameof(expression));
+
+			Expression<Func<T, TResult>> rewrittenExpression;
+			try
+			{
+				rewrittenExpression = (Expression<Func<T, TResult>>)ReplaceDuck(expression);
+			}
+			catch (ArgumentException ex)
+			{
+				throw new ArgumentException(ex.Message, nameof(expression));
+			}
+
+			Mock.Verify(this.mock, rewrittenExpression, times ?? Times.AtLeastOnce(), failMessage);
+		}
+
+		public void VerifyGet<TProperty>(Expression<Func<TDuck, TProperty>> expression, Times? times = null, string failMessage = null)
+		{
+			Guard.NotNull(expression, nameof(expression));
+
+			Expression<Func<T, TProperty>> rewrittenExpression;
+			try
+			{
+				rewrittenExpression = (Expression<Func<T, TProperty>>)ReplaceDuck(expression);
+			}
+			catch (ArgumentException ex)
+			{
+				throw new ArgumentException(ex.Message, nameof(expression));
+			}
+
+			Mock.VerifyGet(this.mock, rewrittenExpression, times ?? Times.AtLeastOnce(), failMessage);
+		}
+
 		private static LambdaExpression ReplaceDuck(LambdaExpression expression)
 		{
 			Debug.Assert(expression.Parameters.Count == 1);

--- a/Source/Protected/ProtectedAsMock.cs
+++ b/Source/Protected/ProtectedAsMock.cs
@@ -1,0 +1,231 @@
+﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//https://github.com/moq/moq4
+//All rights reserved.
+
+//Redistribution and use in source and binary forms, 
+//with or without modification, are permitted provided 
+//that the following conditions are met:
+
+//    * Redistributions of source code must retain the 
+//    above copyright notice, this list of conditions and 
+//    the following disclaimer.
+
+//    * Redistributions in binary form must reproduce 
+//    the above copyright notice, this list of conditions 
+//    and the following disclaimer in the documentation 
+//    and/or other materials provided with the distribution.
+
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
+//    names of its contributors may be used to endorse 
+//    or promote products derived from this software 
+//    without specific prior written permission.
+
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+//SUCH DAMAGE.
+
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+using Moq.Language.Flow;
+
+namespace Moq.Protected
+{
+	internal sealed class ProtectedAsMock<T, TDuck> : IProtectedAsMock<T, TDuck>
+		where T : class
+		where TDuck : class
+    {
+		private Mock<T> mock;
+
+		private static DuckReplacer DuckReplacerInstance = new DuckReplacer(typeof(TDuck), typeof(T));
+
+		public ProtectedAsMock(Mock<T> mock)
+		{
+			this.mock = mock;
+		}
+
+		public ISetup<T> Setup(Expression<Action<TDuck>> expression)
+		{
+			return Mock.Setup(this.mock, (Expression<Action<T>>)ReplaceDuck(expression), null);
+		}
+
+		public ISetup<T, TResult> Setup<TResult>(Expression<Func<TDuck, TResult>> expression)
+		{
+			return Mock.Setup(this.mock, (Expression<Func<T, TResult>>)ReplaceDuck(expression), null);
+		}
+
+		private static LambdaExpression ReplaceDuck(LambdaExpression expression)
+		{
+			var targetParameter = Expression.Parameter(typeof(T), expression.Parameters[0].Name);
+			return Expression.Lambda(DuckReplacerInstance.Visit(expression.Body), targetParameter);
+		}
+
+		/// <summary>
+		/// <see cref="ExpressionVisitor"/> used to replace occurrences of `TDuck.Member` sub-expressions with `T.Member`.
+		/// </summary>
+		private sealed class DuckReplacer : ExpressionVisitor
+		{
+			private Type duckType;
+			private Type targetType;
+
+			public DuckReplacer(Type duckType, Type targetType)
+			{
+				this.duckType = duckType;
+				this.targetType = targetType;
+			}
+
+			protected override Expression VisitMethodCall(MethodCallExpression node)
+			{
+				if (node.Object is ParameterExpression left && left.Type == this.duckType)
+				{
+					var targetParameter = Expression.Parameter(typeof(T), left.Name);
+					return Expression.Call(targetParameter, FindCorrespondingMethod(node.Method), node.Arguments);
+				}
+				else
+				{
+					return node;
+				}
+			}
+
+			protected override Expression VisitMember(MemberExpression node)
+			{
+				if (node.Expression is ParameterExpression left && left.Type == this.duckType)
+				{
+					var targetParameter = Expression.Parameter(typeof(T), left.Name);
+					return Expression.MakeMemberAccess(targetParameter, FindCorrespondingMember(node.Member));
+				}
+				else
+				{
+					return node;
+				}
+			}
+
+			private MemberInfo FindCorrespondingMember(MemberInfo duckMember)
+			{
+				if (duckMember is MethodInfo duckMethod)
+				{
+					return FindCorrespondingMethod(duckMethod);
+				}
+				else if (duckMember is PropertyInfo duckProperty)
+				{
+					return FindCorrespondingProperty(duckProperty);
+				}
+				else
+				{
+					throw new NotSupportedException();
+				}
+			}
+
+			private MethodInfo FindCorrespondingMethod(MethodInfo duckMethod)
+			{
+				var candidateTargetMethods =
+					this.targetType
+				    .GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
+				    .Where(ctm => IsCorrespondingMethod(duckMethod, ctm));
+
+				var targetMethod = candidateTargetMethods.Single();
+
+				if (targetMethod.IsGenericMethodDefinition)
+				{
+					var duckGenericArgs = duckMethod.GetGenericArguments();
+					targetMethod = targetMethod.MakeGenericMethod(duckGenericArgs);
+				}
+
+				return targetMethod;
+			}
+
+			private PropertyInfo FindCorrespondingProperty(PropertyInfo duckProperty)
+			{
+				var candidateTargetProperties =
+					this.targetType
+					.GetProperties(BindingFlags.NonPublic | BindingFlags.Instance)
+					.Where(ctp => IsCorrespondingProperty(duckProperty, ctp));
+
+				return candidateTargetProperties.Single();
+			}
+
+			private static bool IsCorrespondingMethod(MethodInfo duckMethod, MethodInfo candidateTargetMethod)
+			{
+				if (candidateTargetMethod.Name != duckMethod.Name)
+				{
+					return false;
+				}
+
+				if (candidateTargetMethod.IsGenericMethod != duckMethod.IsGenericMethod)
+				{
+					return false;
+				}
+
+				var candidateParameters = candidateTargetMethod.GetParameters();
+				var duckParameters = duckMethod.GetParameters();
+
+				if (candidateParameters.Length != duckParameters.Length)
+				{
+					return false;
+				}
+
+				for (int i = 0, n = candidateParameters.Length; i < n; ++i)
+				{
+					if (candidateParameters[i].ParameterType != duckParameters[i].ParameterType)
+					{
+						return false;
+					}
+				}
+
+				if (candidateTargetMethod.IsGenericMethod)
+				{
+					var candidateGenericArgs = candidateTargetMethod.GetGenericArguments();
+					var duckGenericArgs = duckMethod.GetGenericArguments();
+
+					if (candidateGenericArgs.Length != duckGenericArgs.Length)
+					{
+						return false;
+					}
+
+					for (int i = 0, n = candidateGenericArgs.Length; i < n; ++i)
+					{
+						Debug.Assert(candidateGenericArgs[i].IsGenericParameter);
+
+						var candidateGenericConstraints = candidateGenericArgs[i].GetTypeInfo().GetGenericParameterConstraints();
+						foreach (var candidateGenericConstraint in candidateGenericConstraints)
+						{
+							if (!candidateGenericConstraint.IsAssignableFrom(duckGenericArgs[i]))
+							{
+								return false;
+							}
+						}
+					}
+				}
+
+				return true;
+			}
+
+			private static bool IsCorrespondingProperty(PropertyInfo duckProperty, PropertyInfo candidateTargetProperty)
+			{
+				return candidateTargetProperty.Name == duckProperty.Name
+				    && candidateTargetProperty.PropertyType == duckProperty.PropertyType
+				    && candidateTargetProperty.CanRead == duckProperty.CanRead
+				    && candidateTargetProperty.CanWrite == duckProperty.CanWrite;
+
+				// TODO: parameter lists should be compared, too, to properly support indexers.
+			}
+		}
+    }
+}

--- a/Source/Protected/ProtectedMock.cs
+++ b/Source/Protected/ProtectedMock.cs
@@ -61,6 +61,12 @@ namespace Moq.Protected
 			this.mock = mock;
 		}
 
+		public IProtectedAsMock<T, TDuck> As<TDuck>()
+			where TDuck : class
+		{
+			return new ProtectedAsMock<T, TDuck>(this.mock);
+		}
+
 		#region Setup
 
 		public ISetup<T> Setup(string methodName, params object[] args)


### PR DESCRIPTION
This proposes a new feature that aims to offer more complete support for setting up and verifying protected members (including the ability to set up protected generic methods, and protected methods with by-ref parameters).

It closes #223 and #249 if merged.

### Problem:

The current `Setup` and `Verify` methods accessible via `mock.Protected()` admittedly offer a handy way to get at protected members, but with the following downsides:

* They are by necessity completely "untyped". As such, they do not fit well into Moq's generally strongly-typed API.
* They are not easy to extend with support for generic methods, or methods with by-ref parameters.

### Proposed solution:

The new feature proposed here adds a new method, `mock.Protected().As<TDuck>()`, which offers `Setup` and `Verify` methods by which protected members can be accessed in a strongly-typed manner through a totally unrelated type `TDuck`. This type's members are expected to correspond to the mocked type's members (by having identical signatures). 

```csharp
abstract class Foo
{
    protected abstract void Protected(); 
}

interface Fooish
{
    void Protected();
}

var mock = new Mock<Foo>();
mock.Protected().As<Fooish>()
    .Setup(m => m.Protected())....; // `Foo.Protected` gets set up instead of `Fooish.Protected`
```

### When does this feature offer true added value?

This feature might seem pointless since it forces the user to declare a type just for testing; one could argue that it would be just as easy, and more meaningful, to simply let `Foo` implement `Fooish` and then mock `Fooish` directly. This is a fair assessment, but there might be cases where the type to be mocked is not owned by the user and cannot be modified. In these cases, the new feature offers a way to get at all protected members of that type.