### PR TITLE
Turn collection of source file information per setup into an opt-in feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
+## 4.7.145 (2017-11-06)
+
+#### Changed
+
+* Moq no longer collects source file information for verification error messages by default. A current .NET Framework regression (https://github.com/Microsoft/dotnet/issues/529) makes this extremely costly, so this is now an opt-in feature; see `Switches.CollectSourceFileInfoForSetups` (@stakx, #515)
+
+#### Added
+
+* `Mock.Switches` and `MockRepository.Switches`, which allow opting in and out of certain features (@stakx, #515)
+
+
 ## 4.7.142 (2017-10-11)
 
 #### Changed

--- a/Source/AsInterface.cs
+++ b/Source/AsInterface.cs
@@ -95,6 +95,12 @@ namespace Moq
 			get { return this.owner.Object as TInterface; }
 		}
 
+		public override Switches Switches
+		{
+			get => this.owner.Switches;
+			set => this.owner.Switches = value;
+		}
+
 		public override Mock<TNewInterface> As<TNewInterface>()
 		{
 			return this.owner.As<TNewInterface>();

--- a/Source/MethodCall.cs
+++ b/Source/MethodCall.cs
@@ -181,9 +181,14 @@ namespace Moq
 		[SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
 		private void SetFileInfo()
 		{
+#if !NETCORE
+			if ((this.Mock.Switches & Switches.CollectDiagnosticFileInfoForSetups) == 0)
+			{
+				return;
+			}
+
 			try
 			{
-#if !NETCORE
 				var thisMethod = MethodBase.GetCurrentMethod();
 				var mockAssembly = Assembly.GetExecutingAssembly();
 				// Move 'till we're at the entry point into Moq API
@@ -199,12 +204,12 @@ namespace Moq
 					this.FileName = Path.GetFileName(frame.GetFileName());
 					this.TestMethod = frame.GetMethod();
 				}
-#endif
 			}
 			catch
 			{
 				// Must NEVER fail, as this is a nice-to-have feature only.
 			}
+#endif
 		}
 
 		public void SetOutParameters(ICallContext call)

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -60,12 +60,14 @@ namespace Moq
 		private bool isInitialized;
 		private DefaultValue defaultValue = DefaultValue.Empty;
 		private IDefaultValueProvider defaultValueProvider = new EmptyDefaultValueProvider();
+		private Switches switches;
 
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.ctor"]/*'/>
 		protected Mock()
 		{
 			this.ImplementedInterfaces = new List<Type>();
 			this.InnerMocks = new ConcurrentDictionary<MethodInfo, Mock>();
+			this.switches = Switches.Default;
 		}
 
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.Get"]/*'/>
@@ -227,6 +229,16 @@ namespace Moq
 		/// defined internally, rather than through calls to <see cref="As{TInterface}"/>.
 		/// </summary>
 		internal protected int InternallyImplementedInterfaceCount { get; protected set; }
+
+		/// <summary>
+		/// A set of switches that influence how this mock will operate.
+		/// You can opt in or out of certain features via this property.
+		/// </summary>
+		public virtual Switches Switches
+		{
+			get => this.switches;
+			set => this.switches = value;
+		}
 
 		#region Verify
 

--- a/Source/Obsolete/MockFactory.cs
+++ b/Source/Obsolete/MockFactory.cs
@@ -137,6 +137,7 @@ namespace Moq
 	{
 		List<Mock> mocks = new List<Mock>();
 		MockBehavior defaultBehavior;
+		private Switches switches;
 
 		/// <summary>
 		/// Initializes the factory with the given <paramref name="defaultBehavior"/> 
@@ -148,6 +149,7 @@ namespace Moq
 		public MockFactory(MockBehavior defaultBehavior)
 		{
 			this.defaultBehavior = defaultBehavior;
+			this.switches = Switches.Default;
 		}
 
 		/// <summary>
@@ -167,6 +169,16 @@ namespace Moq
 		/// that will get verified together.
 		/// </summary>
 		protected internal IEnumerable<Mock> Mocks { get { return mocks; } }
+
+		/// <summary>
+		/// A set of switches that influence how mocks created by this factory will operate.
+		/// You can opt in or out of certain features via this property.
+		/// </summary>
+		public Switches Switches
+		{
+			get => this.switches;
+			set => this.switches = value;
+		}
 
 		/// <summary>
 		/// Creates a new mock with the default <see cref="MockBehavior"/> 
@@ -292,6 +304,7 @@ namespace Moq
 
 			mock.CallBase = this.CallBase;
 			mock.DefaultValue = this.DefaultValue;
+			mock.Switches = this.switches;
 
 			return mock;
 		}

--- a/Source/Switches.cs
+++ b/Source/Switches.cs
@@ -39,44 +39,25 @@
 // http://www.opensource.org/licenses/bsd-license.php]
 
 using System;
-using System.Reflection;
 
 namespace Moq
 {
 	/// <summary>
-	/// A <see cref="IDefaultValueProvider"/> that returns an empty default value 
-	/// for non-mockeable types, and mocks for all other types (interfaces and 
-	/// non-sealed classes) that can be mocked.
+	/// Represents a switch, or a combination of switches, that can be either enabled or disabled.
+	/// When set via <see cref="Mock.Switches"/> or <see cref="MockFactory.Switches"/>, they determine how a mock will operate.
 	/// </summary>
-	internal class MockDefaultValueProvider : EmptyDefaultValueProvider
+	[Flags]
+	public enum Switches
 	{
-		private Mock owner;
+		/// <summary>
+		/// The default set of switches. The switches covered by this enumeration value may change between different versions of Moq.
+		/// </summary>
+		Default = 0,
 
-		public MockDefaultValueProvider(Mock owner)
-		{
-			this.owner = owner;
-		}
-
-		public override object ProvideDefault(MethodInfo member)
-		{
-			var value = base.ProvideDefault(member);
-
-			Mock mock = null;
-			if (value == null && member.ReturnType.IsMockeable())
-			{
-				mock = owner.InnerMocks.GetOrAdd(member, info =>
-				{
-					// Create a new mock to be placed to InnerMocks dictionary if it's missing there
-					var mockType = typeof(Mock<>).MakeGenericType(info.ReturnType);
-					Mock newMock = (Mock)Activator.CreateInstance(mockType, owner.Behavior);
-					newMock.DefaultValue = owner.DefaultValue;
-					newMock.CallBase = owner.CallBase;
-					newMock.Switches = owner.Switches;
-					return newMock;
-				});
-			}
-
-			return mock != null ? mock.Object : value;
-		}
+		/// <summary>
+		/// When enabled, specifies that source file information should be collected for each setup.
+		/// This results in more helpful error messages, but may affect performance.
+		/// </summary>
+		CollectDiagnosticFileInfoForSetups = 1 << 0,
 	}
 }

--- a/UnitTests/MockDefaultValueProviderFixture.cs
+++ b/UnitTests/MockDefaultValueProviderFixture.cs
@@ -102,6 +102,17 @@ namespace Moq.Tests
 			Assert.Equal(DefaultValue.Empty, mockBar.DefaultValue);
 		}
 
+		[Fact]
+		public void Inner_mocks_inherit_switches_of_parent_mock()
+		{
+			const Switches expectedSwitches = Switches.CollectDiagnosticFileInfoForSetups;
+
+			var parentMock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock, Switches = expectedSwitches };
+			var innerMock = Mock.Get(parentMock.Object.Bar);
+
+			Assert.Equal(expectedSwitches, actual: innerMock.Switches);
+		}
+
 		public interface IFoo
 		{
 			IBar Bar { get; set; }

--- a/UnitTests/MockFixture.cs
+++ b/UnitTests/MockFixture.cs
@@ -922,6 +922,14 @@ namespace Moq.Tests
 			return new Foo(barMock.Object);
 		}
 
