### PR TITLE
Add ValueTask extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * Support for sequential setups (`SetupSequence`) of protected members (@stakx, #493)
 * Support for callbacks for methods having `ref` or `out` parameters via two new overloads of `Callback` and `Returns` (@stakx, #468)
 * Improved support for setting up and verifying protected members (including generic methods and methods having by-ref parameters) via the new duck-typing `mock.Protected().As<TDuck>()` interface (@stakx, #495, #501)
+* Support for `ValueTask<TResult>` when using the `ReturnsAsync` extension methods, similar to `Task<TResult>` (@AdamDotNet, #506)
 
 #### Changed
 

--- a/Moq.Tests/ReturnsExtensionsFixture.cs
+++ b/Moq.Tests/ReturnsExtensionsFixture.cs
@@ -26,6 +26,23 @@ namespace Moq.Tests
 			Task<Guid> NewGuidAsync();
 		}
 
+		public interface IValueTaskAsyncInterface
+		{
+			ValueTask<string> NoParametersRefReturnType();
+
+			ValueTask<int> NoParametersValueReturnType();
+
+			ValueTask<string> RefParameterRefReturnType(string value);
+
+			ValueTask<int> RefParameterValueReturnType(string value);
+
+			ValueTask<string> ValueParameterRefReturnType(int value);
+
+			ValueTask<int> ValueParameterValueReturnType(int value);
+
+			ValueTask<Guid> NewGuidAsync();
+		}
+
 		[Fact]
 		public void ReturnsAsync_on_NoParametersRefReturnType()
 		{
@@ -460,5 +477,426 @@ namespace Moq.Tests
 			Assert.Equal("random", paramName);
 		}
 
+		[Fact]
+		public void ValueTaskReturnsAsync_on_NoParametersRefReturnType()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			mock.Setup(x => x.NoParametersRefReturnType()).ReturnsAsync("TestString");
+
+			var task = mock.Object.NoParametersRefReturnType();
+
+			Assert.IsType<ValueTask<string>>(task);
+			Assert.True(task.IsCompleted);
+			Assert.Equal("TestString", task.Result);
+		}
+
+		[Fact]
+		public void ValueTaskReturnsAsync_on_NoParametersValueReturnType()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			mock.Setup(x => x.NoParametersValueReturnType()).ReturnsAsync(36);
+
+			var task = mock.Object.NoParametersValueReturnType();
+
+			Assert.IsType<ValueTask<int>>(task);
+			Assert.True(task.IsCompleted);
+			Assert.Equal(36, task.Result);
+		}
+
+		[Fact]
+		public void ValueTaskReturnsAsync_on_RefParameterRefReturnType()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			mock.Setup(x => x.RefParameterRefReturnType("Param1")).ReturnsAsync("TestString");
+
+			var task = mock.Object.RefParameterRefReturnType("Param1");
+
+			Assert.IsType<ValueTask<string>>(task);
+			Assert.True(task.IsCompleted);
+			Assert.Equal("TestString", task.Result);
+		}
+
+		[Fact]
+		public void ValueTaskReturnsAsync_on_RefParameterValueReturnType()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			mock.Setup(x => x.RefParameterValueReturnType("Param1")).ReturnsAsync(36);
+
+			var task = mock.Object.RefParameterValueReturnType("Param1");
+
+			Assert.IsType<ValueTask<int>>(task);
+			Assert.True(task.IsCompleted);
+			Assert.Equal(36, task.Result);
+		}
+
+		[Fact]
+		public void ValueTaskReturnsAsync_on_ValueParameterRefReturnType()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			mock.Setup(x => x.ValueParameterRefReturnType(36)).ReturnsAsync("TestString");
+
+			var task = mock.Object.ValueParameterRefReturnType(36);
+
+			Assert.IsType<ValueTask<string>>(task);
+			Assert.True(task.IsCompleted);
+			Assert.Equal("TestString", task.Result);
+		}
+
+		[Fact]
+		public void ValueTaskReturnsAsync_on_ValueParameterValueReturnType()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			mock.Setup(x => x.ValueParameterValueReturnType(36)).ReturnsAsync(37);
+
+			var task = mock.Object.ValueParameterValueReturnType(36);
+
+			Assert.IsType<ValueTask<int>>(task);
+			Assert.True(task.IsCompleted);
+			Assert.Equal(37, task.Result);
+		}
+
+		[Fact]
+		public void ValueTaskReturnsAsyncFunc_on_NoParametersRefReturnType()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			mock.Setup(x => x.NoParametersRefReturnType()).ReturnsAsync(() => "TestString");
+
+			var task = mock.Object.NoParametersRefReturnType();
+
+			Assert.IsType<ValueTask<string>>(task);
+			Assert.True(task.IsCompleted);
+			Assert.Equal("TestString", task.Result);
+		}
+
+		[Fact]
+		public void ValueTaskReturnsAsyncFunc_on_NoParametersValueReturnType()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			mock.Setup(x => x.NoParametersValueReturnType()).ReturnsAsync(() => 36);
+
+			var task = mock.Object.NoParametersValueReturnType();
+
+			Assert.IsType<ValueTask<int>>(task);
+			Assert.True(task.IsCompleted);
+			Assert.Equal(36, task.Result);
+		}
+
+		[Fact]
+		public void ValueTaskReturnsAsyncFunc_on_RefParameterRefReturnType()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			mock.Setup(x => x.RefParameterRefReturnType("Param1")).ReturnsAsync(() => "TestString");
+
+			var task = mock.Object.RefParameterRefReturnType("Param1");
+
+			Assert.IsType<ValueTask<string>>(task);
+			Assert.True(task.IsCompleted);
+			Assert.Equal("TestString", task.Result);
+		}
+
+		[Fact]
+		public void ValueTaskReturnsAsyncFunc_on_RefParameterValueReturnType()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			mock.Setup(x => x.RefParameterValueReturnType("Param1")).ReturnsAsync(() => 36);
+
+			var task = mock.Object.RefParameterValueReturnType("Param1");
+
+			Assert.IsType<ValueTask<int>>(task);
+			Assert.True(task.IsCompleted);
+			Assert.Equal(36, task.Result);
+		}
+
+		[Fact]
+		public void ValueTaskReturnsAsyncFunc_on_ValueParameterRefReturnType()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			mock.Setup(x => x.ValueParameterRefReturnType(36)).ReturnsAsync(() => "TestString");
+
+			var task = mock.Object.ValueParameterRefReturnType(36);
+
+			Assert.IsType<ValueTask<string>>(task);
+			Assert.True(task.IsCompleted);
+			Assert.Equal("TestString", task.Result);
+		}
+
+		[Fact]
+		public void ValueTaskReturnsAsyncFunc_on_ValueParameterValueReturnType()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			mock.Setup(x => x.ValueParameterValueReturnType(36)).ReturnsAsync(() => 37);
+
+			var task = mock.Object.ValueParameterValueReturnType(36);
+
+			Assert.IsType<ValueTask<int>>(task);
+			Assert.True(task.IsCompleted);
+			Assert.Equal(37, task.Result);
+		}
+
+		[Fact]
+		public void ValueTaskReturnsAsyncFunc_onEachInvocation_ValueReturnTypeLazyEvaluation()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			mock.Setup(x => x.NewGuidAsync()).ReturnsAsync(Guid.NewGuid);
+
+			var firstTask = mock.Object.NewGuidAsync();
+			var secondTask = mock.Object.NewGuidAsync();
+
+			Assert.IsType<ValueTask<Guid>>(firstTask);
+			Assert.IsType<ValueTask<Guid>>(secondTask);
+			Assert.NotEqual(firstTask.Result, secondTask.Result);
+		}
+
+		[Fact]
+		public void ValueTaskReturnsAsyncFunc_onEachInvocation_RefReturnTypeLazyEvaluation()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			mock.Setup(x => x.ValueParameterRefReturnType(36)).ReturnsAsync(() => new string(new[] { 'M', 'o', 'q', '4' }));
+
+			var firstTask = mock.Object.ValueParameterRefReturnType(36);
+			var secondTask = mock.Object.ValueParameterRefReturnType(36);
+			
+			Assert.IsType<ValueTask<string>>(firstTask);
+			Assert.IsType<ValueTask<string>>(secondTask);
+			Assert.NotSame(firstTask.Result, secondTask.Result);
+		}
+
+		[Fact]
+		public void ValueTaskThrowsAsync_on_NoParametersRefReturnType()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			var exception = new InvalidOperationException();
+			mock.Setup(x => x.NoParametersRefReturnType()).ThrowsAsync(exception);
+
+			var task = mock.Object.NoParametersRefReturnType();
+
+			Assert.IsType<ValueTask<string>>(task);
+			Assert.True(task.IsFaulted);
+			Assert.Equal(exception, task.AsTask().Exception.InnerException);
+		}
+
+		[Fact]
+		public void ValueTaskThrowsAsync_on_NoParametersValueReturnType()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			var exception = new InvalidOperationException();
+			mock.Setup(x => x.NoParametersValueReturnType()).ThrowsAsync(exception);
+
+			var task = mock.Object.NoParametersValueReturnType();
+
+			Assert.IsType<ValueTask<int>>(task);
+			Assert.True(task.IsFaulted);
+			Assert.Equal(exception, task.AsTask().Exception.InnerException);
+		}
+
+		[Fact]
+		public void ValueTaskThrowsAsync_on_RefParameterRefReturnType()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			var exception = new InvalidOperationException();
+			mock.Setup(x => x.RefParameterRefReturnType("Param1")).ThrowsAsync(exception);
+
+			var task = mock.Object.RefParameterRefReturnType("Param1");
+
+			Assert.IsType<ValueTask<string>>(task);
+			Assert.True(task.IsFaulted);
+			Assert.Equal(exception, task.AsTask().Exception.InnerException);
+		}
+
+		[Fact]
+		public void ValueTaskThrowsAsync_on_RefParameterValueReturnType()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			var exception = new InvalidOperationException();
+			mock.Setup(x => x.RefParameterValueReturnType("Param1")).ThrowsAsync(exception);
+
+			var task = mock.Object.RefParameterValueReturnType("Param1");
+
+			Assert.IsType<ValueTask<int>>(task);
+			Assert.True(task.IsFaulted);
+			Assert.Equal(exception, task.AsTask().Exception.InnerException);
+		}
+
+		[Fact]
+		public void ValueTaskThrowsAsync_on_ValueParameterRefReturnType()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			var exception = new InvalidOperationException();
+			mock.Setup(x => x.ValueParameterRefReturnType(36)).ThrowsAsync(exception);
+
+			var task = mock.Object.ValueParameterRefReturnType(36);
+
+			Assert.IsType<ValueTask<string>>(task);
+			Assert.True(task.IsFaulted);
+			Assert.Equal(exception, task.AsTask().Exception.InnerException);
+		}
+
+		[Fact]
+		public void ValueTaskThrowsAsync_on_ValueParameterValueReturnType()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			var exception = new InvalidOperationException();
+			mock.Setup(x => x.ValueParameterValueReturnType(36)).ThrowsAsync(exception);
+
+			var task = mock.Object.ValueParameterValueReturnType(36);
+
+			Assert.IsType<ValueTask<int>>(task);
+			Assert.True(task.IsFaulted);
+			Assert.Equal(exception, task.AsTask().Exception.InnerException);
+		}
+		
+		[Fact]
+		public void ValueTaskReturnsAsyncWithDelayDoesNotImmediatelyComplete()
+		{
+			var longEnoughForAnyBuildServer = TimeSpan.FromSeconds(5);
+
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			mock.Setup(x => x.RefParameterValueReturnType("test")).ReturnsAsync(5, longEnoughForAnyBuildServer);
+
+			var task = mock.Object.RefParameterValueReturnType("test");
+
+			Assert.IsType<ValueTask<int>>(task);
+			Assert.False(task.IsCompleted);
+		}
+
+		[Theory]
+		[InlineData(-1, true)]
+		[InlineData(0, true)]
+		[InlineData(1, false)]
+		public void ValueTaskDelayMustBePositive(int ticks, bool mustThrow)
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+
+			Action setup = () => mock
+				.Setup(x => x.RefParameterValueReturnType("test"))
+				.ReturnsAsync(5, TimeSpan.FromTicks(ticks));
+
+			if (mustThrow)
+				Assert.Throws<ArgumentException>(setup);
+			else
+				setup();
+		}
+
+
+		[Fact]
+		public async Task ValueTaskReturnsAsyncWithDelayReturnsValue()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			mock.Setup(x => x.RefParameterValueReturnType("test")).ReturnsAsync(5, TimeSpan.FromMilliseconds(1));
+
+			var task = mock.Object.RefParameterValueReturnType("test");
+			var value = await Assert.IsType<ValueTask<int>>(task);
+
+			Assert.Equal(5, value);
+		}
+
+		[Fact]
+		public async Task ValueTaskReturnsAsyncWithMinAndMaxDelayReturnsValue()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			mock.Setup(x => x.RefParameterValueReturnType("test")).ReturnsAsync(5, TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(2));
+
+			var task = mock.Object.RefParameterValueReturnType("test");
+			var value = await Assert.IsType<ValueTask<int>>(task);
+
+			Assert.Equal(5, value);
+		}
+
+		[Fact]
+		public async Task ValueTaskReturnsAsyncWithMinAndMaxDelayAndOwnRandomGeneratorReturnsValue()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			mock.Setup(x => x.RefParameterValueReturnType("test")).ReturnsAsync(5, TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(2), new Random());
+
+			var task = mock.Object.RefParameterValueReturnType("test");
+			var value = await Assert.IsType<ValueTask<int>>(task);
+
+			Assert.Equal(5, value);
+		}
+
+		[Fact]
+		public void ValueTaskReturnsAsyncWithNullRandomGenerator()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+
+			Action setup = () => mock
+				.Setup(x => x.RefParameterValueReturnType("test"))
+				.ReturnsAsync(5, TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(2), null);
+
+			var paramName = Assert.Throws<ArgumentNullException>(setup).ParamName;
+			Assert.Equal("random", paramName);
+		}
+
+		[Fact]
+		public async Task ValueTaskThrowsWithDelay()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+
+			mock
+				.Setup(x => x.RefParameterValueReturnType("test"))
+				.ThrowsAsync(new ArithmeticException("yikes"), TimeSpan.FromMilliseconds(1));
+
+			Func<ValueTask<int>> test = () => mock.Object.RefParameterValueReturnType("test");
+
+			var exception = await Assert.ThrowsAsync<ArithmeticException>(() => test().AsTask());
+			Assert.Equal("yikes", exception.Message);
+		}
+
+		[Fact]
+		public async Task ValueTaskThrowsWithRandomDelay()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+
+			var minDelay = TimeSpan.FromMilliseconds(1);
+			var maxDelay = TimeSpan.FromMilliseconds(2);
+
+			mock
+				.Setup(x => x.RefParameterValueReturnType("test"))
+				.ThrowsAsync(new ArithmeticException("yikes"), minDelay, maxDelay);
+
+			Func<ValueTask<int>> test = () => mock.Object.RefParameterValueReturnType("test");
+
+			var exception = await Assert.ThrowsAsync<ArithmeticException>(() => test().AsTask());
+			Assert.Equal("yikes", exception.Message);
+		}
+
+		[Fact]
+		public async Task ValueTaskThrowsWithRandomDelayAndOwnRandomGenerator()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+
+			var minDelay = TimeSpan.FromMilliseconds(1);
+			var maxDelay = TimeSpan.FromMilliseconds(2);
+
+			mock
+				.Setup(x => x.RefParameterValueReturnType("test"))
+				.ThrowsAsync(new ArithmeticException("yikes"), minDelay, maxDelay, new Random());
+
+			Func<ValueTask<int>> test = () => mock.Object.RefParameterValueReturnType("test");
+
+			var exception = await Assert.ThrowsAsync<ArithmeticException>(() => test().AsTask());
+			Assert.Equal("yikes", exception.Message);
+		}
+
+
+		[Fact]
+		public void ValueTaskThrowsAsyncWithNullRandomGenerator()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+
+			Action setup = () =>
+			{
+				var anyException = new Exception();
+				var minDelay = TimeSpan.FromMilliseconds(1);
+				var maxDelay = TimeSpan.FromMilliseconds(2);
+
+				mock
+					.Setup(x => x.RefParameterValueReturnType("test"))
+					.ThrowsAsync(anyException, minDelay, maxDelay, null);
+			};
+
+			var paramName = Assert.Throws<ArgumentNullException>(setup).ParamName;
+			Assert.Equal("random", paramName);
+		}
 	}
 }

