### PR TITLE
Move state (fields) from `Mock` into `Mock<T>`

### DIFF
--- a/Source/AsInterface.cs
+++ b/Source/AsInterface.cs
@@ -65,6 +65,8 @@ namespace Moq
 
 		internal override InvocationCollection Invocations => this.owner.Invocations;
 
+		internal override bool IsObjectInitialized => this.owner.IsObjectInitialized;
+
 		internal override Type MockedType
 		{
 			get { return typeof(TInterface); }

--- a/Source/AsInterface.cs
+++ b/Source/AsInterface.cs
@@ -92,6 +92,10 @@ namespace Moq
 
 		internal override EventHandlerCollection EventHandlers => this.owner.EventHandlers;
 
+		internal override List<Type> ImplementedInterfaces => this.owner.ImplementedInterfaces;
+
+		internal override int InternallyImplementedInterfaceCount => this.owner.InternallyImplementedInterfaceCount;
+
 		public override TInterface Object
 		{
 			get { return this.owner.Object as TInterface; }

--- a/Source/AsInterface.cs
+++ b/Source/AsInterface.cs
@@ -72,11 +72,7 @@ namespace Moq
 			get { return typeof(TInterface); }
 		}
 
-		public override MockBehavior Behavior
-		{
-			get { return this.owner.Behavior; }
-			internal set { this.owner.Behavior = value; }
-		}
+		public override MockBehavior Behavior => this.owner.Behavior;
 
 		public override bool CallBase
 		{

--- a/Source/Mock.Generic.cs
+++ b/Source/Mock.Generic.cs
@@ -62,11 +62,14 @@ namespace Moq
 	public partial class Mock<T> : Mock, IMock<T> where T : class
 	{
 		private static int serialNumberCounter = 0;
+
 		private T instance;
 		private Dictionary<Type, object> configuredDefaultValues;
 		private object[] constructorArguments;
 		private DefaultValueProvider defaultValueProvider;
 		private EventHandlerCollection eventHandlers;
+		private List<Type> implementedInterfaces;
+		private int internallyImplementedInterfaceCount;
 		private ConcurrentDictionary<MethodInfo, MockWithWrappedMockObject> innerMocks;
 		private InvocationCollection invocations;
 		private SetupCollection setups;
@@ -127,9 +130,10 @@ namespace Moq
 			this.constructorArguments = args;
 			this.defaultValueProvider = DefaultValueProvider.Empty;
 			this.eventHandlers = new EventHandlerCollection();
-			this.ImplementedInterfaces.AddRange(typeof(T).GetInterfaces().Where(i => (i.GetTypeInfo().IsPublic || i.GetTypeInfo().IsNestedPublic) && !i.GetTypeInfo().IsImport));
-			this.ImplementedInterfaces.Add(typeof(IMocked<T>));
-			this.InternallyImplementedInterfaceCount = this.ImplementedInterfaces.Count;
+			this.implementedInterfaces = new List<Type>();
+			this.implementedInterfaces.AddRange(typeof(T).GetInterfaces().Where(i => (i.GetTypeInfo().IsPublic || i.GetTypeInfo().IsNestedPublic) && !i.GetTypeInfo().IsImport));
+			this.implementedInterfaces.Add(typeof(IMocked<T>));
+			this.internallyImplementedInterfaceCount = this.ImplementedInterfaces.Count;
 			this.innerMocks = new ConcurrentDictionary<MethodInfo, MockWithWrappedMockObject>();
 			this.invocations = new InvocationCollection();
 			this.setups = new SetupCollection();
@@ -194,6 +198,10 @@ namespace Moq
 		internal override EventHandlerCollection EventHandlers => this.eventHandlers;
 
 		internal override ConcurrentDictionary<MethodInfo, MockWithWrappedMockObject> InnerMocks => this.innerMocks;
+
+		internal override List<Type> ImplementedInterfaces => this.implementedInterfaces;
+
+		internal override int InternallyImplementedInterfaceCount => this.internallyImplementedInterfaceCount;
 
 		internal override InvocationCollection Invocations => this.invocations;
 

--- a/Source/Mock.Generic.cs
+++ b/Source/Mock.Generic.cs
@@ -72,6 +72,7 @@ namespace Moq
 		private int internallyImplementedInterfaceCount;
 		private ConcurrentDictionary<MethodInfo, MockWithWrappedMockObject> innerMocks;
 		private InvocationCollection invocations;
+		private string name;
 		private SetupCollection setups;
 
 		private MockBehavior behavior;
@@ -126,8 +127,6 @@ namespace Moq
 				args = new object[] { null };
 			}
 
-			this.Name = GenerateMockName();
-
 			this.behavior = behavior;
 			this.configuredDefaultValues = new Dictionary<Type, object>();
 			this.constructorArguments = args;
@@ -139,17 +138,18 @@ namespace Moq
 			this.internallyImplementedInterfaceCount = this.ImplementedInterfaces.Count;
 			this.innerMocks = new ConcurrentDictionary<MethodInfo, MockWithWrappedMockObject>();
 			this.invocations = new InvocationCollection();
+			this.name = CreateUniqueDefaultMockName();
 			this.setups = new SetupCollection();
 			this.switches = Switches.Default;
 
 			this.CheckParameters();
 		}
 
-		private string GenerateMockName()
+		private static string CreateUniqueDefaultMockName()
 		{
 			var serialNumber = Interlocked.Increment(ref serialNumberCounter).ToString("x8");
 
-			var typeName = typeof (T).FullName;
+			string typeName = typeof (T).FullName;
 
 #if FEATURE_CODEDOM
 			if (typeof (T).IsGenericType)
@@ -229,7 +229,11 @@ namespace Moq
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Name"]/*'/>
-		public string Name { get; set; }
+		public string Name
+		{
+			get => this.name;
+			set => this.name = value;
+		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.ToString"]/*'/>
 		public override string ToString()

--- a/Source/Mock.Generic.cs
+++ b/Source/Mock.Generic.cs
@@ -65,6 +65,9 @@ namespace Moq
 		private Dictionary<Type, object> configuredDefaultValues;
 		private object[] constructorArguments;
 		private DefaultValueProvider defaultValueProvider;
+		private EventHandlerCollection eventHandlers;
+		private InvocationCollection invocations;
+		private SetupCollection setups;
 		private Switches switches;
 
 #region Ctors
@@ -121,9 +124,12 @@ namespace Moq
 			this.configuredDefaultValues = new Dictionary<Type, object>();
 			this.constructorArguments = args;
 			this.defaultValueProvider = DefaultValueProvider.Empty;
+			this.eventHandlers = new EventHandlerCollection();
 			this.ImplementedInterfaces.AddRange(typeof(T).GetInterfaces().Where(i => (i.GetTypeInfo().IsPublic || i.GetTypeInfo().IsNestedPublic) && !i.GetTypeInfo().IsImport));
 			this.ImplementedInterfaces.Add(typeof(IMocked<T>));
 			this.InternallyImplementedInterfaceCount = this.ImplementedInterfaces.Count;
+			this.invocations = new InvocationCollection();
+			this.setups = new SetupCollection();
 			this.switches = Switches.Default;
 
 			this.CheckParameters();
@@ -181,6 +187,10 @@ namespace Moq
 			get => this.defaultValueProvider;
 			set => this.defaultValueProvider = value ?? throw new ArgumentNullException(nameof(value));
 		}
+
+		internal override EventHandlerCollection EventHandlers => this.eventHandlers;
+
+		internal override InvocationCollection Invocations => this.invocations;
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Object"]/*'/>
 		[SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Object", Justification = "Exposes the mocked object instance, so it's appropriate.")]
@@ -273,6 +283,8 @@ namespace Moq
 		{
 			get { return typeof(T); }
 		}
+
+		internal override SetupCollection Setups => this.setups;
 
 		internal override Type TargetType => typeof(T);
 

--- a/Source/Mock.Generic.cs
+++ b/Source/Mock.Generic.cs
@@ -65,6 +65,7 @@ namespace Moq
 		private Dictionary<Type, object> configuredDefaultValues;
 		private object[] constructorArguments;
 		private DefaultValueProvider defaultValueProvider;
+		private Switches switches;
 
 #region Ctors
 
@@ -123,6 +124,7 @@ namespace Moq
 			this.ImplementedInterfaces.AddRange(typeof(T).GetInterfaces().Where(i => (i.GetTypeInfo().IsPublic || i.GetTypeInfo().IsNestedPublic) && !i.GetTypeInfo().IsImport));
 			this.ImplementedInterfaces.Add(typeof(IMocked<T>));
 			this.InternallyImplementedInterfaceCount = this.ImplementedInterfaces.Count;
+			this.switches = Switches.Default;
 
 			this.CheckParameters();
 		}
@@ -273,6 +275,16 @@ namespace Moq
 		}
 
 		internal override Type TargetType => typeof(T);
+
+		/// <summary>
+		/// A set of switches that influence how this mock will operate.
+		/// You can opt in or out of certain features via this property.
+		/// </summary>
+		public override Switches Switches
+		{
+			get => this.switches;
+			set => this.switches = value;
+		}
 
 #endregion
 

--- a/Source/Mock.Generic.cs
+++ b/Source/Mock.Generic.cs
@@ -73,6 +73,8 @@ namespace Moq
 		private ConcurrentDictionary<MethodInfo, MockWithWrappedMockObject> innerMocks;
 		private InvocationCollection invocations;
 		private SetupCollection setups;
+
+		private MockBehavior behavior;
 		private Switches switches;
 
 #region Ctors
@@ -125,7 +127,7 @@ namespace Moq
 
 			this.Name = GenerateMockName();
 
-			this.Behavior = behavior;
+			this.behavior = behavior;
 			this.configuredDefaultValues = new Dictionary<Type, object>();
 			this.constructorArguments = args;
 			this.defaultValueProvider = DefaultValueProvider.Empty;
@@ -182,6 +184,9 @@ namespace Moq
 #endregion
 
 #region Properties
+
+		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.Behavior"]/*'/>
+		public override MockBehavior Behavior => this.behavior;
 
 		internal override Dictionary<Type, object> ConfiguredDefaultValues => this.configuredDefaultValues;
 

--- a/Source/Mock.Generic.cs
+++ b/Source/Mock.Generic.cs
@@ -192,6 +192,8 @@ namespace Moq
 
 		internal override InvocationCollection Invocations => this.invocations;
 
+		internal override bool IsObjectInitialized => this.instance != null;
+
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Object"]/*'/>
 		[SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Object", Justification = "Exposes the mocked object instance, so it's appropriate.")]
 		[SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods", Justification = "The public Object property is the only one visible to Moq consumers. The protected member is for internal use only.")]

--- a/Source/Mock.Generic.cs
+++ b/Source/Mock.Generic.cs
@@ -75,6 +75,7 @@ namespace Moq
 		private SetupCollection setups;
 
 		private MockBehavior behavior;
+		private bool callBase;
 		private Switches switches;
 
 #region Ctors
@@ -187,6 +188,13 @@ namespace Moq
 
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.Behavior"]/*'/>
 		public override MockBehavior Behavior => this.behavior;
+
+		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.CallBase"]/*'/>
+		public override bool CallBase
+		{
+			get => this.callBase;
+			set => this.callBase = value;
+		}
 
 		internal override Dictionary<Type, object> ConfiguredDefaultValues => this.configuredDefaultValues;
 

--- a/Source/Mock.Generic.cs
+++ b/Source/Mock.Generic.cs
@@ -39,6 +39,7 @@
 // http://www.opensource.org/licenses/bsd-license.php]
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -66,6 +67,7 @@ namespace Moq
 		private object[] constructorArguments;
 		private DefaultValueProvider defaultValueProvider;
 		private EventHandlerCollection eventHandlers;
+		private ConcurrentDictionary<MethodInfo, MockWithWrappedMockObject> innerMocks;
 		private InvocationCollection invocations;
 		private SetupCollection setups;
 		private Switches switches;
@@ -128,6 +130,7 @@ namespace Moq
 			this.ImplementedInterfaces.AddRange(typeof(T).GetInterfaces().Where(i => (i.GetTypeInfo().IsPublic || i.GetTypeInfo().IsNestedPublic) && !i.GetTypeInfo().IsImport));
 			this.ImplementedInterfaces.Add(typeof(IMocked<T>));
 			this.InternallyImplementedInterfaceCount = this.ImplementedInterfaces.Count;
+			this.innerMocks = new ConcurrentDictionary<MethodInfo, MockWithWrappedMockObject>();
 			this.invocations = new InvocationCollection();
 			this.setups = new SetupCollection();
 			this.switches = Switches.Default;
@@ -189,6 +192,8 @@ namespace Moq
 		}
 
 		internal override EventHandlerCollection EventHandlers => this.eventHandlers;
+
+		internal override ConcurrentDictionary<MethodInfo, MockWithWrappedMockObject> InnerMocks => this.innerMocks;
 
 		internal override InvocationCollection Invocations => this.invocations;
 

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -60,18 +60,12 @@ namespace Moq
 	public abstract partial class Mock : IFluentInterface
 	{
 		private bool isInitialized;
-		private EventHandlerCollection eventHandlers;
-		private InvocationCollection invocations;
-		private SetupCollection setups;
 
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.ctor"]/*'/>
 		protected Mock()
 		{
-			this.eventHandlers = new EventHandlerCollection();
 			this.ImplementedInterfaces = new List<Type>();
 			this.InnerMocks = new ConcurrentDictionary<MethodInfo, MockWithWrappedMockObject>();
-			this.invocations = new InvocationCollection();
-			this.setups = new SetupCollection();
 		}
 
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.Get"]/*'/>
@@ -179,7 +173,7 @@ namespace Moq
 			}
 		}
 
-		internal virtual EventHandlerCollection EventHandlers => this.eventHandlers;
+		internal abstract EventHandlerCollection EventHandlers { get; }
 
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.Object"]/*'/>
 		[SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Object", Justification = "Exposes the mocked object instance, so it's appropriate.")]
@@ -198,7 +192,7 @@ namespace Moq
 
 		internal virtual ConcurrentDictionary<MethodInfo, MockWithWrappedMockObject> InnerMocks { get; private set; }
 
-		internal virtual InvocationCollection Invocations => this.invocations;
+		internal abstract InvocationCollection Invocations { get; }
 
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.OnGetObject"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "This is actually the protected virtual implementation of the property Object.")]
@@ -241,7 +235,7 @@ namespace Moq
 		/// </summary>
 		internal protected int InternallyImplementedInterfaceCount { get; protected set; }
 
-		internal virtual SetupCollection Setups => this.setups;
+		internal abstract SetupCollection Setups { get; }
 
 		/// <summary>
 		/// A set of switches that influence how this mock will operate.
@@ -410,7 +404,7 @@ namespace Moq
 
 		internal static void VerifyNoOtherCalls(Mock mock)
 		{
-			var unverifiedInvocations = mock.invocations.ToArray(invocation => !invocation.Verified);
+			var unverifiedInvocations = mock.Invocations.ToArray(invocation => !invocation.Verified);
 			if (unverifiedInvocations.Any())
 			{
 				throw new MockException(

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -139,7 +139,7 @@ namespace Moq
 		}
 
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.Behavior"]/*'/>
-		public virtual MockBehavior Behavior { get; internal set; }
+		public abstract MockBehavior Behavior { get; }
 
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.CallBase"]/*'/>
 		public virtual bool CallBase { get; set; }

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -59,8 +59,6 @@ namespace Moq
 	/// <include file='Mock.xdoc' path='docs/doc[@for="Mock"]/*'/>
 	public abstract partial class Mock : IFluentInterface
 	{
-		private bool isInitialized;
-
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.ctor"]/*'/>
 		protected Mock()
 		{
@@ -178,19 +176,11 @@ namespace Moq
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.Object"]/*'/>
 		[SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Object", Justification = "Exposes the mocked object instance, so it's appropriate.")]
 		[SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods", Justification = "The public Object property is the only one visible to Moq consumers. The protected member is for internal use only.")]
-		public object Object
-		{
-			get { return this.GetObject(); }
-		}
-
-		private object GetObject()
-		{
-			var value = this.OnGetObject();
-			this.isInitialized = true;
-			return value;
-		}
+		public object Object => this.OnGetObject();
 
 		internal virtual ConcurrentDictionary<MethodInfo, MockWithWrappedMockObject> InnerMocks { get; private set; }
+
+		internal abstract bool IsObjectInitialized { get; }
 
 		internal abstract InvocationCollection Invocations { get; }
 
@@ -1146,7 +1136,7 @@ namespace Moq
 			var index = this.ImplementedInterfaces.LastIndexOf(typeof(TInterface));
 
 			var isImplemented = index >= 0;
-			if (this.isInitialized && !isImplemented)
+			if (this.IsObjectInitialized && !isImplemented)
 			{
 				throw new InvalidOperationException(Resources.AlreadyInitialized);
 			}

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -62,7 +62,6 @@ namespace Moq
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.ctor"]/*'/>
 		protected Mock()
 		{
-			this.ImplementedInterfaces = new List<Type>();
 		}
 
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.Get"]/*'/>
@@ -216,13 +215,13 @@ namespace Moq
 		/// <summary>
 		/// Exposes the list of extra interfaces implemented by the mock.
 		/// </summary>
-		internal List<Type> ImplementedInterfaces { get; private set; }
+		internal abstract List<Type> ImplementedInterfaces { get; }
 
 		/// <summary>
 		/// Indicates the number of interfaces in <see cref="ImplementedInterfaces"/> that were
 		/// defined internally, rather than through calls to <see cref="As{TInterface}"/>.
 		/// </summary>
-		internal protected int InternallyImplementedInterfaceCount { get; protected set; }
+		internal abstract int InternallyImplementedInterfaceCount { get; }
 
 		internal abstract SetupCollection Setups { get; }
 

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -142,7 +142,7 @@ namespace Moq
 		public abstract MockBehavior Behavior { get; }
 
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.CallBase"]/*'/>
-		public virtual bool CallBase { get; set; }
+		public abstract bool CallBase { get; set; }
 
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.DefaultValue"]/*'/>
 		public DefaultValue DefaultValue

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -63,7 +63,6 @@ namespace Moq
 		private EventHandlerCollection eventHandlers;
 		private InvocationCollection invocations;
 		private SetupCollection setups;
-		private Switches switches;
 
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.ctor"]/*'/>
 		protected Mock()
@@ -73,7 +72,6 @@ namespace Moq
 			this.InnerMocks = new ConcurrentDictionary<MethodInfo, MockWithWrappedMockObject>();
 			this.invocations = new InvocationCollection();
 			this.setups = new SetupCollection();
-			this.switches = Switches.Default;
 		}
 
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.Get"]/*'/>
@@ -131,7 +129,7 @@ namespace Moq
 
 			throw new ArgumentException(Resources.ObjectInstanceNotMock, "mocked");
 		}
-		
+
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.Verify"]/*'/>
 		public static void Verify(params Mock[] mocks)
 		{
@@ -140,7 +138,7 @@ namespace Moq
 				mock.Verify();
 			}
 		}
-		
+
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.VerifyAll"]/*'/>
 		public static void VerifyAll(params Mock[] mocks)
 		{
@@ -249,11 +247,7 @@ namespace Moq
 		/// A set of switches that influence how this mock will operate.
 		/// You can opt in or out of certain features via this property.
 		/// </summary>
-		public virtual Switches Switches
-		{
-			get => this.switches;
-			set => this.switches = value;
-		}
+		public abstract Switches Switches { get; set; }
 
 		internal abstract Type TargetType { get; }
 

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -63,7 +63,6 @@ namespace Moq
 		protected Mock()
 		{
 			this.ImplementedInterfaces = new List<Type>();
-			this.InnerMocks = new ConcurrentDictionary<MethodInfo, MockWithWrappedMockObject>();
 		}
 
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.Get"]/*'/>
@@ -178,7 +177,7 @@ namespace Moq
 		[SuppressMessage("Microsoft.Naming", "CA1721:PropertyNamesShouldNotMatchGetMethods", Justification = "The public Object property is the only one visible to Moq consumers. The protected member is for internal use only.")]
 		public object Object => this.OnGetObject();
 
-		internal virtual ConcurrentDictionary<MethodInfo, MockWithWrappedMockObject> InnerMocks { get; private set; }
+		internal abstract ConcurrentDictionary<MethodInfo, MockWithWrappedMockObject> InnerMocks { get; }
 
 		internal abstract bool IsObjectInitialized { get; }
 


### PR DESCRIPTION
Mock state and initialization is currently split across both `Mock` and `Mock<T>`. This is not ideal for at least three reasons:

1. It is difficult to get an idea how much state a mock object really carries.

2. It can be hard to understand control flow (e. g. with mock object initialization), which might bounce back and forth between methods defined in both `Mock` and `Mock<T>`.

3. It's relatively easy to introduce `As<TInterface>`-related bugs by directly referencing backing fields instead of their corresponding properties. `As<TInterface>` mocks do not use their own backing fields (which remain completely uninitialized), but instead delegate all properties to the "owner" mock's. Therefore, for `As<TInterface>` mocks to work correctly, code should always reference the properties, and never the backing fields. Moving the fields away from `Mock` (where most logic sits) helps with enforcing this.