### PR TITLE
Add optional validation of `Returns` delegate signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * Support for callbacks for methods having `ref` or `out` parameters via two new overloads of `Callback` and `Returns` (@stakx, #468)
 * Improved support for setting up and verifying protected members (including generic methods and methods having by-ref parameters) via the new duck-typing `mock.Protected().As<TDuck>()` interface (@stakx, #495, #501)
 * Support for `ValueTask<TResult>` when using the `ReturnsAsync` extension methods, similar to `Task<TResult>` (@AdamDotNet, #506)
+* On-demand verification of `Returns` delegate signatures (parameters and return type must match method being set up); enable with `Switches.ValidateReturnsDelegateSignatures` (@stakx, #519)
 
 #### Changed
 

--- a/Source/MethodCall.cs
+++ b/Source/MethodCall.cs
@@ -163,7 +163,9 @@ namespace Moq
 
 		bool IProxyCall.Invoked => this.callCount > 0;
 
-		MethodInfo IProxyCall.Method => this.method;
+		public MethodInfo Method => this.method;
+
+		public Mock Mock => this.mock;
 
 		Expression IProxyCall.SetupExpression => this.originalExpression;
 

--- a/Source/Properties/Resources.Designer.cs
+++ b/Source/Properties/Resources.Designer.cs
@@ -187,6 +187,15 @@ namespace Moq.Properties {
 		}
 		
 		/// <summary>
+		///   Looks up a localized string similar to Invalid callback. Setup on method with return type {0} cannot invoke callback with return type {1}..
+		/// </summary>
+		internal static string InvalidCallbackReturnTypeMismatch {
+			get {
+				return ResourceManager.GetString("InvalidCallbackReturnTypeMismatch", resourceCulture);
+			}
+		}
+		
+		/// <summary>
 		///   Looks up a localized string similar to Type to mock must be an interface or an abstract or non-sealed class. .
 		/// </summary>
 		internal static string InvalidMockClass {

--- a/Source/Properties/Resources.resx
+++ b/Source/Properties/Resources.resx
@@ -365,4 +365,7 @@ Expected invocation on the mock once, but was {4} times: {1}</value>
 	<data name="ProtectedMemberNotFound" xml:space="preserve">
 		<value>Type {0} does not have matching protected member: {1}</value>
 	</data>
+	<data name="InvalidCallbackReturnTypeMismatch" xml:space="preserve">
+		<value>Invalid callback. Setup on method with return type {0} cannot invoke callback with return type {1}.</value>
+	</data>
 </root>

--- a/Source/Switches.cs
+++ b/Source/Switches.cs
@@ -59,5 +59,10 @@ namespace Moq
 		/// This results in more helpful error messages, but may affect performance.
 		/// </summary>
 		CollectDiagnosticFileInfoForSetups = 1 << 0,
+
+		/// <summary>
+		/// When enabled, specifies that delegates passed to `Returns` must have a signature matching that of the method being set up.
+		/// </summary>
+		ValidateReturnsDelegateSignatures = 1 << 1,
 	}
 }


### PR DESCRIPTION
This is in response to #445. This new feature needs to start as an opt-in feature&mdash;enabled via `mockOrMockRepository.Switches |= Switches.ValidateReturnsDelegateSignatures`&mdash;since it could easily break existing user code.