### PR TITLE
Add `Empty`, `Mock` properties to `DefaultValueProvider`

### DIFF
--- a/Moq.Tests/EmptyDefaultValueProviderFixture.cs
+++ b/Moq.Tests/EmptyDefaultValueProviderFixture.cs
@@ -176,7 +176,7 @@ namespace Moq.Tests
 		private static object GetDefaultValueForProperty(string propertyName)
 		{
 			var propertyGetter = typeof(IFoo).GetProperty(propertyName).GetGetMethod();
-			return EmptyDefaultValueProvider.Instance.GetDefaultReturnValue(propertyGetter, new Mock<IFoo>());
+			return DefaultValueProvider.Empty.GetDefaultReturnValue(propertyGetter, new Mock<IFoo>());
 		}
 
 		public interface IFoo

--- a/Moq.Tests/MockDefaultValueProviderFixture.cs
+++ b/Moq.Tests/MockDefaultValueProviderFixture.cs
@@ -246,7 +246,7 @@ namespace Moq.Tests
 		private static object GetDefaultValueForProperty(string propertyName, Mock<IFoo> mock)
 		{
 			var propertyGetter = typeof(IFoo).GetProperty(propertyName).GetGetMethod();
-			return MockDefaultValueProvider.Instance.GetDefaultReturnValue(propertyGetter, mock);
+			return DefaultValueProvider.Mock.GetDefaultReturnValue(propertyGetter, mock);
 		}
 
 		public interface IFoo

--- a/Source/DefaultValueProvider.cs
+++ b/Source/DefaultValueProvider.cs
@@ -53,6 +53,18 @@ namespace Moq
 	public abstract class DefaultValueProvider
 	{
 		/// <summary>
+		/// Gets the <see cref="DefaultValueProvider"/> corresponding to <see cref="DefaultValue.Empty"/>;
+		/// that is, a default value provider returning "empty" values e. g. for collection types.
+		/// </summary>
+		public static DefaultValueProvider Empty { get; } = new EmptyDefaultValueProvider();
+
+		/// <summary>
+		/// Gets the <see cref="DefaultValueProvider"/> corresponding to <see cref="DefaultValue.Mock"/>;
+		/// that is, a default value provider returning mocked objects or "empty" values for unmockable types.
+		/// </summary>
+		public static DefaultValueProvider Mock { get; } = new MockDefaultValueProvider();
+
+		/// <summary>
 		/// Initializes a new instance of the <see cref="DefaultValueProvider"/> class.
 		/// </summary>
 		protected DefaultValueProvider()
@@ -70,7 +82,7 @@ namespace Moq
 		/// Must be overridden in derived classes.
 		/// </summary>
 		/// <param name="type">The <see cref="Type"/> of the requested default value.</param>
-		/// <param name="mock">The <see cref="Mock"/> on which an unexpected invocation has occurred.</param>
+		/// <param name="mock">The <see cref="Moq.Mock"/> on which an unexpected invocation has occurred.</param>
 		/// <remarks>
 		/// Implementations may assume that all parameters have valid, non-<see langword="null"/>, non-<see langword="void"/> values.
 		/// </remarks>
@@ -86,7 +98,7 @@ namespace Moq
 		///   </para>
 		/// </summary>
 		/// <param name="parameter">The <see cref="ParameterInfo"/> describing the method parameter for which a default argument value should be produced.</param>
-		/// <param name="mock">The <see cref="Mock"/> on which an unexpected invocation has occurred.</param>
+		/// <param name="mock">The <see cref="Moq.Mock"/> on which an unexpected invocation has occurred.</param>
 		/// <remarks>
 		/// Implementations may assume that all parameters have valid, non-<see langword="null"/>, non-<see langword="void"/> values.
 		/// </remarks>
@@ -109,7 +121,7 @@ namespace Moq
 		///   </para>
 		/// </summary>
 		/// <param name="method">The <see cref="MethodInfo"/> describing the method for which a default return value should be produced.</param>
-		/// <param name="mock">The <see cref="Mock"/> on which an unexpected invocation has occurred.</param>
+		/// <param name="mock">The <see cref="Moq.Mock"/> on which an unexpected invocation has occurred.</param>
 		/// <remarks>
 		/// Implementations may assume that all parameters have valid, non-<see langword="null"/>, non-<see langword="void"/> values.
 		/// </remarks>

--- a/Source/EmptyDefaultValueProvider.cs
+++ b/Source/EmptyDefaultValueProvider.cs
@@ -67,13 +67,11 @@ namespace Moq
 			[typeof(ValueTask<>)] = CreateValueTaskOf,
 		};
 
-		internal override DefaultValue Kind => DefaultValue.Empty;
-
-		public static EmptyDefaultValueProvider Instance { get; } = new EmptyDefaultValueProvider();
-
-		private EmptyDefaultValueProvider()
+		internal EmptyDefaultValueProvider()
 		{
 		}
