### PR TITLE
Match any values for `ref` parameters using `It.Ref<TValue>.IsAny` / `ItExpr.Ref<TValue>.IsAny`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
   Implement custom providers by subclassing either `DefaultValueProvider` or `LookupOrFallbackDefaultValueProvider`,
   install them by setting `Mock[Repository].DefaultValueProvider` (@stakx, #533, #536)
 * Allow `DefaultValue.Mock` to mock `Task<TMockable>` and `ValueTask<TMockable>` (@stakx, #502)
+* Match any value for `ref` parameters with `It.Ref<T>.IsAny` (or `ItExpr.Ref<T>.IsAny` for protected methods) as you would with `It.IsAny<T>()` for regular parameters (@stakx, #537) 
 
 #### Changed
 

--- a/Moq.Tests/MatchersFixture.cs
+++ b/Moq.Tests/MatchersFixture.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text.RegularExpressions;
+
 using Moq.Matchers;
+
 using Xunit;
 
 namespace Moq.Tests
@@ -307,6 +310,37 @@ namespace Moq.Tests
 			mock.Verify();
 		}
 
+		[Fact]
+		public void Can_use_IsAny_for_ref_parameters_in_Setup_to_match_any_argument_value()
+		{
+			var setupInvocationCount = 0;
+
+			var mock = new Mock<IFoo>();
+			mock.Setup(m => m.Do(ref It.Ref<int>.IsAny)).Callback(() => ++setupInvocationCount);
+
+			var anyValue = new Random().Next();
+			var anyDifferentValue = unchecked(anyValue + 1);
+
+			mock.Object.Do(ref anyValue);
+			mock.Object.Do(ref anyDifferentValue);
+
+			Assert.Equal(2, setupInvocationCount);
+		}
+
+		[Fact]
+		public void Can_use_IsAny_for_ref_parameters_in_Verify_to_match_any_argument_value()
+		{
+			var mock = new Mock<IFoo>();
+
+			var anyValue = new Random().Next();
+			var anyDifferentValue = unchecked(anyValue + 1);
+
+			mock.Object.Do(ref anyValue);
+			mock.Object.Do(ref anyDifferentValue);
+
+			mock.Verify(m => m.Do(ref It.Ref<int>.IsAny), Times.Exactly(2));
+		}
+
 		private int GetToRange()
 		{
 			return 5;
@@ -325,6 +359,7 @@ namespace Moq.Tests
 			int[] Items { get; set; }
 			int TakesNullableParameter(int? value);
 			void TakesTwoValueTypes(int a, int b);
+			void Do(ref int arg);
 		}
 	}
 }

--- a/Source/It.cs
+++ b/Source/It.cs
@@ -54,6 +54,18 @@ namespace Moq
 	/// <include file='It.xdoc' path='docs/doc[@for="It"]/*'/>
 	public static class It
 	{
+		/// <summary>
+		/// Contains matchers for <see langword="ref"/> (C#) / <see langword="ByRef"/> (VB.NET) parameters of type <typeparamref name="TValue"/>.
+		/// </summary>
+		/// <typeparam name="TValue">The parameter type.</typeparam>
+		public static class Ref<TValue>
+		{
+			/// <summary>
+			/// Matches any value that is assignment-compatible with type <typeparamref name="TValue"/>.
+			/// </summary>
+			public static TValue IsAny;
+		}
+
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsAny"]/*'/>
 		public static TValue IsAny<TValue>()
 		{

--- a/Source/Matchers/AnyMatcher.cs
+++ b/Source/Matchers/AnyMatcher.cs
@@ -1,0 +1,53 @@
+﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//https://github.com/moq/moq4
+//All rights reserved.
+
+//Redistribution and use in source and binary forms, 
+//with or without modification, are permitted provided 
+//that the following conditions are met:
+
+//    * Redistributions of source code must retain the 
+//    above copyright notice, this list of conditions and 
+//    the following disclaimer.
+
+//    * Redistributions in binary form must reproduce 
+//    the above copyright notice, this list of conditions 
+//    and the following disclaimer in the documentation 
+//    and/or other materials provided with the distribution.
+
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
+//    names of its contributors may be used to endorse 
+//    or promote products derived from this software 
+//    without specific prior written permission.
+
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+//SUCH DAMAGE.
+
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+namespace Moq.Matchers
+{
+    internal sealed class AnyMatcher : IMatcher
+    {
+		public static AnyMatcher Instance { get; } = new AnyMatcher();
+
+		private AnyMatcher()
+		{
+		}
+
+		public bool Matches(object value) => true;
+	}
+}

--- a/Source/MethodCall.cs
+++ b/Source/MethodCall.cs
@@ -133,6 +133,25 @@ namespace Moq
 				}
 				else if (parameter.IsRefArgument())
 				{
+					// Test for special case: `It.Ref<TValue>.IsAny`
+					if (argument is MemberExpression memberExpression)
+					{
+						var member = memberExpression.Member;
+						if (member.Name == nameof(It.Ref<object>.IsAny))
+						{
+							var memberDeclaringType = member.DeclaringType;
+							if (memberDeclaringType.GetTypeInfo().IsGenericType)
+							{
+								var memberDeclaringTypeDefinition = memberDeclaringType.GetGenericTypeDefinition();
+								if (memberDeclaringTypeDefinition == typeof(It.Ref<>))
+								{
+									this.argumentMatchers.Add(AnyMatcher.Instance);
+									continue;
+								}
+							}
+						}
+					}
+
 					var constant = argument.PartialEval() as ConstantExpression;
 					if (constant == null)
 					{

--- a/Source/Protected/ItExpr.cs
+++ b/Source/Protected/ItExpr.cs
@@ -64,6 +64,26 @@ namespace Moq.Protected
 	public static class ItExpr
 	{
 		/// <summary>
+		/// Contains matchers for <see langword="ref"/> (C#) / <see langword="ByRef"/> (VB.NET) parameters of type <typeparamref name="TValue"/>.
+		/// </summary>
+		/// <typeparam name="TValue"></typeparam>
+		public static class Ref<TValue>
+		{
+			/// <summary>
+			/// Matches any value that is assignment-compatible with type <typeparamref name="TValue"/>.
+			/// </summary>
+			/// <returns></returns>
+			public static Expression IsAny
+			{
+				get
+				{
+					Expression<Func<TValue>> expr = () => It.Ref<TValue>.IsAny;
+					return expr.Body;
+				}
+			}
+		}
+
+		/// <summary>
 		/// Matches a null value of the given <typeparamref name="TValue"/> type.
 		/// </summary>
 		/// <remarks>


### PR DESCRIPTION
This PR adds `It.Ref<T>.IsAny` which is to `ref` parameters what `It.IsAny<T>()` is to regular by-value parameters:

```csharp
interface IFoo
{
    void Do(ref int n);
}

var mock = new Mock<IFoo>();
mock.Setup(m => m.Do(ref It.Ref<int>.IsAny));
```

This resolves #479.