--- a/Moq.nuspec
+++ b/Moq.nuspec
@@ -15,12 +15,14 @@
 		<dependencies>
 			<group targetFramework=".NETFramework4.5">
 				<dependency id="Castle.Core" version="4.2.1" />
+				<dependency id="System.Threading.Tasks.Extensions" version="4.4.0" />
 			</group>
 			<group targetFramework=".NETStandard1.3">
 				<dependency id="NETStandard.Library" version="1.6.1" />
 				<dependency id="System.Linq.Queryable" version="4.3.0" />
 				<dependency id="System.Reflection.TypeExtensions" version="4.3.0" />
 				<dependency id="Castle.Core" version="4.2.1" />
+				<dependency id="System.Threading.Tasks.Extensions" version="4.4.0" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/Source/Moq.csproj
+++ b/Source/Moq.csproj
@@ -28,7 +28,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Castle.Core" Version="4.2.1" />
-    <PackageReference Include="GitInfo" Version="1.1.14" />
+		<PackageReference Include="GitInfo" Version="1.1.14" />
 		<PackageReference Include="IFluentInterface" Version="2.0.0" />
 		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.2.1" PrivateAssets="All" />
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.4.0" />

--- a/Source/Moq.csproj
+++ b/Source/Moq.csproj
@@ -28,9 +28,10 @@
 
 	<ItemGroup>
 		<PackageReference Include="Castle.Core" Version="4.2.1" />
