### PR TITLE
Get `PexProtector` out of the debugger's way

### DIFF
--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -41,6 +41,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
@@ -428,122 +429,151 @@ namespace Moq
 
 		#region Setup
 
+		[DebuggerStepThrough]
 		internal static MethodCall<T> Setup<T>(Mock<T> mock, Expression<Action<T>> expression, Condition condition)
 			where T : class
 		{
-			return PexProtector.Invoke(() =>
-			{
-				var methodCall = expression.GetCallInfo(mock);
-				var method = methodCall.Method;
-				var args = methodCall.Arguments.ToArray();
-
-				ThrowIfSetupExpressionInvolvesUnsupportedMember(expression, method);
-				ThrowIfSetupMethodNotVisibleToProxyFactory(method);
-				var call = new MethodCall<T>(mock, condition, expression, method, args);
-
-				var targetInterceptor = GetInterceptor(methodCall.Object, mock);
-
-				targetInterceptor.AddCall(call, SetupKind.Other);
-
-				return call;
-			});
+			return PexProtector.Invoke(SetupPexProtected, mock, expression, condition);
 		}
 
+		private static MethodCall<T> SetupPexProtected<T>(Mock<T> mock, Expression<Action<T>> expression, Condition condition)
+			where T : class
+		{
+			var methodCall = expression.GetCallInfo(mock);
+			var method = methodCall.Method;
+			var args = methodCall.Arguments.ToArray();
+
+			ThrowIfSetupExpressionInvolvesUnsupportedMember(expression, method);
+			ThrowIfSetupMethodNotVisibleToProxyFactory(method);
+			var call = new MethodCall<T>(mock, condition, expression, method, args);
+
+			var targetInterceptor = GetInterceptor(methodCall.Object, mock);
+
+			targetInterceptor.AddCall(call, SetupKind.Other);
+
+			return call;
+		}
+
+		[DebuggerStepThrough]
 		internal static MethodCallReturn<T, TResult> Setup<T, TResult>(
 			Mock<T> mock,
 			Expression<Func<T, TResult>> expression,
 			Condition condition)
 			where T : class
 		{
-			return PexProtector.Invoke(() =>
-			{
-				if (expression.IsProperty())
-				{
-					return SetupGet(mock, expression, condition);
-				}
-
-				var methodCall = expression.GetCallInfo(mock);
-				var method = methodCall.Method;
-				var args = methodCall.Arguments.ToArray();
-
-				ThrowIfSetupExpressionInvolvesUnsupportedMember(expression, method);
-				ThrowIfSetupMethodNotVisibleToProxyFactory(method);
-				var call = new MethodCallReturn<T, TResult>(mock, condition, expression, method, args);
-
-				var targetInterceptor = GetInterceptor(methodCall.Object, mock);
-
-				targetInterceptor.AddCall(call, SetupKind.Other);
-
-				return call;
-			});
+			return PexProtector.Invoke(SetupPexProtected, mock, expression, condition);
 		}
 
+		private static MethodCallReturn<T, TResult> SetupPexProtected<T, TResult>(
+			Mock<T> mock,
+			Expression<Func<T, TResult>> expression,
+			Condition condition)
+			where T : class
+		{
+			if (expression.IsProperty())
+			{
+				return SetupGet(mock, expression, condition);
+			}
+
+			var methodCall = expression.GetCallInfo(mock);
+			var method = methodCall.Method;
+			var args = methodCall.Arguments.ToArray();
+
+			ThrowIfSetupExpressionInvolvesUnsupportedMember(expression, method);
+			ThrowIfSetupMethodNotVisibleToProxyFactory(method);
+			var call = new MethodCallReturn<T, TResult>(mock, condition, expression, method, args);
+
+			var targetInterceptor = GetInterceptor(methodCall.Object, mock);
+
+			targetInterceptor.AddCall(call, SetupKind.Other);
+
+			return call;
+		}
+
+		[DebuggerStepThrough]
 		internal static MethodCallReturn<T, TProperty> SetupGet<T, TProperty>(
 			Mock<T> mock,
 			Expression<Func<T, TProperty>> expression,
 			Condition condition)
 			where T : class
 		{
-			return PexProtector.Invoke(() =>
-			{
-				if (expression.IsPropertyIndexer())
-				{
-					// Treat indexers as regular method invocations.
-					return Setup<T, TProperty>(mock, expression, condition);
-				}
-
-				var prop = expression.ToPropertyInfo();
-				ThrowIfPropertyNotReadable(prop);
-
-				var propGet = prop.GetGetMethod(true);
-				ThrowIfSetupExpressionInvolvesUnsupportedMember(expression, propGet);
-				ThrowIfSetupMethodNotVisibleToProxyFactory(propGet);
-
-				var call = new MethodCallReturn<T, TProperty>(mock, condition, expression, propGet, new Expression[0]);
-				// Directly casting to MemberExpression is fine as ToPropertyInfo would throw if it wasn't
-				var targetInterceptor = GetInterceptor(((MemberExpression)expression.Body).Expression, mock);
-
-				targetInterceptor.AddCall(call, SetupKind.Other);
-
-				return call;
-			});
+			return PexProtector.Invoke(SetupGetPexProtected, mock, expression, condition);
 		}
 
