### PR TITLE
`Protected().As<T>()`: Fix generic method support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * Support for sequential setup of `void` methods (@alexbestul, #463)
 * Support for sequential setups (`SetupSequence`) of protected members (@stakx, #493)
 * Support for callbacks for methods having `ref` or `out` parameters via two new overloads of `Callback` and `Returns` (@stakx, #468)
-* Improved support for setting up and verifying protected members (including generic methods and methods having by-ref parameters) via the new duck-typing `mock.Protected().As<TDuck>()` interface (@stakx, #495)
+* Improved support for setting up and verifying protected members (including generic methods and methods having by-ref parameters) via the new duck-typing `mock.Protected().As<TDuck>()` interface (@stakx, #495, #501)
 
 #### Changed
 


### PR DESCRIPTION
This should close #249.