### PR TITLE
Remove leaked `MockVerificationException` and catch-throw-recatch cycle during verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * Improve recognition logic for sealed methods so that `Setup` throws when an attempt is made to set one up (@stakx, #497)
 * Let `SetupAllProperties` skip inaccessible methods (@stakx, #499)
 * Prevent Moq from relying on a mock's implementation of `IEnumerable<T>` (@stakx, #510)
+* Verification leaked internal `MockVerificationException` type; remove it (@stakx, #511)
+
 
 ## 4.7.142 (2017-10-11)
 

--- a/Moq.Tests/AsInterfaceFixture.cs
+++ b/Moq.Tests/AsInterfaceFixture.cs
@@ -85,15 +85,10 @@ namespace Moq.Tests
 			bag.Setup(b => b.Add("foo", "bar")).Verifiable();
 			foo.Setup(f => f.Execute()).Verifiable();
 
-			try
-			{
-				bag.Verify();
-			}
-			catch (MockVerificationException me)
-			{
-				Assert.Contains(typeof(IFoo).Name, me.Message);
-				Assert.Contains(typeof(IBag).Name, me.Message);
-			}
+			var me = Assert.Throws<MockException>(() => bag.Verify());
+			Assert.True(me.IsVerificationError);
+			Assert.Contains(typeof(IFoo).Name, me.Message);
+			Assert.Contains(typeof(IBag).Name, me.Message);
 		}
 
 		[Fact]
@@ -130,8 +125,12 @@ namespace Moq.Tests
 
 			foo.Setup(f => f.Execute()).Verifiable();
 
-			Assert.Throws<MockVerificationException>(() => foo.Verify());
-			Assert.Throws<MockVerificationException>(() => foo.VerifyAll());
+			var ex = Assert.Throws<MockException>(() => foo.Verify());
+			Assert.True(ex.IsVerificationError);
+
+			ex = Assert.Throws<MockException>(() => foo.VerifyAll());
+			Assert.True(ex.IsVerificationError);
+
 			Assert.Throws<MockException>(() => foo.Verify(f => f.Execute()));
 
 			foo.Object.Execute();

--- a/Moq.Tests/MockDefaultValueProviderFixture.cs
+++ b/Moq.Tests/MockDefaultValueProviderFixture.cs
@@ -90,7 +90,8 @@ namespace Moq.Tests
 			var barMock = Mock.Get((IBar)value);
 			barMock.Setup(b => b.Do()).Verifiable();
 
-			Assert.Throws<MockVerificationException>(() => mock.Verify());
+			var ex = Assert.Throws<MockException>(() => mock.Verify());
+			Assert.True(ex.IsVerificationError);
 		}
 
 		[Fact]

--- a/Moq.Tests/MockFixture.cs
+++ b/Moq.Tests/MockFixture.cs
@@ -487,11 +487,13 @@ namespace Moq.Tests
 
 			mock.SetupSet(foo => foo.Count = 5);
 
-			Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+			var ex = Assert.Throws<MockException>(() => mock.VerifyAll());
+			Assert.True(ex.IsVerificationError);
 
 			mock.Object.Count = 6;
 
-			Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+			ex = Assert.Throws<MockException>(() => mock.VerifyAll());
+			Assert.True(ex.IsVerificationError);
 
 			mock.Object.Count = 5;
 
@@ -525,7 +527,8 @@ namespace Moq.Tests
 
 			mock.SetupSet(foo => foo.Count = It.IsAny<int>());
 
-			Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+			var ex = Assert.Throws<MockException>(() => mock.VerifyAll());
+			Assert.True(ex.IsVerificationError);
 
 			mock.Object.Count = 6;
 
@@ -539,11 +542,13 @@ namespace Moq.Tests
 
 			mock.SetupSet(foo => foo.Count = It.IsInRange(1, 5, Range.Inclusive));
 
-			Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+			var ex = Assert.Throws<MockException>(() => mock.VerifyAll());
+			Assert.True(ex.IsVerificationError);
 
 			mock.Object.Count = 6;
 
-			Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+			ex = Assert.Throws<MockException>(() => mock.VerifyAll());
+			Assert.True(ex.IsVerificationError);
 
 			mock.Object.Count = 5;
 
@@ -557,11 +562,13 @@ namespace Moq.Tests
 
 			mock.SetupSet(foo => foo.Count = It.Is<int>(v => v % 2 == 0));
 
-			Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+			var ex = Assert.Throws<MockException>(() => mock.VerifyAll());
+			Assert.True(ex.IsVerificationError);
 
 			mock.Object.Count = 7;
 
-			Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+			ex = Assert.Throws<MockException>(() => mock.VerifyAll());
+			Assert.True(ex.IsVerificationError);
 
 			mock.Object.Count = 4;
 
@@ -589,7 +596,8 @@ namespace Moq.Tests
 
 			mock.SetupSet(foo => foo.Count = 5);
 
-			Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+			var ex = Assert.Throws<MockException>(() => mock.VerifyAll());
+			Assert.True(ex.IsVerificationError);
 
 			mock.Object.Count = 5;
 			mock.VerifyAll();
@@ -655,11 +663,13 @@ namespace Moq.Tests
 
 			mock.SetupSet(foo => foo.Value = 5);
 
-			Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+			var ex = Assert.Throws<MockException>(() => mock.VerifyAll());
+			Assert.True(ex.IsVerificationError);
 
 			mock.Object.Value = 6;
 
-			Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+			ex = Assert.Throws<MockException>(() => mock.VerifyAll());
+			Assert.True(ex.IsVerificationError);
 
 			mock.Object.Value = 5;
 
@@ -674,11 +684,13 @@ namespace Moq.Tests
 
 			mock.SetupSet(foo => foo.Object = obj);
 
-			Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+			var ex = Assert.Throws<MockException>(() => mock.VerifyAll());
+			Assert.True(ex.IsVerificationError);
 
 			mock.Object.Object = new object();
 
-			Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+			ex = Assert.Throws<MockException>(() => mock.VerifyAll());
+			Assert.True(ex.IsVerificationError);
 
 			mock.Object.Object = obj;
 
@@ -692,7 +704,8 @@ namespace Moq.Tests
 
 			mock.SetupSet<string>(foo => foo.Bar.Value = "bar");
 
-			Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+			var ex = Assert.Throws<MockException>(() => mock.VerifyAll());
+			Assert.True(ex.IsVerificationError);
 
 			mock.Object.Bar.Value = "bar";
 
@@ -706,7 +719,9 @@ namespace Moq.Tests
 			mock.SetupSet(m => m.Value = null);
 
 			Assert.Throws<MockException>(() => { mock.Object.Value = 5; });
-			Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+
+			var ex = Assert.Throws<MockException>(() => mock.VerifyAll());
+			Assert.True(ex.IsVerificationError);
 
 			mock.Object.Value = null;
 

--- a/Moq.Tests/RecursiveMocksFixture.cs
+++ b/Moq.Tests/RecursiveMocksFixture.cs
@@ -78,7 +78,8 @@ namespace Moq.Tests
 			mock.SetupSet(m => m.Bar.Value = 5);
 
 			Assert.NotNull(mock.Object.Bar);
-			Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+			var ex = Assert.Throws<MockException>(() => mock.VerifyAll());
+			Assert.True(ex.IsVerificationError);
 
 			mock.Object.Bar.Value = 5;
 
@@ -93,7 +94,8 @@ namespace Moq.Tests
 			mock.SetupSet(m => m.Bar.Value = It.IsAny<int>());
 
 			Assert.NotNull(mock.Object.Bar);
-			Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+			var ex = Assert.Throws<MockException>(() => mock.VerifyAll());
+			Assert.True(ex.IsVerificationError);
 
 			mock.Object.Bar.Value = 5;
 
@@ -111,7 +113,8 @@ namespace Moq.Tests
 			mock.Object.Do("ping");
 			var bar = mock.Object.Bar;
 
-			Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+			var ex = Assert.Throws<MockException>(() => mock.VerifyAll());
+			Assert.True(ex.IsVerificationError);
 		}
 
 		[Fact]
