### PR TITLE
Restore default value provider correctly in `FluentMockContext`

### DIFF
--- a/Moq.Tests/CustomDefaultValueProviderFixture.cs
+++ b/Moq.Tests/CustomDefaultValueProviderFixture.cs
@@ -89,8 +89,24 @@ namespace Moq.Tests
 			Assert.Equal(expectedReturnValue, actualReturnValue);
 		}
 
+		[Fact]
+		public void FluentMockContext_properly_restores_custom_default_value_provider()
+		{
+			var customDefaultValueProvider = new ConstantDefaultValueProvider(42);
+			var mock = new Mock<IFoo>() { DefaultValueProvider = customDefaultValueProvider };
+
+			mock.VerifySet(m => m.Inner.Value = 1, Times.Never);
+			//             ^^^^^^^^^^^^^^^^^^^^^^
+			// Moq has to execute this action to analyse what is being set. Because this is a multi-dot expression,
+			// it temporarily switches to DefaultValue.Mock. Once it's done, it should switch back to the one we
+			// set up above.
+
+			Assert.Same(customDefaultValueProvider, mock.DefaultValueProvider);
+		}
+
 		public interface IFoo
 		{
+			int Value { get; set; }
 			int GetValue();
 			int[] GetValues();
 			IFoo Inner { get; }

--- a/Source/FluentMockContext.cs
+++ b/Source/FluentMockContext.cs
@@ -100,14 +100,15 @@ namespace Moq
 
 		internal class MockInvocation : IDisposable
 		{
-			private DefaultValue defaultValue;
+			private DefaultValueProvider defaultValueProvider;
 
 			public MockInvocation(Mock mock, Invocation invocation, Match matcher)
 			{
 				this.Mock = mock;
 				this.Invocation = invocation;
 				this.Match = matcher;
-				defaultValue = mock.DefaultValue;
+				this.defaultValueProvider = mock.DefaultValueProvider;
+
 				// Temporarily set mock default value to Mock so that recursion works.
 				mock.DefaultValue = DefaultValue.Mock;
 			}
@@ -120,7 +121,7 @@ namespace Moq
 
 			public void Dispose()
 			{
-				Mock.DefaultValue = defaultValue;
+				this.Mock.DefaultValueProvider = this.defaultValueProvider;
 			}
 		}
 	}


### PR DESCRIPTION
Bug fix related to the introduction of `DefaultValueProvider`.