+
+		internal override DefaultValue Kind => DefaultValue.Empty;
 
 		protected internal override object GetDefaultValue(Type type, Mock mock)
 		{

--- a/Source/Linq/Mocks.cs
+++ b/Source/Linq/Mocks.cs
@@ -207,7 +207,7 @@ namespace Moq
 			}
 			else
 			{
-				fluentMock = ((IMocked)mock.GetDefaultValue(info, useAlternateProvider: MockDefaultValueProvider.Instance)).Mock;
+				fluentMock = ((IMocked)mock.GetDefaultValue(info, useAlternateProvider: DefaultValueProvider.Mock)).Mock;
 				Mock.SetupAllProperties(fluentMock);
 
 				innerMock = new MockWithWrappedMockObject(fluentMock, fluentMock.Object);

--- a/Source/Mock.Generic.cs
+++ b/Source/Mock.Generic.cs
@@ -120,7 +120,7 @@ namespace Moq
 			this.Behavior = behavior;
 			this.configuredDefaultValues = new Dictionary<Type, object>();
 			this.constructorArguments = args;
-			this.defaultValueProvider = EmptyDefaultValueProvider.Instance;
+			this.defaultValueProvider = DefaultValueProvider.Empty;
 			this.ImplementedInterfaces.AddRange(typeof(T).GetInterfaces().Where(i => (i.GetTypeInfo().IsPublic || i.GetTypeInfo().IsNestedPublic) && !i.GetTypeInfo().IsImport));
 			this.ImplementedInterfaces.Add(typeof(IMocked<T>));
 			this.InternallyImplementedInterfaceCount = this.ImplementedInterfaces.Count;

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -171,11 +171,11 @@ namespace Moq
 				switch (value)
 				{
 					case DefaultValue.Empty:
-						this.DefaultValueProvider = EmptyDefaultValueProvider.Instance;
+						this.DefaultValueProvider = DefaultValueProvider.Empty;
 						return;
 
 					case DefaultValue.Mock:
-						this.DefaultValueProvider = MockDefaultValueProvider.Instance;
+						this.DefaultValueProvider = DefaultValueProvider.Mock;
 						return;
 
 					default:
@@ -858,7 +858,7 @@ namespace Moq
 			if (mockedTypesStack.Contains(property.PropertyType))
 			{
 				// to deal with loops in the property graph
-				valueProvider = EmptyDefaultValueProvider.Instance;
+				valueProvider = DefaultValueProvider.Empty;
 			}
 #if FEATURE_SERIALIZATION
 			else

--- a/Source/MockDefaultValueProvider.cs
+++ b/Source/MockDefaultValueProvider.cs
@@ -53,11 +53,9 @@ namespace Moq
 	/// </summary>
 	internal sealed class MockDefaultValueProvider : DefaultValueProvider
 	{
-		public static MockDefaultValueProvider Instance { get; } = new MockDefaultValueProvider();
-
 		private Dictionary<Type, Func<Type, Mock, object>> factories;
 
-		private MockDefaultValueProvider()
+		internal MockDefaultValueProvider()
 		{
 			this.factories = new Dictionary<Type, Func<Type, Mock, object>>()
 			{
@@ -82,7 +80,7 @@ namespace Moq
 				return factory.Invoke(type, mock);
 			}
 
-			var emptyValue = EmptyDefaultValueProvider.Instance.GetDefaultValue(type, mock);
+			var emptyValue = DefaultValueProvider.Empty.GetDefaultValue(type, mock);
 			if (emptyValue != null)
 			{
 				return emptyValue;

--- a/Source/Obsolete/MockFactory.cs
+++ b/Source/Obsolete/MockFactory.cs
@@ -149,7 +149,7 @@ namespace Moq
 		public MockFactory(MockBehavior defaultBehavior)
 		{
 			this.defaultBehavior = defaultBehavior;
-			this.defaultValueProvider = EmptyDefaultValueProvider.Instance;
+			this.defaultValueProvider = DefaultValueProvider.Empty;
 			this.switches = Switches.Default;
 		}
 
@@ -174,11 +174,11 @@ namespace Moq
 				switch (value)
 				{
 					case DefaultValue.Empty:
-						this.DefaultValueProvider = EmptyDefaultValueProvider.Instance;
+						this.DefaultValueProvider = DefaultValueProvider.Empty;
 						return;
 
 					case DefaultValue.Mock:
-						this.DefaultValueProvider = MockDefaultValueProvider.Instance;
+						this.DefaultValueProvider = DefaultValueProvider.Mock;
 						return;
 
 					default:

--- a/Source/SerializableTypesValueProvider.cs
+++ b/Source/SerializableTypesValueProvider.cs
@@ -31,7 +31,7 @@ namespace Moq
 			Debug.Assert(mock != null);
 
 			return IsSerializableWithIncorrectImplementationForISerializable(parameter.ParameterType)
-				? EmptyDefaultValueProvider.Instance.GetDefaultParameterValue(parameter, mock)
+				? DefaultValueProvider.Empty.GetDefaultParameterValue(parameter, mock)
 				: decorated.GetDefaultParameterValue(parameter, mock);
 		}
 
@@ -43,7 +43,7 @@ namespace Moq
 			Debug.Assert(mock != null);
 
 			return IsSerializableWithIncorrectImplementationForISerializable(method.ReturnType)
-				? EmptyDefaultValueProvider.Instance.GetDefaultReturnValue(method, mock)
+				? DefaultValueProvider.Empty.GetDefaultReturnValue(method, mock)
 				: decorated.GetDefaultReturnValue(method, mock);
 		}
 
@@ -54,7 +54,7 @@ namespace Moq
 			Debug.Assert(mock != null);
 
 			return IsSerializableWithIncorrectImplementationForISerializable(type)
-				? EmptyDefaultValueProvider.Instance.GetDefaultValue(type, mock)
+				? DefaultValueProvider.Empty.GetDefaultValue(type, mock)
 				: decorated.GetDefaultValue(type, mock);
 		}
 


### PR DESCRIPTION
so that it mirrors `DefaultValue` more closely:

```csharp
    new Mock<T> { DefaultValue         = DefaultValue        .Mock }
    new Mock<T> { DefaultValueProvider = DefaultValueProvider.Mock }
```

This also creates a single access point for further standard default value providers in the future.