-		<PackageReference Include="GitInfo" Version="1.1.14" />
+    <PackageReference Include="GitInfo" Version="1.1.14" />
 		<PackageReference Include="IFluentInterface" Version="2.0.0" />
 		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.2.1" PrivateAssets="All" />
+		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.4.0" />
 		<DotNetCliToolReference Include="dotnet-sourcelink" Version="2.2.1" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/Source/ReturnsExtensions.Generated.cs
+++ b/Source/ReturnsExtensions.Generated.cs
@@ -162,5 +162,158 @@ namespace Moq
 		{
 			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14, T15 t15) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)));
 		}
+
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <typeparam name="T">Type of the function parameter.</typeparam>
+		/// <typeparam name="TMock">Mocked type.</typeparam>
+		/// <typeparam name="TResult">Type of the return value.</typeparam>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T, TMock, TResult>(this IReturns<TMock, ValueTask<TResult>> mock, Func<T, TResult> valueFunction) where TMock : class
+		{
+			return mock.Returns((T t) => new ValueTask<TResult>(valueFunction(t)));
+		}	
+		 
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, TMock, TResult>(this IReturns<TMock, ValueTask<TResult>> mock, Func<T1, T2, TResult> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2) => new ValueTask<TResult>(valueFunction(t1, t2)));
+		}
+ 
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, TMock, TResult>(this IReturns<TMock, ValueTask<TResult>> mock, Func<T1, T2, T3, TResult> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3) => new ValueTask<TResult>(valueFunction(t1, t2, t3)));
+		}
+ 
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, TMock, TResult>(this IReturns<TMock, ValueTask<TResult>> mock, Func<T1, T2, T3, T4, TResult> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4)));
+		}
+ 
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, TMock, TResult>(this IReturns<TMock, ValueTask<TResult>> mock, Func<T1, T2, T3, T4, T5, TResult> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5)));
+		}
+ 
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, TMock, TResult>(this IReturns<TMock, ValueTask<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, TResult> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6)));
+		}
+ 
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, TMock, TResult>(this IReturns<TMock, ValueTask<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, TResult> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6, t7)));
+		}
+ 
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, TMock, TResult>(this IReturns<TMock, ValueTask<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8)));
+		}
+ 
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, TMock, TResult>(this IReturns<TMock, ValueTask<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9)));
+		}
+ 
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TMock, TResult>(this IReturns<TMock, ValueTask<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)));
+		}
+ 
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TMock, TResult>(this IReturns<TMock, ValueTask<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)));
+		}
+ 
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TMock, TResult>(this IReturns<TMock, ValueTask<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)));
+		}
+ 
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TMock, TResult>(this IReturns<TMock, ValueTask<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)));
+		}
+ 
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TMock, TResult>(this IReturns<TMock, ValueTask<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)));
+		}
+ 
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TMock, TResult>(this IReturns<TMock, ValueTask<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> valueFunction) where TMock : class
+		{
+			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14, T15 t15) => new ValueTask<TResult>(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)));
+		}
 	}
 }