@@ -125,7 +128,8 @@ namespace Moq.Tests
 			mock.Object.Do("ping");
 			var bar = mock.Object.Bar;
 
-			Assert.Throws<MockVerificationException>(() => mock.Verify());
+			var ex = Assert.Throws<MockException>(() => mock.Verify());
+			Assert.True(ex.IsVerificationError);
 		}
 
 		[Fact]

--- a/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2059,7 +2059,8 @@ namespace Moq.Tests.Regressions
 				var target = new Mock<IFoo>();
 				target.Setup(t => t.Submit(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>()));
 
-				var e = Assert.Throws<MockVerificationException>(() => target.VerifyAll());
+				var e = Assert.Throws<MockException>(() => target.VerifyAll());
+				Assert.True(e.IsVerificationError);
 
 				Assert.Contains(
 					"IFoo t => t.Submit(It.IsAny<String>(), It.IsAny<String>(), new[] { It.IsAny<Int32>() })",

--- a/Moq.Tests/VerifyFixture.cs
+++ b/Moq.Tests/VerifyFixture.cs
@@ -15,8 +15,8 @@ namespace Moq.Tests
 
 			mock.Setup(x => x.Submit()).Verifiable();
 
-			var mex = Assert.Throws<MockVerificationException>(() => mock.Verify());
-			Assert.Equal(MockException.ExceptionReason.VerificationFailed, mex.Reason);
+			var mex = Assert.Throws<MockException>(() => mock.Verify());
+			Assert.True(mex.IsVerificationError);
 		}
 
 		[Fact]
