### PR TITLE
New `LookupOrFallbackDefaultValueProvider` base class for custom default value providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * Improved support for setting up and verifying protected members (including generic methods and methods having by-ref parameters) via the new duck-typing `mock.Protected().As<TDuck>()` interface (@stakx, #495, #501)
 * Support for `ValueTask<TResult>` when using the `ReturnsAsync` extension methods, similar to `Task<TResult>` (@AdamDotNet, #506)
 * Special handling for `ValueTask<TResult>` with `DefaultValue.Empty` (@stakx, #529)
-* Support for custom default value generators (besides `DefaultValue.Empty` and `DefaultValue.Mock`): subclass the new `DefaultValueProvider` and set up via `Mock[Repository].DefaultValueProvider` (@stakx, #533)
+* Support for custom default value generation strategies besides `DefaultValue.Empty` and `DefaultValue.Mock`:
+  Implement custom providers by subclassing either `DefaultValueProvider` or `LookupOrFallbackDefaultValueProvider`,
+  install them by setting `Mock[Repository].DefaultValueProvider` (@stakx, #533, #536)
 * Allow `DefaultValue.Mock` to mock `Task<TMockable>` and `ValueTask<TMockable>` (@stakx, #502)
 
 #### Changed

--- a/Moq.Tests/LookupOrFallbackDefaultValueProviderFixture.cs
+++ b/Moq.Tests/LookupOrFallbackDefaultValueProviderFixture.cs
@@ -1,0 +1,198 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Moq.Tests
+{
+	public class LookupOrFallbackDefaultValueProviderFixture
+	{
+		[Theory]
+		[InlineData(typeof(int), default(int))] // plain value type
+		[InlineData(typeof(float), default(float))] // plain value type
+		[InlineData(typeof(int?), null)] // nullable
+		[InlineData(typeof(int[]), default(int[]))] // emptyable
+		[InlineData(typeof(IEnumerable<>), null)] // emptyable
+		[InlineData(typeof(string), default(string))] // primitive reference type
+		[InlineData(typeof(Exception), default(Exception))] // reference type
+		public void Produces_default_when_no_factory_registered(Type type, object expected)
+		{
+			var provider = new Provider();
+
+			var actual = provider.GetDefaultValue(type);
+			Assert.Equal(expected, actual);
+		}
+
+		[Theory]
+		[InlineData(typeof(int), 42)]
+		public void Falls_back_to_default_generation_strategy_when_no_handler_available(Type type, object fallbackValue)
+		{
+			var provider = new Provider((t, _) => t == type ? fallbackValue : throw new NotSupportedException());
+			provider.Deregister(type);
+
+			var actual = provider.GetDefaultValue(type);
+
+			Assert.Equal(fallbackValue, actual);
+		}
+
+		[Fact]
+		public void Can_register_factory_for_specific_type()
+		{
+			var provider = new Provider();
+			provider.Register(typeof(Exception), (_, __) => new InvalidOperationException());
+
+			var actual = provider.GetDefaultValue(typeof(Exception));
+
+			Assert.NotNull(actual);
+			Assert.IsType<InvalidOperationException>(actual);
+		}
+
+		[Fact]
+		public void Can_register_factory_for_generic_type()
+		{
+			var provider = new Provider();
+			provider.Register(typeof(IEnumerable<>), (type, __) =>
+			{
+				var elementType = type.GetGenericArguments()[0];
+				return Array.CreateInstance(elementType, 0);
+			});
+
+			var actual = provider.GetDefaultValue(typeof(IEnumerable<int>));
+
+			Assert.NotNull(actual);
+			Assert.IsType<int[]>(actual);
+		}
+
+		[Fact]
+		public void Can_register_factory_for_array_type()
+		{
+			var provider = new Provider();
+			provider.Register(typeof(Array), (type, __) =>
+			{
+				var elementType = type.GetElementType();
+				return Array.CreateInstance(elementType, 0);
+			});
+
+			var actual = provider.GetDefaultValue(typeof(int[]));
+
+			Assert.NotNull(actual);
+			Assert.IsType<int[]>(actual);
+		}
+
+		[Fact]
+		public void Produces_completed_Task()
+		{
+			var provider = new Provider();
+
+			var actual = (Task)provider.GetDefaultValue(typeof(Task));
+
+			Assert.True(actual.IsCompleted);
+		}
+
+		[Fact]
+		public void Handling_of_Task_can_be_disabled()
+		{
+			var provider = new Provider();
+			provider.Deregister(typeof(Task));
+
+			var actual = provider.GetDefaultValue(typeof(Task));
+
+			Assert.Null(actual);
+		}
+
+		[Fact]
+		public void Produces_completed_generic_Task()
+		{
+			const int expected = 42;
+			var provider = new Provider();
+			provider.Register(typeof(int), (_, __) => expected);
+
+			var actual = (Task<int>)provider.GetDefaultValue(typeof(Task<int>));
+
+			Assert.True(actual.IsCompleted);
+			Assert.Equal(42, actual.Result);
+		}
+
+		[Fact]
+		public void Handling_of_generic_Task_can_be_disabled()
+		{
+			var provider = new Provider();
+			provider.Deregister(typeof(Task<>));
+
+			var actual = provider.GetDefaultValue(typeof(Task<int>));
+
+			Assert.Null(actual);
+		}
+
+		[Fact]
+		public void Produces_completed_ValueTask()
+		{
+			const int expectedResult = 42;
+			var provider = new Provider();
+			provider.Register(typeof(int), (_, __) => expectedResult);
+
+			var actual = (ValueTask<int>)provider.GetDefaultValue(typeof(ValueTask<int>));
+
+			Assert.True(actual.IsCompleted);
+			Assert.Equal(42, actual.Result);
+		}
+
+		[Fact]
+		public void Handling_of_ValueTask_can_be_disabled()
+		{
+			// If deregistration of ValueTask<> handling really works, the fallback strategy will produce
+			// `default(ValueTask<int>)`, which equals a completed task containing 0 as result. So this test
+			// needs to look different from the `Task<>` equivalent above.
+
+			// We check for successful disabling of `ValueTask<>` handling indirectly, namely by
+			// setting up a specific default value for `int` first, then we can verify that this value
+			// does *not* get wrapped in a value task when we ask for `ValueTask<int>`
+
+			const int unexpected = 42;
+			var provider = new Provider();
+			provider.Register(typeof(int), (_, __) => unexpected);
+			provider.Deregister(typeof(ValueTask<>));
+
+			var actual = (ValueTask<int>)provider.GetDefaultValue(typeof(ValueTask<int>));
+
+			Assert.Equal(default(ValueTask<int>), actual);
+			Assert.NotEqual(unexpected, actual.Result);
+		}
+
+		/// <summary>
+		/// Subclass of <see cref="LookupOrFallbackDefaultValueProvider"/> used as a test surrogate.
+		/// </summary>
+		private sealed class Provider : LookupOrFallbackDefaultValueProvider
+		{
+			private Mock<object> mock;
+			private Func<Type, Mock, object> fallback;
+
+			public Provider(Func<Type, Mock, object> fallback = null)
+			{
+				this.mock = new Mock<object>();
+				this.fallback = fallback;
+			}
+
+			public object GetDefaultValue(Type type)
+			{
+				return base.GetDefaultValue(type, mock);
+			}
+
+			new public void Deregister(Type factoryKey)
+			{
+				base.Deregister(factoryKey);
+			}
+
+			new public void Register(Type factoryKey, Func<Type, Mock, object> factory)
+			{
+				base.Register(factoryKey, factory);
+			}
+
+			protected override object GetFallbackDefaultValue(Type type, Mock mock)
+			{
+				return this.fallback?.Invoke(type, mock)
+				    ?? base.GetFallbackDefaultValue(type, mock);
+			}
+		}
+	}
+}

--- a/Source/LookupOrFallbackDefaultValueProvider.cs
+++ b/Source/LookupOrFallbackDefaultValueProvider.cs
@@ -1,0 +1,201 @@
+﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//https://github.com/moq/moq4
+//All rights reserved.
+
+//Redistribution and use in source and binary forms, 
+//with or without modification, are permitted provided 
+//that the following conditions are met:
+
+//    * Redistributions of source code must retain the 
+//    above copyright notice, this list of conditions and 
+//    the following disclaimer.
+
+//    * Redistributions in binary form must reproduce 
+//    the above copyright notice, this list of conditions 
+//    and the following disclaimer in the documentation 
+//    and/or other materials provided with the distribution.
+
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
+//    names of its contributors may be used to endorse 
+//    or promote products derived from this software 
+//    without specific prior written permission.
+
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+//SUCH DAMAGE.
+
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace Moq
+{
+	/// <summary>
+	///   Abstract base class for default value providers that look up and delegate to value factory functions for the requested type(s).
+	///   If a request cannot be satisfied by any registered factory, the default value gets produced by a fallback strategy.
+	/// </summary>
+	/// <remarks>
+	///   <para>
+	///     Inherited classes can register and deregister factory functions with <see cref="Register"/> and <see cref="Deregister"/>,
+	///     respectively.
+	///   </para>
+	///   <para>
+	///     The fallback value generation strategy is implemented by the overridable <see cref="GetFallbackDefaultValue"/> method.
+	///   </para>
+	///   <para>
+	///     This base class sets up factory functions for task types (<see cref="Task"/>, <see cref="Task{TResult}"/>,
+	///     and <see cref="ValueTask{TResult}"/>) that produce completed tasks containing default values.
+	///     If this behavior is not desired, derived classes may deregister those standard factory functions via <see cref="Deregister"/>.
+	///   </para>
+	/// </remarks>
+	[EditorBrowsable(EditorBrowsableState.Advanced)]
+	public abstract class LookupOrFallbackDefaultValueProvider : DefaultValueProvider
+	{
+		private Dictionary<Type, Func<Type, Mock, object>> factories;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="LookupOrFallbackDefaultValueProvider"/> class.
+		/// </summary>
+		protected LookupOrFallbackDefaultValueProvider()
+		{
+			this.factories = new Dictionary<Type, Func<Type, Mock, object>>()
+			{
+				[typeof(Task)] = CreateTask,
+				[typeof(Task<>)] = CreateTaskOf,
+				[typeof(ValueTask<>)] = CreateValueTaskOf,
+			};
+		}
+
+		/// <summary>
+		/// Deregisters any factory function that might currently be registered for the given type(s).
+		/// Subsequent requests for values of the given type(s) will be handled by the fallback strategy.
+		/// </summary>
+		/// <param name="factoryKey">The type(s) for which to remove any registered factory function.</param>
+		protected void Deregister(Type factoryKey)
+		{
+			Debug.Assert(factoryKey != null);
+
+			this.factories.Remove(factoryKey);
+		}
+
+		/// <summary>
+		/// Registers a factory function for the given type(s).
+		/// Subsequent requests for values of the given type(s) will be handled by the specified function.
+		/// </summary>
+		/// <param name="factoryKey">
+		///   <para>
+		///     The type(s) for which to register the given <paramref name="factory"/> function.
+		///   </para>
+		///   <para>
+		///     All array types are represented by <c><see langword="typeof"/>(<see cref="Array"/>)</c>.
+		///     Generic types are represented by their open generic type definiton, e. g. <c><see langword="typeof"/>(<see cref="IEnumerable"/>&lt;&gt;)</c>.
+		///   </para>
+		/// </param>
+		/// <param name="factory">The factory function responsible for producing values for the given type.</param>
+		protected void Register(Type factoryKey, Func<Type, Mock, object> factory)
+		{
+			Debug.Assert(factoryKey != null);
+			Debug.Assert(factory != null);
+
+			this.factories[factoryKey] = factory;
+		}
+
+		/// <inheritdoc/>
+		protected internal sealed override object GetDefaultParameterValue(ParameterInfo parameter, Mock mock)
+		{
+			Debug.Assert(parameter != null);
+			Debug.Assert(parameter.ParameterType != typeof(void));
+			Debug.Assert(mock != null);
+
+			return this.GetDefaultValue(parameter.ParameterType, mock);
+		}
+
+		/// <inheritdoc/>
+		protected internal sealed override object GetDefaultReturnValue(MethodInfo method, Mock mock)
+		{
+			Debug.Assert(method != null);
+			Debug.Assert(method.ReturnType != typeof(void));
+			Debug.Assert(mock != null);
+
+			return this.GetDefaultValue(method.ReturnType, mock);
+		}
+
+		/// <inheritdoc/>
+		protected internal sealed override object GetDefaultValue(Type type, Mock mock)
+		{
+			Debug.Assert(type != null);
+			Debug.Assert(type != typeof(void));
+			Debug.Assert(mock != null);
+
+			var typeInfo = type.GetTypeInfo();
+
+			var handlerKey = typeInfo.IsGenericType ? type.GetGenericTypeDefinition()
+			               : type.IsArray ? typeof(Array)
+			               : type;
+
+			return this.factories.TryGetValue(handlerKey, out Func<Type, Mock, object> factory) ? factory.Invoke(type, mock)
+			     : this.GetFallbackDefaultValue(type, mock);
+		}
+
+		/// <summary>
+		/// Determines the default value for the given <paramref name="type"/> when no suitable factory is registered for it.
+		/// May be overridden in derived classes.
+		/// </summary>
+		/// <param name="type">The type of which to produce a value.</param>
+		/// <param name="mock">The <see cref="Moq.Mock"/> on which an unexpected invocation has occurred.</param>
+		protected virtual object GetFallbackDefaultValue(Type type, Mock mock)
+		{
+			Debug.Assert(type != null);
+			Debug.Assert(type != typeof(void));
+			Debug.Assert(mock != null);
+
+			return type.GetTypeInfo().IsValueType ? Activator.CreateInstance(type)
+			     : null;
+		}
+
+		private static object CreateTask(Type type, Mock mock)
+		{
+			return Task.FromResult(false);
+		}
+
+		private object CreateTaskOf(Type type, Mock mock)
+		{
+			var resultType = type.GetGenericArguments()[0];
+			var result = this.GetDefaultValue(resultType, mock);
+
+			var tcsType = typeof(TaskCompletionSource<>).MakeGenericType(resultType);
+			var tcs = Activator.CreateInstance(tcsType);
+			tcsType.GetMethod("SetResult").Invoke(tcs, new[] { result });
+			return tcsType.GetProperty("Task").GetValue(tcs, null);
+		}
+
+		private object CreateValueTaskOf(Type type, Mock mock)
+		{
+			var resultType = type.GetGenericArguments()[0];
+			var result = this.GetDefaultValue(resultType, mock);
+
+			// `Activator.CreateInstance` could throw an `AmbiguousMatchException` in this use case,
+			// so we're explicitly selecting and calling the constructor we want to use:
+			var valueTaskCtor = type.GetConstructor(new[] { resultType });
+			return valueTaskCtor.Invoke(new object[] { result });
+		}
+	}
+}


### PR DESCRIPTION
This adds a new base class `LookupOrFallbackDefaultValueProvider`, which builds on top of `DefaultValueProvider`, to Moq's public API.

* This type becomes the new base class for both `EmptyDefaultValueProvider` and `MockDefaultValueProvider`.

* It has inbuilt support for task types `Task`, `Task<TResult>`, and `ValueTask<TResult>`.

* It also provides enough customizability for folks to easily create their own default value providers that work like the empty default value provider. Here's an example of a provider that will produce empty collections for `IReadOnlyList<T>`:

   ```csharp
   sealed class MyEmptyDefaultValueProvider : LookupOrFallbackDefaultValueProvider
   {
       public MyEmptyDefaultValueProvider()
       {
           base.Register(typeof(IReadOnlyList<>), CreateReadOnlyListOf);
       }

       private static CreateReadOnlyListOf(Type type, Mock _)
       {
           var listType = typeof(List<>).MakeGenericType(type.GetGenericArguments());
           return Activator.CreateInstance(listType);
       }
   }
   ```

For the rationale behind this new type, and the reasoning why it doesn't come preconfigured as an empty default value provider supporting all standard collection types from the .NET BCL, see #173.

Perhaps we can add a customizable or expanded empty default value provider at a later time if there's still widespread demand / need for it.