### PR TITLE
`VerifyNoOtherCalls`: Fix bugs with `Mock.Of<T>`

### DIFF
--- a/Moq.Tests/VerifyFixture.cs
+++ b/Moq.Tests/VerifyFixture.cs
@@ -1150,6 +1150,33 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public void VerifyNoOtherCalls_succeeds_if_no_calls_were_made_on_mock_created_by_Mock_Of()
+		{
+			var mocked = Mock.Of<IFoo>();
+			var mock = Mock.Get(mocked);
+
+			mock.VerifyNoOtherCalls();
+		}
+
+		[Fact]
+		public void VerifyNoOtherCalls_succeeds_if_no_calls_were_made_on_mock_created_by_Mock_Of_with_single_dot_predicate()
+		{
+			var mocked = Mock.Of<IFoo>(m => m.Value == 1);
+			var mock = Mock.Get(mocked);
+
+			mock.VerifyNoOtherCalls();
+		}
+
+		[Fact]
+		public void VerifyNoOtherCalls_succeeds_if_no_calls_were_made_on_mock_created_by_Mock_Of_with_multi_dot_predicate()
+		{
+			var mocked = Mock.Of<IFoo>(m => m.Bar.Value == 1);
+			var mock = Mock.Get(mocked);
+
+			mock.VerifyNoOtherCalls();
+		}
+
+		[Fact]
 		public void VerifyNoOtherCalls_fails_if_an_unverified_call_was_made()
 		{
 			var mock = new Mock<IFoo>();
@@ -1209,6 +1236,7 @@ namespace Moq.Tests
 
 		public interface IFoo
 		{
+			IBar Bar { get; }
 			int WriteOnly { set; }
 			int? Value { get; set; }
 			void EchoRef<T>(ref T value);

--- a/Source/Linq/Mocks.cs
+++ b/Source/Linq/Mocks.cs
@@ -94,7 +94,7 @@ namespace Moq
 		[Obsolete("Moved to Mock.Of<T>, as it's a single one, so no reason to be on Mocks.", true)]
 		public static T OneOf<T>() where T : class
 		{
-			return CreateMockQuery<T>().First<T>();
+			return Mock.Of<T>();
 		}
 
 		/// <summary>
@@ -108,7 +108,7 @@ namespace Moq
 		[Obsolete("Moved to Mock.Of<T>, as it's a single one, so no reason to be on Mocks.", true)]
 		public static T OneOf<T>(Expression<Func<T, bool>> specification) where T : class
 		{
-			return CreateMockQuery<T>().First<T>(specification);
+			return Mock.Of<T>(specification);
 		}
 
 		/// <summary>


### PR DESCRIPTION
This PR ensures that mocks created with `Mock.Of<T>` initially have no recorded invocations.

Due to the way `Mock.Of<T>` is currently implemented, mocks created using this method might already have recorded invocations. This never really mattered up until now, where it can interfere with `VerifyNoOtherCalls`.

This solves one of two issues with the initial `VerifyNoOtherCalls` implementation, as tracked in  https://github.com/moq/moq4/issues/527#issuecomment-348697314.