### PR TITLE
Let `SetupAllProperties` skip inaccessible methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * Sequences set up with `SetupSequence` are now thread-safe (@stakx, #476)
 * Record calls to methods that are named like event accessors (`add_X`, `remove_X`) so they can be verified (@stakx, #488)
 * Improve recognition logic for sealed methods so that `Setup` throws when an attempt is made to set one up (@stakx, #497)
+* Let `SetupAllProperties` skip inaccessible methods (@stakx, #499)
 
 ## 4.7.142 (2017-10-11)
 

--- a/Moq.Tests/PropertiesFixture.cs
+++ b/Moq.Tests/PropertiesFixture.cs
@@ -165,6 +165,19 @@ namespace Moq.Tests
 			Assert.NotNull(exception);      // and Moq should tell us by throwing an exception.
 		}
 
+		[Fact]
+		public void SetupAllProperties_does_not_throw_when_it_encounters_properties_that_cannot_be_setup()
+		{
+			var mock = new Mock<Foo>();
+
+			var exception = Record.Exception(() =>
+			{
+				mock.SetupAllProperties();
+			});
+
+			Assert.Null(exception);
+		}
+
 		public abstract class FooBase
 		{
 			public abstract object A { get; }

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -727,11 +727,12 @@ namespace Moq
 				//   interface as a getter-and-setter property.
 				.Where(p =>
 					   p.CanRead && p.CanOverrideGet() &&
-					   p.GetIndexParameters().Length == 0 &&
-					   p.CanWrite == p.CanOverrideSet())
-					   // ^ The last condition will be true for two kinds of properties:
+					   p.CanWrite == p.CanOverrideSet() &&
+					   // ^ This condition will be true for two kinds of properties:
 					   //    (a) those that are read-only; and
 					   //    (b) those that are writable and whose setter can be overridden.
+					   p.GetIndexParameters().Length == 0 &&
+					   ProxyFactory.IsMethodVisible(p.GetGetMethod(), out _))
 				.Distinct();
 
 			var setupPropertyMethod = mock.GetType().GetMethods()


### PR DESCRIPTION
This fixes #498.