### PR TITLE
Refactor `ImplementedInterfaces` contraption

### DIFF
--- a/Source/AsInterface.cs
+++ b/Source/AsInterface.cs
@@ -56,6 +56,8 @@ namespace Moq
 			this.owner = owner;
 		}
 
+		internal override List<Type> AdditionalInterfaces => this.owner.AdditionalInterfaces;
+
 		internal override Dictionary<Type, object> ConfiguredDefaultValues => this.owner.ConfiguredDefaultValues;
 
 		internal override ConcurrentDictionary<MethodInfo, MockWithWrappedMockObject> InnerMocks
@@ -88,9 +90,7 @@ namespace Moq
 
 		internal override EventHandlerCollection EventHandlers => this.owner.EventHandlers;
 
-		internal override List<Type> ImplementedInterfaces => this.owner.ImplementedInterfaces;
-
-		internal override int InternallyImplementedInterfaceCount => this.owner.InternallyImplementedInterfaceCount;
+		internal override Type[] InheritedInterfaces => this.owner.InheritedInterfaces;
 
 		public override TInterface Object
 		{

--- a/Source/Interception/InterceptionAspects.cs
+++ b/Source/Interception/InterceptionAspects.cs
@@ -173,7 +173,7 @@ namespace Moq
 		public override InterceptionAction Handle(Invocation invocation, Mock mock)
 		{
 			if (invocation.Method.DeclaringType == typeof(object) || // interface proxy
-				mock.ImplementedInterfaces.Contains(invocation.Method.DeclaringType) && !invocation.Method.LooksLikeEventAttach() && !invocation.Method.LooksLikeEventDetach() && mock.CallBase && !mock.MockedType.GetTypeInfo().IsInterface || // class proxy with explicitly implemented interfaces. The method's declaring type is the interface and the method couldn't be abstract
+				mock.ImplementsInterface(invocation.Method.DeclaringType) && !invocation.Method.LooksLikeEventAttach() && !invocation.Method.LooksLikeEventDetach() && mock.CallBase && !mock.MockedType.GetTypeInfo().IsInterface || // class proxy with explicitly implemented interfaces. The method's declaring type is the interface and the method couldn't be abstract
 				invocation.Method.DeclaringType.GetTypeInfo().IsClass && !invocation.Method.IsAbstract && mock.CallBase // class proxy
 				)
 			{
@@ -350,8 +350,8 @@ namespace Moq
 		/// <param name="mock"/>
 		private static EventInfo GetEventFromName(string eventName, BindingFlags bindingAttr, Mock mock)
 		{
-			// Ignore internally implemented interfaces
-			var depthFirstProgress = new Queue<Type>(mock.ImplementedInterfaces.Skip(mock.InternallyImplementedInterfaceCount));
+			// Ignore inherited interfaces and internally defined IMocked<T>
+			var depthFirstProgress = new Queue<Type>(mock.AdditionalInterfaces);
 			depthFirstProgress.Enqueue(mock.TargetType);
 			while (depthFirstProgress.Count > 0)
 			{


### PR DESCRIPTION
`ImplementedInterfaces` together with `InternallyImplementedInterfaceCount` contains three logically semi-separate sets of interface types:

 1. interface types inherited from the mocked type
 2. `IMocked<T>`
 3. additional interface types requested through `As<TInterface>()`

Combining these three into a single collection results in some rather convoluted code.

This commit pries these three things apart: (1) is turned into a `InheritedInterfaces` property, which is implemented using a static backing field, (2) is directly referenced where required, and (3) is turned into a `AdditionalInterfaces` property.

This results in simpler code and reduced memory consumption.