### PR TITLE
Rewrite `EmptyDefaultValueProvider` to use dictionary lookup for special type handling

### DIFF
--- a/Source/EmptyDefaultValueProvider.cs
+++ b/Source/EmptyDefaultValueProvider.cs
@@ -156,12 +156,6 @@ namespace Moq
 
 		private static object GetValueTypeDefault(Type valueType)
 		{
-			// For nullable value types, return null.
-			if (valueType.GetTypeInfo().IsGenericType && valueType.GetGenericTypeDefinition() == typeof(Nullable<>))
-			{
-				return null;
-			}
-
 			return Activator.CreateInstance(valueType);
 		}
 	}


### PR DESCRIPTION
This is a lot more efficient (I observed speed-ups of simple mock method invocations by 67%) and makes it possible to easily add handling of additional types that are currently ignored (such as `List<T>`, `IReadOnlyList<T>`, etc.).