### PR TITLE
Add support for `ValueTask<TResult>` to `DefaultValue.Empty`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * Support for callbacks for methods having `ref` or `out` parameters via two new overloads of `Callback` and `Returns` (@stakx, #468)
 * Improved support for setting up and verifying protected members (including generic methods and methods having by-ref parameters) via the new duck-typing `mock.Protected().As<TDuck>()` interface (@stakx, #495, #501)
 * Support for `ValueTask<TResult>` when using the `ReturnsAsync` extension methods, similar to `Task<TResult>` (@AdamDotNet, #506)
+* Special handling for `ValueTask<TResult>` with `DefaultValue.Empty` (@stakx, #529)
 
 #### Changed
 

--- a/Moq.Tests/EmptyDefaultValueProviderFixture.cs
+++ b/Moq.Tests/EmptyDefaultValueProviderFixture.cs
@@ -158,6 +158,57 @@ namespace Moq.Tests
 			Assert.Equal(default(int), ((Task<Task<int>>) value).Result.Result);
 		}
 
+		[Fact]
+		public void ProvidesDefaultValueTaskOfValueType()
+		{
+			var provider = new EmptyDefaultValueProvider();
+
+			var value = provider.ProvideDefault(typeof(IFoo).GetProperty(nameof(IFoo.ValueTaskOfValueType)).GetGetMethod());
+
+			var result = (ValueTask<int>)value;
+			Assert.True(result.IsCompleted);
+			Assert.Equal(default(int), result.Result);
+		}
+
+		[Fact]
+		public void ProvidesDefaultValueTaskOfValueTypeArray()
+		{
+			var provider = new EmptyDefaultValueProvider();
+
+			var value = provider.ProvideDefault(typeof(IFoo).GetProperty(nameof(IFoo.ValueTaskOfValueTypeArray)).GetGetMethod());
+
+			var result = (ValueTask<int[]>)value;
+			Assert.True(result.IsCompleted);
+			Assert.NotNull(result.Result);
+			Assert.Empty(result.Result);
+		}
+
+		[Fact]
+		public void ProvidesDefaultValueTaskOfReferenceType()
+		{
+			var provider = new EmptyDefaultValueProvider();
+
+			var value = provider.ProvideDefault(typeof(IFoo).GetProperty(nameof(IFoo.ValueTaskOfReferenceType)).GetGetMethod());
+
+			var result = (ValueTask<string>)value;
+			Assert.True(result.IsCompleted);
+			Assert.Equal(default(string), result.Result);
+		}
+
+		[Fact]
+		public void ProvidesDefaultValueTaskOfTaskOfValueType()
+		{
+			var provider = new EmptyDefaultValueProvider();
+
+			var value = provider.ProvideDefault(typeof(IFoo).GetProperty(nameof(IFoo.ValueTaskOfTaskOfValueType)).GetGetMethod());
+
+			var result = (ValueTask<Task<int>>)value;
+			Assert.True(result.IsCompleted);
+			Assert.NotNull(result.Result);
+			Assert.True(result.Result.IsCompleted);
+			Assert.Equal(default(int), result.Result.Result);
+		}
+
 		public interface IFoo
 		{
 			object Object { get; set; }
@@ -175,6 +226,10 @@ namespace Moq.Tests
 			Task<int> GenericTaskOfValueType { get; set; }
 			Task<string> GenericTaskOfReferenceType { get; set; }
 			Task<Task<int>> TaskOfGenericTaskOfValueType { get; set; }
+			ValueTask<int> ValueTaskOfValueType { get; set; }
+			ValueTask<int[]> ValueTaskOfValueTypeArray { get; set; }
+			ValueTask<string> ValueTaskOfReferenceType { get; set; }
+			ValueTask<Task<int>> ValueTaskOfTaskOfValueType { get; set; }
 		}
 
 		public interface IBar { }

--- a/Moq.Tests/EmptyDefaultValueProviderFixture.cs
+++ b/Moq.Tests/EmptyDefaultValueProviderFixture.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-#if NETCORE
-using System.Reflection;
-#endif
 using System.Threading.Tasks;
+
 using Xunit;
 
 namespace Moq.Tests
@@ -14,9 +12,7 @@ namespace Moq.Tests
 		[Fact]
 		public void ProvidesNullString()
 		{
-			var provider = new EmptyDefaultValueProvider();
-
-			var value = provider.ProvideDefault(typeof(IFoo).GetProperty("StringValue").GetGetMethod());
+			var value = GetDefaultValueForProperty(nameof(IFoo.StringValue));
 
 			Assert.Null(value);
 		}
@@ -24,9 +20,7 @@ namespace Moq.Tests
 		[Fact]
 		public void ProvidesDefaultInt()
 		{
-			var provider = new EmptyDefaultValueProvider();
-
-			var value = provider.ProvideDefault(typeof(IFoo).GetProperty("IntValue").GetGetMethod());
+			var value = GetDefaultValueForProperty(nameof(IFoo.IntValue));
 
 			Assert.Equal(default(int), value);
 		}
@@ -34,9 +28,7 @@ namespace Moq.Tests
 		[Fact]
 		public void ProvidesNullInt()
 		{
-			var provider = new EmptyDefaultValueProvider();
-
-			var value = provider.ProvideDefault(typeof(IFoo).GetProperty("NullableIntValue").GetGetMethod());
+			var value = GetDefaultValueForProperty(nameof(IFoo.NullableIntValue));
 
 			Assert.Null(value);
 		}
@@ -44,9 +36,7 @@ namespace Moq.Tests
 		[Fact]
 		public void ProvidesDefaultBool()
 		{
-			var provider = new EmptyDefaultValueProvider();
-
-			var value = provider.ProvideDefault(typeof(IFoo).GetProperty("BoolValue").GetGetMethod());
+			var value = GetDefaultValueForProperty(nameof(IFoo.BoolValue));
 
 			Assert.Equal(default(bool), value);
 		}
@@ -54,9 +44,7 @@ namespace Moq.Tests
 		[Fact]
 		public void ProvidesDefaultEnum()
 		{
-			var provider = new EmptyDefaultValueProvider();
-
-			var value = provider.ProvideDefault(typeof(IFoo).GetProperty("UriKind").GetGetMethod());
+			var value = GetDefaultValueForProperty(nameof(IFoo.UriKind));
 
 			Assert.Equal(default(UriKind), value);
 		}
@@ -64,28 +52,22 @@ namespace Moq.Tests
 		[Fact]
 		public void ProvidesEmptyEnumerable()
 		{
-			var provider = new EmptyDefaultValueProvider();
-
-			var value = provider.ProvideDefault(typeof(IFoo).GetProperty("Indexes").GetGetMethod());
+			var value = GetDefaultValueForProperty(nameof(IFoo.Indexes));
 			Assert.True(value is IEnumerable<int> && ((IEnumerable<int>)value).Count() == 0);
 		}
 
 		[Fact]
 		public void ProvidesEmptyArray()
 		{
-			var provider = new EmptyDefaultValueProvider();
-
-			var value = provider.ProvideDefault(typeof(IFoo).GetProperty("Bars").GetGetMethod());
+			var value = GetDefaultValueForProperty(nameof(IFoo.Bars));
 			Assert.True(value is IBar[] && ((IBar[])value).Length == 0);
 		}
 
 		[Fact]
 		public void ProvidesNullReferenceTypes()
 		{
-			var provider = new EmptyDefaultValueProvider();
-
-			var value1 = provider.ProvideDefault(typeof(IFoo).GetProperty("Bar").GetGetMethod());
-			var value2 = provider.ProvideDefault(typeof(IFoo).GetProperty("Object").GetGetMethod());
+			var value1 = GetDefaultValueForProperty(nameof(IFoo.Bar));
+			var value2 = GetDefaultValueForProperty(nameof(IFoo.Object));
 
 			Assert.Null(value1);
 			Assert.Null(value2);
@@ -94,8 +76,7 @@ namespace Moq.Tests
 		[Fact]
 		public void ProvideEmptyQueryable()
 		{
-			var provider = new EmptyDefaultValueProvider();
-			var value = provider.ProvideDefault(typeof(IFoo).GetProperty("Queryable").GetGetMethod());
+			var value = GetDefaultValueForProperty(nameof(IFoo.Queryable));
 
 			Assert.IsAssignableFrom<IQueryable<int>>(value);
 			Assert.Equal(0, ((IQueryable<int>)value).Count());
@@ -104,8 +85,7 @@ namespace Moq.Tests
 		[Fact]
 		public void ProvideEmptyQueryableObjects()
 		{
-			var provider = new EmptyDefaultValueProvider();
-			var value = provider.ProvideDefault(typeof(IFoo).GetProperty("QueryableObjects").GetGetMethod());
+			var value = GetDefaultValueForProperty(nameof(IFoo.QueryableObjects));
 
 			Assert.IsAssignableFrom<IQueryable>(value);
 			Assert.Equal(0, ((IQueryable)value).Cast<object>().Count());
@@ -114,9 +94,7 @@ namespace Moq.Tests
 		[Fact]
 		public void ProvidesDefaultTask()
 		{
-			var provider = new EmptyDefaultValueProvider();
-
-			var value = provider.ProvideDefault(typeof(IFoo).GetProperty("TaskValue").GetGetMethod());
+			var value = GetDefaultValueForProperty(nameof(IFoo.TaskValue));
 
 			Assert.NotNull(value);
 			Assert.True(((Task)value).IsCompleted);
@@ -125,9 +103,7 @@ namespace Moq.Tests
 		[Fact]
 		public void ProvidesDefaultGenericTaskOfValueType()
 		{
-			var provider = new EmptyDefaultValueProvider();
-
-			var value = provider.ProvideDefault(typeof(IFoo).GetProperty("GenericTaskOfValueType").GetGetMethod());
+			var value = GetDefaultValueForProperty(nameof(IFoo.GenericTaskOfValueType));
 
 			Assert.NotNull(value);
 			Assert.True(((Task)value).IsCompleted);
@@ -137,9 +113,7 @@ namespace Moq.Tests
 		[Fact]
 		public void ProvidesDefaultGenericTaskOfReferenceType()
 		{
-			var provider = new EmptyDefaultValueProvider();
-
-			var value = provider.ProvideDefault(typeof(IFoo).GetProperty("GenericTaskOfReferenceType").GetGetMethod());
+			var value = GetDefaultValueForProperty(nameof(IFoo.GenericTaskOfReferenceType));
 
 			Assert.NotNull(value);
 			Assert.True(((Task)value).IsCompleted);
@@ -149,9 +123,7 @@ namespace Moq.Tests
 		[Fact]
 		public void ProvidesDefaultTaskOfGenericTask()
 		{
-			var provider = new EmptyDefaultValueProvider();
-
-			var value = provider.ProvideDefault(typeof(IFoo).GetProperty("TaskOfGenericTaskOfValueType").GetGetMethod());
+			var value = GetDefaultValueForProperty(nameof(IFoo.TaskOfGenericTaskOfValueType));
 
 			Assert.NotNull(value);
 			Assert.True(((Task)value).IsCompleted);
@@ -161,9 +133,7 @@ namespace Moq.Tests
 		[Fact]
 		public void ProvidesDefaultValueTaskOfValueType()
 		{
-			var provider = new EmptyDefaultValueProvider();
-
-			var value = provider.ProvideDefault(typeof(IFoo).GetProperty(nameof(IFoo.ValueTaskOfValueType)).GetGetMethod());
+			var value = GetDefaultValueForProperty(nameof(IFoo.ValueTaskOfValueType));
 
 			var result = (ValueTask<int>)value;
 			Assert.True(result.IsCompleted);
@@ -173,9 +143,7 @@ namespace Moq.Tests
 		[Fact]
 		public void ProvidesDefaultValueTaskOfValueTypeArray()
 		{
-			var provider = new EmptyDefaultValueProvider();
-
-			var value = provider.ProvideDefault(typeof(IFoo).GetProperty(nameof(IFoo.ValueTaskOfValueTypeArray)).GetGetMethod());
+			var value = GetDefaultValueForProperty(nameof(IFoo.ValueTaskOfValueTypeArray));
 
 			var result = (ValueTask<int[]>)value;
 			Assert.True(result.IsCompleted);
@@ -186,9 +154,7 @@ namespace Moq.Tests
 		[Fact]
 		public void ProvidesDefaultValueTaskOfReferenceType()
 		{
-			var provider = new EmptyDefaultValueProvider();
-
-			var value = provider.ProvideDefault(typeof(IFoo).GetProperty(nameof(IFoo.ValueTaskOfReferenceType)).GetGetMethod());
+			var value = GetDefaultValueForProperty(nameof(IFoo.ValueTaskOfReferenceType));
 
 			var result = (ValueTask<string>)value;
 			Assert.True(result.IsCompleted);
@@ -198,15 +164,20 @@ namespace Moq.Tests
 		[Fact]
 		public void ProvidesDefaultValueTaskOfTaskOfValueType()
 		{
-			var provider = new EmptyDefaultValueProvider();
-
-			var value = provider.ProvideDefault(typeof(IFoo).GetProperty(nameof(IFoo.ValueTaskOfTaskOfValueType)).GetGetMethod());
+			var value = GetDefaultValueForProperty(nameof(IFoo.ValueTaskOfTaskOfValueType));
 
 			var result = (ValueTask<Task<int>>)value;
 			Assert.True(result.IsCompleted);
 			Assert.NotNull(result.Result);
 			Assert.True(result.Result.IsCompleted);
 			Assert.Equal(default(int), result.Result.Result);
+		}
+
+		private static object GetDefaultValueForProperty(string propertyName)
+		{
+			var provider = new EmptyDefaultValueProvider();
+			var propertyGetter = typeof(IFoo).GetProperty(propertyName).GetGetMethod();
+			return provider.ProvideDefault(propertyGetter);
 		}
 
 		public interface IFoo


### PR DESCRIPTION
#506 added support for `ValueTask<TResult>` to the `ReturnsAsync` method group. If Moq has support for `ValueTask<TResult>` in one place, it should consistently support that type everywhere.

This PR therefore adds special handling of that type for `DefaultValue.Empty`: Moq will produce a completed `ValueTask<TResult>` containing an empty `TResult` value for type members having a return type of `ValueTask<TResult>`.