+		private static MethodCallReturn<T, TProperty> SetupGetPexProtected<T, TProperty>(
+			Mock<T> mock,
+			Expression<Func<T, TProperty>> expression,
+			Condition condition)
+			where T : class
+		{
+			if (expression.IsPropertyIndexer())
+			{
+				// Treat indexers as regular method invocations.
+				return Setup<T, TProperty>(mock, expression, condition);
+			}
+
+			var prop = expression.ToPropertyInfo();
+			ThrowIfPropertyNotReadable(prop);
+
+			var propGet = prop.GetGetMethod(true);
+			ThrowIfSetupExpressionInvolvesUnsupportedMember(expression, propGet);
+			ThrowIfSetupMethodNotVisibleToProxyFactory(propGet);
+
+			var call = new MethodCallReturn<T, TProperty>(mock, condition, expression, propGet, new Expression[0]);
+			// Directly casting to MemberExpression is fine as ToPropertyInfo would throw if it wasn't
+			var targetInterceptor = GetInterceptor(((MemberExpression)expression.Body).Expression, mock);
+
+			targetInterceptor.AddCall(call, SetupKind.Other);
+
+			return call;
+		}
+
+		[DebuggerStepThrough]
 		internal static SetterMethodCall<T, TProperty> SetupSet<T, TProperty>(
 			Mock<T> mock,
 			Action<T> setterExpression,
 			Condition condition)
 			where T : class
 		{
-			return PexProtector.Invoke(() =>
-			{
-				return SetupSetImpl<T, SetterMethodCall<T, TProperty>>(
-					mock,
-					setterExpression,
-					(m, expr, method, value) =>
-					{
-						var call = new SetterMethodCall<T, TProperty>(m, condition, expr, method, value[0]);
-						m.Interceptor.AddCall(call, SetupKind.PropertySet);
-						return call;
-					});
-			});
+			return PexProtector.Invoke(SetupSetPexProtected<T, TProperty>, mock, setterExpression, condition);
 		}
 
+		private static SetterMethodCall<T, TProperty> SetupSetPexProtected<T, TProperty>(
+			Mock<T> mock,
+			Action<T> setterExpression,
+			Condition condition)
+			where T : class
+		{
+			return SetupSetImpl<T, SetterMethodCall<T, TProperty>>(
+				mock,
+				setterExpression,
+				(m, expr, method, value) =>
+				{
+					var call = new SetterMethodCall<T, TProperty>(m, condition, expr, method, value[0]);
+					m.Interceptor.AddCall(call, SetupKind.PropertySet);
+					return call;
+				});
+		}
+
+		[DebuggerStepThrough]
 		internal static MethodCall<T> SetupSet<T>(Mock<T> mock, Action<T> setterExpression, Condition condition)
 			where T : class
 		{
-			return PexProtector.Invoke(() =>
-			{
-				return SetupSetImpl<T, MethodCall<T>>(
-					mock,
-					setterExpression,
-					(m, expr, method, values) =>
-					{
-						var call = new MethodCall<T>(m, condition, expr, method, values);
-						m.Interceptor.AddCall(call, SetupKind.PropertySet);
-						return call;
-					});
-			});
+			return PexProtector.Invoke(SetupSetPexProtected, mock, setterExpression, condition);
+		}
+
+		private static MethodCall<T> SetupSetPexProtected<T>(Mock<T> mock, Action<T> setterExpression, Condition condition)
+			where T : class
+		{
+			return SetupSetImpl<T, MethodCall<T>>(
+				mock,
+				setterExpression,
+				(m, expr, method, values) =>
+				{
+					var call = new MethodCall<T>(m, condition, expr, method, values);
+					m.Interceptor.AddCall(call, SetupKind.PropertySet);
+					return call;
+				});
 		}
 
 		internal static SetterMethodCall<T, TProperty> SetupSet<T, TProperty>(
@@ -704,13 +734,16 @@ namespace Moq
 			return new SetupSequencePhrase(setup);
 		}
 
+		[DebuggerStepThrough]
 		internal static void SetupAllProperties(Mock mock)
 		{
-			PexProtector.Invoke(() =>
-			{
-				var mockedTypesStack = new Stack<Type>();
-				SetupAllProperties(mock, mockedTypesStack);
-			});
+			PexProtector.Invoke(SetupAllPropertiesPexProtected, mock);
+		}
+
+		private static void SetupAllPropertiesPexProtected(Mock mock)
+		{
+			var mockedTypesStack = new Stack<Type>();
+			SetupAllProperties(mock, mockedTypesStack);
 		}
 
 		private static void SetupAllProperties(Mock mock, Stack<Type> mockedTypesStack)

--- a/Source/PexProtector.cs
+++ b/Source/PexProtector.cs
@@ -51,14 +51,22 @@ namespace Moq
 	[DebuggerStepThrough]
 	internal static class PexProtector
 	{
+		[DebuggerHidden]
 		public static void Invoke(Action action)
 		{
 			action();
 		}
 
-		public static T Invoke<T>(Func<T> function)
+		[DebuggerHidden]
+		public static void Invoke<T1>(Action<T1> action, T1 arg1)
 		{
-			return function();
+			action(arg1);
+		}
+
+		[DebuggerHidden]
+		public static TResult Invoke<T1, T2, T3, TResult>(Func<T1, T2, T3, TResult> function, T1 arg1, T2 arg2, T3 arg3)
+		{
+			return function(arg1, arg2, arg3);
 		}
 	}
 }


### PR DESCRIPTION
`PexProtector.Invoke` annoyingly breaks step-debugging through affected parts of Moq's source code. This commit solves this (and, besides, reduces object allocations caused by the lambda's variable capturing).

Hopefully, at a later point, we can get rid of `PexProtector` entirely. (Is anyone actually using Pex / Smart Unit Tests / IntelliTest these days?)