@@ -26,9 +26,9 @@ namespace Moq.Tests
 
 			mock.Setup(x => x.Submit()).Verifiable("Kaboom!");
 
-			var mex = Assert.Throws<MockVerificationException>(() => mock.Verify());
+			var mex = Assert.Throws<MockException>(() => mock.Verify());
+			Assert.True(mex.IsVerificationError);
 			Assert.Contains("Kaboom!", mex.Message);
-			Assert.Equal(MockException.ExceptionReason.VerificationFailed, mex.Reason);
 		}
 
 		[Fact]
@@ -41,8 +41,8 @@ namespace Moq.Tests
 				.Returns("ack")
 				.Verifiable();
 
-			var mex = Assert.Throws<MockVerificationException>(() => mock.Verify());
-			Assert.Equal(MockException.ExceptionReason.VerificationFailed, mex.Reason);
+			var mex = Assert.Throws<MockException>(() => mock.Verify());
+			Assert.True(mex.IsVerificationError);
 			Assert.True(mex.Message.Contains(@".Execute(""lorem"")"), "Contains evaluated expected argument.");
 		}
 
@@ -55,8 +55,8 @@ namespace Moq.Tests
 				.Returns("ack")
 				.Verifiable();
 
-			var mex = Assert.Throws<MockVerificationException>(() => mock.Verify());
-			Assert.Equal(MockException.ExceptionReason.VerificationFailed, mex.Reason);
+			var mex = Assert.Throws<MockException>(() => mock.Verify());
+			Assert.True(mex.IsVerificationError);
 			Assert.Contains(@".Execute(It.Is<String>(s => String.IsNullOrEmpty(s)))", mex.Message);
 		}
 
@@ -75,8 +75,8 @@ namespace Moq.Tests
 
 			mock.Setup(x => x.Submit());
 
-			var mex = Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
-			Assert.Equal(MockException.ExceptionReason.VerificationFailed, mex.Reason);
+			var mex = Assert.Throws<MockException>(() => mock.VerifyAll());
+			Assert.True(mex.IsVerificationError);
 		}
 
 		[Fact]
@@ -1121,7 +1121,8 @@ namespace SomeNamespace
 			mock.Setup(x => x.Echo(1));
 			mock.Setup(x => x.Execute("ping"));
 
-			var ex = Assert.Throws<MockVerificationException>(() => mock.VerifyAll());
+			var ex = Assert.Throws<MockException>(() => mock.VerifyAll());
+			Assert.True(ex.IsVerificationError);
 			Assert.Contains("x => x.Submit()", ex.Message);
 			Assert.Contains("x => x.Echo(1)", ex.Message);
 			Assert.Contains("x => x.Execute(\"ping\")", ex.Message);

--- a/Source/Diagnostics/Errors/IError.cs
+++ b/Source/Diagnostics/Errors/IError.cs
@@ -1,0 +1,47 @@
+﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//https://github.com/moq/moq4
+//All rights reserved.
+
+//Redistribution and use in source and binary forms, 
+//with or without modification, are permitted provided 
+//that the following conditions are met:
+
+//    * Redistributions of source code must retain the 
+//    above copyright notice, this list of conditions and 
+//    the following disclaimer.
+
+//    * Redistributions in binary form must reproduce 
+//    the above copyright notice, this list of conditions 
+//    and the following disclaimer in the documentation 
+//    and/or other materials provided with the distribution.
+
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
+//    names of its contributors may be used to endorse 
+//    or promote products derived from this software 
+//    without specific prior written permission.
+
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+//SUCH DAMAGE.
+
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+namespace Moq.Diagnostics.Errors
+{
+	internal interface IError
+	{
+		string Message { get; }
+	}
+}

