### PR TITLE
Prevent Moq from relying on a mock's implementation of IEnumerable<T>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * Record calls to methods that are named like event accessors (`add_X`, `remove_X`) so they can be verified (@stakx, #488)
 * Improve recognition logic for sealed methods so that `Setup` throws when an attempt is made to set one up (@stakx, #497)
 * Let `SetupAllProperties` skip inaccessible methods (@stakx, #499)
+* Prevent Moq from relying on a mock's implementation of `IEnumerable<T>` (@stakx, #510)
 
 ## 4.7.142 (2017-10-11)
 

--- a/Moq.Tests/Moq.Tests.csproj
+++ b/Moq.Tests/Moq.Tests.csproj
@@ -27,6 +27,7 @@
 		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+		<PackageReference Include="EntityFramework" Version="6.2.0" />
 		<Reference Include="System.Web" />
 		<Reference Include="System.Windows.Forms" />
 	</ItemGroup>

--- a/Source/ExpressionStringBuilder.cs
+++ b/Source/ExpressionStringBuilder.cs
@@ -258,8 +258,8 @@ namespace Moq
 				{
 					builder.Append("\"").Append(value).Append("\"");
 				}
-				else if (value is IEnumerable enumerable && enumerable.GetEnumerator() != null)
-				{                                        // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+				else if (value is IEnumerable enumerable && !(value is IMocked))
+				{                                        // ^^^^^^^^^^^^^^^^^^^
 					// This second check ensures that we have a usable implementation of IEnumerable.
 					// If value is a mocked object, its IEnumerable implementation might very well
 					// not work correctly.

--- a/Source/Extensions.cs
+++ b/Source/Extensions.cs
@@ -88,8 +88,8 @@ namespace Moq
 			{
 				return "\"" + typedValue + "\"";
 			}
-			if (value is IEnumerable enumerable && enumerable.GetEnumerator() != null)
-			{                                   // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+			if (value is IEnumerable enumerable && !(value is IMocked))
+			{                                   // ^^^^^^^^^^^^^^^^^^^
 				// This second check ensures that we have a usable implementation of IEnumerable.
 				// If value is a mocked object, its IEnumerable implementation might very well
 				// not work correctly.


### PR DESCRIPTION
This resolves both #464 (for which a regression test is added) and #478.