### PR TITLE
Ensure custom matcher properties print correctly in verification error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * Let `SetupAllProperties` skip inaccessible methods (@stakx, #499)
 * Prevent Moq from relying on a mock's implementation of `IEnumerable<T>` (@stakx, #510)
 * Verification leaked internal `MockVerificationException` type; remove it (@stakx, #511)
+* Custom matcher properties not printed correctly in error messages (@stakx, #517)
 
 #### Obsoleted
 

--- a/Moq.Tests/CustomMatcherFixture.cs
+++ b/Moq.Tests/CustomMatcherFixture.cs
@@ -60,5 +60,42 @@ namespace Moq.Tests
 			bool Do(string value);
 			bool Do(int value);
 		}
+
+
+		[Fact]
+		public void Custom_matcher_property_appears_by_name_in_verification_error_message()
+		{
+			var child = new Mock<IChild>();
+			child.Setup(c => c.PlayWith(Toy.IsRed)).Verifiable();
+
+			var ex = Assert.Throws<MockException>(() => child.Verify());
+
+			Assert.Contains(".PlayWith(Toy.IsRed)", ex.Message);
+		}
+
+		[Fact]
+		public void Custom_matcher_method_appears_by_name_in_verification_error_message()
+		{
+			var child = new Mock<IChild>();
+			child.Setup(c => c.PlayWith(Toy.IsGreen())).Verifiable();
+
+			var ex = Assert.Throws<MockException>(() => child.Verify());
+
+			Assert.Contains(".PlayWith(Toy.IsGreen())", ex.Message);
+		}
+
+		public class Toy
+		{
+			public static Toy IsRed => Match.Create((Toy toy) => toy.Color == "red");
+
+			public static Toy IsGreen() => Match.Create((Toy toy) => toy.Color == "green");
+
+			public string Color { get; set; }
+		}
+
+		public interface IChild
+		{
+			void PlayWith(Toy toy);
+		}
 	}
 }

--- a/Source/ExpressionExtensions.cs
+++ b/Source/ExpressionExtensions.cs
@@ -196,11 +196,26 @@ namespace Moq
 		{
 			return Evaluator.PartialEval(
 				expression,
-				e => e.NodeType != ExpressionType.Parameter &&
-					(e.NodeType != ExpressionType.Call || !ReturnsMatch((MethodCallExpression)e)));
+				PartialMatcherAwareEval_ShouldEvaluate);
 		}
 
-		private static bool ReturnsMatch(MethodCallExpression expression)
+		private static bool PartialMatcherAwareEval_ShouldEvaluate(Expression expression)
+		{
+			switch (expression.NodeType)
+			{
+				case ExpressionType.Parameter:
+					return false;
+
+				case ExpressionType.Call:
+				case ExpressionType.MemberAccess:
+					return ReturnsMatch(expression) == false;
+
+				default:
+					return true;
+			}
+		}
+
+		private static bool ReturnsMatch(Expression expression)
 		{
 			using (var context = new FluentMockContext())
 			{


### PR DESCRIPTION
This closes #516.