--- a/Source/Diagnostics/Errors/UnmatchedSetups.cs
+++ b/Source/Diagnostics/Errors/UnmatchedSetups.cs
@@ -64,7 +64,7 @@ namespace Moq.Diagnostics.Errors
 			string.Format(
 				CultureInfo.CurrentCulture,
 				Resources.VerficationFailed,
-				this.setups.Reverse().Aggregate(new StringBuilder(), (builder, setup) => builder.AppendLine(setup.ToString())).ToString());
+				this.setups.Aggregate(new StringBuilder(), (builder, setup) => builder.AppendLine(setup.ToString())).ToString());
 
 		public IEnumerable<IProxyCall> Setups => this.setups;
 

--- a/Source/Diagnostics/Errors/UnmatchedSetups.cs
+++ b/Source/Diagnostics/Errors/UnmatchedSetups.cs
@@ -1,0 +1,73 @@
+﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//https://github.com/moq/moq4
+//All rights reserved.
+
+//Redistribution and use in source and binary forms, 
+//with or without modification, are permitted provided 
+//that the following conditions are met:
+
+//    * Redistributions of source code must retain the 
+//    above copyright notice, this list of conditions and 
+//    the following disclaimer.
+
+//    * Redistributions in binary form must reproduce 
+//    the above copyright notice, this list of conditions 
+//    and the following disclaimer in the documentation 
+//    and/or other materials provided with the distribution.
+
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
+//    names of its contributors may be used to endorse 
+//    or promote products derived from this software 
+//    without specific prior written permission.
+
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+//SUCH DAMAGE.
+
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+using Moq.Properties;
+
+namespace Moq.Diagnostics.Errors
+{
+	internal sealed class UnmatchedSetups : IError
+	{
+		private IEnumerable<IProxyCall> setups;
+
+		public UnmatchedSetups(IEnumerable<IProxyCall> setups)
+		{
+			Debug.Assert(setups != null);
+			Debug.Assert(setups.Any());
+
+			this.setups = setups;
+		}
+
+		public string Message =>
+			string.Format(
+				CultureInfo.CurrentCulture,
+				Resources.VerficationFailed,
+				this.setups.Reverse().Aggregate(new StringBuilder(), (builder, setup) => builder.AppendLine(setup.ToString())).ToString());
+
+		public IEnumerable<IProxyCall> Setups => this.setups;
+
+		public MockException AsMockException() => new MockException(MockException.ExceptionReason.VerificationFailed, this);
+	}
+}

--- a/Source/Diagnostics/Errors/UnmatchedSetupsAggregated.cs
+++ b/Source/Diagnostics/Errors/UnmatchedSetupsAggregated.cs
@@ -1,0 +1,74 @@
+﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//https://github.com/moq/moq4
+//All rights reserved.
+
+//Redistribution and use in source and binary forms, 
+//with or without modification, are permitted provided 
+//that the following conditions are met:
+
+//    * Redistributions of source code must retain the 
+//    above copyright notice, this list of conditions and 
+//    the following disclaimer.
+
+//    * Redistributions in binary form must reproduce 
+//    the above copyright notice, this list of conditions 
+//    and the following disclaimer in the documentation 
+//    and/or other materials provided with the distribution.
+
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
+//    names of its contributors may be used to endorse 
+//    or promote products derived from this software 
+//    without specific prior written permission.
+
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+//SUCH DAMAGE.
+
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+using Moq.Properties;
+
+namespace Moq.Diagnostics.Errors
+{
+	internal sealed class UnmatchedSetupsAggregated : IError
+	{
+		private IEnumerable<UnmatchedSetups> errors;
+
+		public UnmatchedSetupsAggregated(IEnumerable<UnmatchedSetups> errors)
+		{
+			Debug.Assert(errors != null);
+			Debug.Assert(errors.Any());
+
+			this.errors = errors;
+		}
+
+		public string Message =>
+			string.Format(
+				CultureInfo.CurrentCulture,
+				Resources.VerficationFailed,
+				string.Join(
+					Environment.NewLine,
+					this.errors.Select(error => error.Setups.Reverse().Aggregate(new StringBuilder(), (builder, setup) => builder.AppendLine(setup.ToString())))));
+
+		public MockException AsMockException() => new MockException(MockException.ExceptionReason.VerificationFailed, this);
+	}
+}

