### PR TITLE
Improve `Setup` recognition logic for sealed methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * Update a method's invocation count correctly, even when it is set up to throw an exception (@stakx, #473)
 * Sequences set up with `SetupSequence` are now thread-safe (@stakx, #476)
 * Record calls to methods that are named like event accessors (`add_X`, `remove_X`) so they can be verified (@stakx, #488)
+* Improve recognition logic for sealed methods so that `Setup` throws when an attempt is made to set one up (@stakx, #497)
 
 ## 4.7.142 (2017-10-11)
 


### PR DESCRIPTION
This fixes #496.

Given the two types `FooBase` and `Foo` in that issue and the following expression tree:

```csharp
Expression<Func<Foo, object>> expression = foo => foo.Property;
```

If one inspects the `PropertyInfo` that the compiler puts into `expression` for `foo.Property`, it'll be the `PropertyInfo` representing `FooBase.Property` instead of `Foo.Property`. (See also the [this Stack Overflow question, "ReflectedType from MemberExpression"](https://stackoverflow.com/questions/23105567/reflectedtype-from-memberexpression).)

This PR adds code to Moq's `expression.ToPropertyInfo()` extension method to counteract this peculiar C# compiler behaviour.