+		[Fact]
+		public void Mock_initially_uses_default_switches()
+		{
+			var mock = new Mock<IFoo>();
+
+			Assert.Equal(Switches.Default, actual: mock.Switches);
+		}
+
 		public class Foo
 		{
 			public Foo() : this(new Bar()) { }

--- a/UnitTests/MockRepositoryFixture.cs
+++ b/UnitTests/MockRepositoryFixture.cs
@@ -146,6 +146,25 @@ namespace Moq.Tests
 			Assert.True(mock.Object.BaseCalled);
 		}
 
+		[Fact]
+		public void Repository_initially_uses_default_switches()
+		{
+			var repository = new MockRepository(MockBehavior.Default);
+
+			Assert.Equal(Switches.Default, actual: repository.Switches);
+		}
+
+		[Fact]
+		public void Mock_inherits_switches_from_repository()
+		{
+			const Switches expectedSwitches = Switches.CollectDiagnosticFileInfoForSetups;
+
+			var repository = new MockRepository(MockBehavior.Default) { Switches = expectedSwitches };
+			var mock = repository.Create<IFoo>();
+
+			Assert.Equal(expectedSwitches, actual: mock.Switches);
+		}
+
 		public interface IFoo
 		{
 			void Do();

--- a/UnitTests/VerifyFixture.cs
+++ b/UnitTests/VerifyFixture.cs
@@ -981,6 +981,36 @@ namespace Moq.Tests
 			});
 		}
 
+#if !NETCORE
+		[Fact]
+		public void Enabling_diagnostic_file_info_leads_to_that_information_in_verification_error_messages()
+		{
+			var repository = new MockRepository(MockBehavior.Default);
+			repository.Switches |= Switches.CollectDiagnosticFileInfoForSetups;
+
+			var mock = repository.Create<IFoo>();
+			mock.Setup(m => m.Submit());
+
+			var ex = Assert.Throws<MockException>(() => repository.VerifyAll());
+			Assert.Contains("in ", ex.Message);
+			Assert.Contains("VerifyFixture.cs: line ", ex.Message);
+		}
+#endif
+
+		[Fact]
+		public void Disabling_diagnostic_file_info_leads_to_that_information_missing_in_verification_error_messages()
+		{
+			var repository = new MockRepository(MockBehavior.Default);
+			repository.Switches &= ~Switches.CollectDiagnosticFileInfoForSetups;
+
+			var mock = repository.Create<IFoo>();
+			mock.Setup(m => m.Submit());
+
+			var ex = Assert.Throws<MockException>(() => repository.VerifyAll());
+			Assert.DoesNotContain("in ", ex.Message);
+			Assert.DoesNotContain("VerifyFixture.cs: line ", ex.Message);
+		}
+
 		public interface IBar
 		{
 			int? Value { get; set; }


### PR DESCRIPTION
Up until now, Moq has been collecting source file information for each setup created. This came at a slight performance penalty. There is currently a regression in the .NET Framework which means this penalty becomes gigantic (more expensive than proxy creation!).

This commit turns source file information collection into an opt-in feature. Towards that end, a `Switches` property is added to `Mock` and `MockRepository` which allows users to opt in or out of certain features. Source file info collection is controlled via the switch `Switches.CollectDiagnosticFileInfoForSetups`.