--- a/Source/Diagnostics/Errors/UnmatchedSetupsAggregated.cs
+++ b/Source/Diagnostics/Errors/UnmatchedSetupsAggregated.cs
@@ -67,7 +67,7 @@ namespace Moq.Diagnostics.Errors
 				Resources.VerficationFailed,
 				string.Join(
 					Environment.NewLine,
-					this.errors.Select(error => error.Setups.Reverse().Aggregate(new StringBuilder(), (builder, setup) => builder.AppendLine(setup.ToString())))));
+					this.errors.Select(error => error.Setups.Aggregate(new StringBuilder(), (builder, setup) => builder.AppendLine(setup.ToString())))));
 
 		public MockException AsMockException() => new MockException(MockException.ExceptionReason.VerificationFailed, this);
 	}

--- a/Source/Interceptor.cs
+++ b/Source/Interceptor.cs
@@ -111,7 +111,7 @@ namespace Moq
 
 			if (failures.Any())
 			{
-				throw new MockVerificationException(failures);
+				throw new MockException(failures);
 			}
 		}
 

--- a/Source/Interceptor.cs
+++ b/Source/Interceptor.cs
@@ -45,6 +45,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
+using Moq.Diagnostics.Errors;
 using Moq.Proxy;
 
 namespace Moq
@@ -111,7 +112,7 @@ namespace Moq
 
 			if (failures.Any())
 			{
-				throw new MockException(failures);
+				throw new UnmatchedSetups(failures).AsMockException();
 			}
 		}
 

--- a/Source/Interceptor.cs
+++ b/Source/Interceptor.cs
@@ -75,7 +75,7 @@ namespace Moq
 
 		private void VerifyOrThrow(Func<IProxyCall, bool> match)
 		{
-			var failures = new List<IProxyCall>();
+			var failures = new Stack<IProxyCall>();
 
 			// The following verification logic will remember each processed setup so that duplicate setups
 			// (that is, setups overridden by later setups with an equivalent expression) can be detected.
@@ -104,7 +104,7 @@ namespace Moq
 
 				if (match(setup))
 				{
-					failures.Add(setup);
+					failures.Push(setup);
 				}
 
 				verifiedSetupsForMethod.Add(expr);

--- a/Source/Interceptor.cs
+++ b/Source/Interceptor.cs
@@ -63,17 +63,17 @@ namespace Moq
 
 		internal InterceptorContext InterceptionContext { get; private set; }
 
-		internal void Verify()
+		internal bool TryVerify(out UnmatchedSetups error)
 		{
-			VerifyOrThrow(call => call.IsVerifiable && !call.Invoked);
+			return this.TryVerifyOrThrow(call => call.IsVerifiable && !call.Invoked, out error);
 		}
 
-		internal void VerifyAll()
+		internal bool TryVerifyAll(out UnmatchedSetups error)
 		{
-			VerifyOrThrow(call => !call.Invoked);
+			return this.TryVerifyOrThrow(call => !call.Invoked, out error);
 		}
 
-		private void VerifyOrThrow(Func<IProxyCall, bool> match)
+		private bool TryVerifyOrThrow(Func<IProxyCall, bool> match, out UnmatchedSetups error)
 		{
 			var failures = new Stack<IProxyCall>();
 
@@ -112,7 +112,13 @@ namespace Moq
 
 			if (failures.Any())
 			{
-				throw new UnmatchedSetups(failures).AsMockException();
+				error = new UnmatchedSetups(failures);
+				return false;
+			}
+			else
+			{
+				error = null;
+				return true;
 			}
 		}
 

--- a/Source/Obsolete/MockFactory.cs
+++ b/Source/Obsolete/MockFactory.cs
@@ -321,7 +321,7 @@ namespace Moq
 		/// <summary>
 		/// Invokes <paramref name="verifyAction"/> for each mock 
 		/// in <see cref="Mocks"/>, and accumulates the resulting 
-		/// <see cref="MockVerificationException"/> that might be 
+		/// verification exceptions that might be
 		/// thrown from the action.
 		/// </summary>
 		/// <param name="verifyAction">The action to execute against 
@@ -338,7 +338,7 @@ namespace Moq
 				{
 					verifyAction(mock);
 				}
-				catch (MockVerificationException mve)
+				catch (MockException mve) when (mve.FailedSetups != null)
 				{
 					message.AppendLine(mve.GetRawSetups());
 				}


### PR DESCRIPTION
Closes #507.