--- a/Source/ReturnsExtensions.Generated.cs
+++ b/Source/ReturnsExtensions.Generated.cs
@@ -8,7 +8,7 @@ namespace Moq
 	/// <summary>
 	/// Defines async extension methods on IReturns.
 	/// </summary>
-	public static class GeneratedReturnsExtensions
+	static partial class ReturnsExtensions
 	{
 		/// <summary>
 		/// Specifies a function that will calculate the value to return from the asynchronous method.

--- a/Source/ReturnsExtensions.cs
+++ b/Source/ReturnsExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 using Moq.Language;
 using Moq.Language.Flow;
@@ -9,7 +10,8 @@ namespace Moq
 	/// <summary>
 	/// Defines async extension methods on IReturns.
 	/// </summary>
-	public static class ReturnsExtensions
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public static partial class ReturnsExtensions
 	{
 		/// <summary>
 		/// Specifies the value to return from an asynchronous method.

--- a/Source/ReturnsExtensions.tt
+++ b/Source/ReturnsExtensions.tt
@@ -12,7 +12,7 @@ namespace Moq
 	/// <summary>
 	/// Defines async extension methods on IReturns.
 	/// </summary>
-	public static class GeneratedReturnsExtensions
+	static partial class ReturnsExtensions
 	{
 		/// <summary>
 		/// Specifies a function that will calculate the value to return from the asynchronous method.

--- a/Source/ReturnsExtensions.tt
+++ b/Source/ReturnsExtensions.tt
@@ -58,5 +58,50 @@ namespace Moq
 <#
 		}
 		#>
+
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <typeparam name="T">Type of the function parameter.</typeparam>
+		/// <typeparam name="TMock">Mocked type.</typeparam>
+		/// <typeparam name="TResult">Type of the return value.</typeparam>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<T, TMock, TResult>(this IReturns<TMock, ValueTask<TResult>> mock, Func<T, TResult> valueFunction) where TMock : class
+		{
+			return mock.Returns((T t) => new ValueTask<TResult>(valueFunction(t)));
+		}	
+		<# 
+		for (var argumentCount = 2; argumentCount <= 15; ++argumentCount)
+		{ #> 
+		/// <summary>
+		/// Specifies a function that will calculate the value to return from the asynchronous method.
+		/// </summary>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="valueFunction">The function that will calculate the return value.</param>
+		public static IReturnsResult<TMock> ReturnsAsync<<#
+			for (var i = 1; i <= argumentCount; ++i)
+			{
+				#>T<#=i#>, <#
+			}#>TMock, TResult>(this IReturns<TMock, ValueTask<TResult>> mock, Func<<#
+			for (var i = 1; i <= argumentCount; ++i)
+			{
+				#>T<#=i#>, <#
+			}#>TResult> valueFunction) where TMock : class
+		{
+			return mock.Returns((<#
+			for (var i = 1; i <= argumentCount; ++i)
+			{ #>T<#=i#> t<#=i#><#
+				if(i != argumentCount) {#>, <#}#><#
+			}#>) => new ValueTask<TResult>(valueFunction(<#
+			for (var i = 1; i <= argumentCount; ++i)
+			{
+				#>t<#=i#><#
+				if (i != argumentCount) { #>, <#}#><#
+			}#>)));
+		}
+<#
+		}
+		#>
 	}
 }


### PR DESCRIPTION
Addresses #437  
- Reference NuGet System.Threading.Tasks.Extensions
 - Add extension methods to ReturnsExtensions.cs/.tt
 - Add unit tests to ReturnsExtensionsFixture.cs

Tests pass on NetCoreApp2.0 and Net46 TFMs.