### PR TITLE
Allow `DefaultValue.Mock` to mock `Task<TMockable>` and `ValueTask<TMockable>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * Support for `ValueTask<TResult>` when using the `ReturnsAsync` extension methods, similar to `Task<TResult>` (@AdamDotNet, #506)
 * Special handling for `ValueTask<TResult>` with `DefaultValue.Empty` (@stakx, #529)
 * Support for custom default value generators (besides `DefaultValue.Empty` and `DefaultValue.Mock`): subclass the new `DefaultValueProvider` and set up via `Mock[Repository].DefaultValueProvider` (@stakx, #533)
+* Allow `DefaultValue.Mock` to mock `Task<TMockable>` and `ValueTask<TMockable>` (@stakx, #502)
 
 #### Changed
 

--- a/Moq.Tests/MockDefaultValueProviderFixture.cs
+++ b/Moq.Tests/MockDefaultValueProviderFixture.cs
@@ -217,6 +217,32 @@ namespace Moq.Tests
 			Assert.True(task.Result.Result is IMocked);
 		}
 
+		[Fact]
+		public async Task Mock_wrapped_in_completed_Task_gets_included_in_verification_of_outer_mock()
+		{
+			var mock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock };
+
+			var bar = await mock.Object.TaskOfMockableType;
+			var barMock = Mock.Get(bar);
+			barMock.Setup(b => b.Do()).Verifiable();
+
+			var ex = Assert.Throws<MockException>(() => mock.Verify());
+			Assert.True(ex.IsVerificationError);
+		}
+
+		[Fact]
+		public async Task Mock_wrapped_in_completed_ValueTask_gets_included_in_verification_of_outer_mock()
+		{
+			var mock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock };
+
+			var bar = await mock.Object.ValueTaskOfMockableType;
+			var barMock = Mock.Get(bar);
+			barMock.Setup(b => b.Do()).Verifiable();
+
+			var ex = Assert.Throws<MockException>(() => mock.Verify());
+			Assert.True(ex.IsVerificationError);
+		}
+
 		private static object GetDefaultValueForProperty(string propertyName, Mock<IFoo> mock)
 		{
 			var propertyGetter = typeof(IFoo).GetProperty(propertyName).GetGetMethod();

--- a/Moq.Tests/MockDefaultValueProviderFixture.cs
+++ b/Moq.Tests/MockDefaultValueProviderFixture.cs
@@ -1,8 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
-#if NETCORE
-using System.Reflection;
-#endif
+using System.Threading.Tasks;
+
 using Xunit;
 
 namespace Moq.Tests
@@ -104,6 +104,119 @@ namespace Moq.Tests
 			Assert.Equal(expectedSwitches, actual: innerMock.Switches);
 		}
 
+		[Fact]
+		public void Provides_completed_Task_containing_default_value_for_Task_of_value_type()
+		{
+			var mock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock };
+			var task = (Task<int>)GetDefaultValueForProperty(nameof(IFoo.TaskOfValueType), mock);
+
+			Assert.NotNull(task);
+			Assert.True(task.IsCompleted);
+			Assert.Equal(default(int), task.Result);
+		}
+
+		[Fact]
+		public void Provides_completed_Task_containing_empty_value_for_Task_of_emptyable_type()
+		{
+			var mock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock };
+			var task = (Task<int[]>)GetDefaultValueForProperty(nameof(IFoo.TaskOfEmptyableType), mock);
+
+			Assert.NotNull(task);
+			Assert.True(task.IsCompleted);
+			Assert.NotNull(task.Result);
+			Assert.Empty(task.Result);
+		}
+
+		[Fact]
+		public void Provides_completed_Task_containing_null_for_Task_of_unmockable_reference_type()
+		{
+			var mock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock };
+			var task = (Task<IndexOutOfRangeException>)GetDefaultValueForProperty(nameof(IFoo.TaskOfUnmockableReferenceType), mock);
+
+			Assert.NotNull(task);
+			Assert.True(task.IsCompleted);
+			Assert.Null(task.Result);
+		}
+
+		[Fact]
+		public void Provides_completed_Task_containing_mocked_value_for_Task_of_mockable_type()
+		{
+			var mock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock };
+			var task = (Task<IBar>)GetDefaultValueForProperty(nameof(IFoo.TaskOfMockableType), mock);
+
+			Assert.NotNull(task);
+			Assert.True(task.IsCompleted);
+			Assert.NotNull(task.Result);
+			Assert.True(task.Result is IMocked);
+		}
+
+		[Fact]
+		public void Provides_completed_Task_containing_completed_Task_containing_whatever_for_Task_of_Task_of_whatever()
+		{
+			var mock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock };
+			var task = (Task<Task<int>>)GetDefaultValueForProperty(nameof(IFoo.TaskOfTaskOfWhatever), mock);
+
+			Assert.NotNull(task);
+			Assert.True(task.IsCompleted);
+			Assert.NotNull(task.Result);
+			Assert.True(task.Result.IsCompleted);
+		}
+
+		[Fact]
+		public void Provides_completed_ValueTask_containing_default_value_for_ValueTask_of_value_type()
+		{
+			var mock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock };
+			var task = (ValueTask<int>)GetDefaultValueForProperty(nameof(IFoo.ValueTaskOfValueType), mock);
+
+			Assert.True(task.IsCompleted);
+			Assert.Equal(default(int), task.Result);
+		}
+
+		[Fact]
+		public void Provides_completed_ValueTask_containing_empty_value_for_ValueTask_of_emptyable_type()
+		{
+			var mock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock };
+			var task = (ValueTask<int[]>)GetDefaultValueForProperty(nameof(IFoo.ValueTaskOfEmptyableType), mock);
+
+			Assert.True(task.IsCompleted);
+			Assert.NotNull(task.Result);
+			Assert.Empty(task.Result);
+		}
+
+		[Fact]
+		public void Provides_completed_ValueTask_containing_null_for_Task_of_unmockable_reference_type()
+		{
+			var mock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock };
+			var task = (ValueTask<IndexOutOfRangeException>)GetDefaultValueForProperty(nameof(IFoo.ValueTaskOfUnmockableReferenceType), mock);
+
+			Assert.True(task.IsCompleted);
+			Assert.Null(task.Result);
+		}
+
+		[Fact]
+		public void Provides_completed_ValueTask_containing_mocked_value_for_ValueTask_of_mockable_type()
+		{
+			var mock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock };
+			var task = (ValueTask<IBar>)GetDefaultValueForProperty(nameof(IFoo.ValueTaskOfMockableType), mock);
+
+			Assert.True(task.IsCompleted);
+			Assert.NotNull(task.Result);
+			Assert.True(task.Result is IMocked);
+		}
+
+		[Fact]
+		public void Provides_completed_ValueTask_of_completed_Task_of_mocked_value_for_ValueTask_of_Task_of_mockable_type()
+		{
+			var mock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock };
+			var task = (ValueTask<Task<IBar>>)GetDefaultValueForProperty(nameof(IFoo.ValueTaskOfTaskOfMockableType), mock);
+
+			Assert.True(task.IsCompleted);
+			Assert.NotNull(task.Result);
+			Assert.True(task.Result.IsCompleted);
+			Assert.NotNull(task.Result.Result);
+			Assert.True(task.Result.Result is IMocked);
+		}
+
 		private static object GetDefaultValueForProperty(string propertyName, Mock<IFoo> mock)
 		{
 			var propertyGetter = typeof(IFoo).GetProperty(propertyName).GetGetMethod();
@@ -116,6 +229,16 @@ namespace Moq.Tests
 			string Value { get; set; }
 			IEnumerable<int> Indexes { get; set; }
 			IBar[] Bars { get; set; }
+			Task<int> TaskOfValueType { get; set; }
+			Task<int[]> TaskOfEmptyableType { get; set; }
+			Task<IndexOutOfRangeException> TaskOfUnmockableReferenceType { get; set; }
+			Task<IBar> TaskOfMockableType { get; set; }
+			Task<Task<int>> TaskOfTaskOfWhatever { get; set; }
+			ValueTask<int> ValueTaskOfValueType { get; set; }
+			ValueTask<int[]> ValueTaskOfEmptyableType { get; set; }
+			ValueTask<IndexOutOfRangeException> ValueTaskOfUnmockableReferenceType { get; set; }
+			ValueTask<IBar> ValueTaskOfMockableType { get; set; }
+			ValueTask<Task<IBar>> ValueTaskOfTaskOfMockableType { get; set; }
 		}
 
 		public interface IBar { void Do(); }

--- a/Source/InterceptorStrategies.cs
+++ b/Source/InterceptorStrategies.cs
@@ -153,10 +153,10 @@ namespace Moq
 
 			if (invocation.Method.ReturnType != typeof(void))
 			{
-				Mock recursiveMock;
+				MockWithWrappedMockObject recursiveMock;
 				if (mock.InnerMocks.TryGetValue(invocation.Method, out recursiveMock))
 				{
-					invocation.ReturnValue = recursiveMock.Object;
+					invocation.ReturnValue = recursiveMock.WrappedMockObject;
 				}
 				else
 				{

--- a/Source/Linq/Mocks.cs
+++ b/Source/Linq/Mocks.cs
@@ -42,10 +42,10 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+
 using Moq.Linq;
 using Moq.Properties;
 
@@ -200,13 +200,26 @@ namespace Moq
 			info.ReturnType.ThrowIfNotMockeable();
 
 			Mock fluentMock;
-			if (!mock.InnerMocks.TryGetValue(info, out fluentMock))
+			MockWithWrappedMockObject innerMock;
+			if (mock.InnerMocks.TryGetValue(info, out innerMock))
+			{
+				fluentMock = innerMock.Mock;
+			}
+			else
 			{
 				fluentMock = ((IMocked)mock.GetDefaultValue(info, useAlternateProvider: MockDefaultValueProvider.Instance)).Mock;
 				Mock.SetupAllProperties(fluentMock);
+
+				innerMock = new MockWithWrappedMockObject(fluentMock, fluentMock.Object);
+				//                                                    ^^^^^^^^^^^^^^^^^
+				// NOTE: Above, we are assuming that a default value was returned that is neither a `Task<T>` nor a `ValueTask<T>`,
+				// i.e. nothing we'd need to first "unwrap" to get at the actual mocked object. This assumption would seem permissible
+				// since the present method gets called only for multi-dot expressions ("recursive mocking"), which do not allow
+				// `await` expressions. Therefore we don't need to deal with `Task<T>` nor `ValueTask<T>`, and we proceed as if the
+				// returned default value were already "unwrapped".
 			}
 
-			var result = (TResult)fluentMock.Object;
+			var result = (TResult)innerMock.WrappedMockObject;
 
 			mock.Setup(setup).Returns(result);
 


### PR DESCRIPTION
This PR enables the following scenario (shown for `Task<T>`, but same goes for `ValueTask<T>`):

```csharp
var mock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock };
var property = (await mock.Object.GetBarAsync()).Property;
             // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
             // With DefaultValue.Mock, Task<T> no longer returns tasks
             // that resolve to default(T), but to a mocked T, so these are
             // now awaitable straight away.

public interface IFoo
{
    Task<IBar> GetBarAsync();
}

public interface  IBar
{
    object Property { get; }
}
```

This closes #171.