### PR TITLE
Prevent infinite loop when invoking delegate in `Mock.Of` setup expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * Prevent Moq from relying on a mock's implementation of `IEnumerable<T>` (@stakx, #510)
 * Verification leaked internal `MockVerificationException` type; remove it (@stakx, #511)
 * Custom matcher properties not printed correctly in error messages (@stakx, #517)
+* Infinite loop when invoking delegate in `Mock.Of` setup expression (@stakx, #528) 
 
 #### Obsoleted
 

--- a/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -891,6 +891,27 @@ namespace Moq.Tests.Regressions
 
 		#endregion // #184
 
+		#region 224
+
+		public class Issue224
+		{
+			[Fact]
+			public void Delegate_invocation_in_Mock_Of_does_not_cause_infinite_loop()
+			{
+				var infiniteLoopTimeout = TimeSpan.FromSeconds(5);
+
+				var timedOut = !Task.Run(() =>
+				{
+					var fn = Mock.Of<Func<int>>(f => f() == 42);
+					Assert.Equal(42, fn());
+				}).Wait(infiniteLoopTimeout);
+
+				Assert.False(timedOut);
+			}
+		}
+
+		#endregion
+
 		#region 239
 
 		public class Issue239


### PR DESCRIPTION
This fixes #224.