### PR TITLE
`VerifyNoOtherCalls`: fix bugs with multi-dot expressions

### DIFF
--- a/Moq.Tests/VerifyFixture.cs
+++ b/Moq.Tests/VerifyFixture.cs
@@ -1259,6 +1259,16 @@ namespace Moq.Tests
 			mock.VerifyNoOtherCalls();
 		}
 
+		[Fact]
+		public void VerifyNoOtherCalls_performs_recursive_verification()
+		{
+			var mock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock };
+			mock.Object.Bar.Poke();
+
+			mock.VerifyGet(m => m.Bar);
+			Assert.Throws<MockException>(() => mock.VerifyNoOtherCalls()); // should fail due to the unverified call to `Poke`
+		}
+
 		public interface IBar
 		{
 			int? Value { get; set; }

--- a/Moq.Tests/VerifyFixture.cs
+++ b/Moq.Tests/VerifyFixture.cs
@@ -1269,6 +1269,46 @@ namespace Moq.Tests
 			Assert.Throws<MockException>(() => mock.VerifyNoOtherCalls()); // should fail due to the unverified call to `Poke`
 		}
 
+		[Fact]
+		public void VerifyNoOtherCalls_requires_explicit_verification_of_automocked_properties_that_are_not_used_transitively()
+		{
+			var mock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock };
+
+			var _ = mock.Object.Bar;
+
+			// Even though `Bar` is mockable and will be automatically mocked, it isn't used "transitively",
+			// i.e. in a way to get at one of its members. Therefore, it ought to be verified explicitly.
+			// Because we don't verify it, a verification exception should be thrown:
+			Assert.Throws<MockException>(() => mock.VerifyNoOtherCalls());
+		}
+
+		[Fact(Skip = "Not yet implemented.")]
+		public void VerifyNoOtherCalls_can_tell_apart_transitive_and_nontransitive_usages_of_automocked_properties()
+		{
+			var mock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock };
+
+			object _;
+			_ = mock.Object.Bar;
+			_ = mock.Object.Bar.Value;
+
+			mock.Verify(m => m.Bar.Value);
+
+			// `Bar` was used both in a "transitive" and non-transitive way. We would expect that the former
+			// doesn't have to be explicitly verified (as it's implied by the verifiation of `Bar.Value`).
+			// However, the non-transitive call ought to be explicitly verified. Because we don't, a verific-
+			// ation exception is expected: (THIS DOES NOT WORK YET.)
+			Assert.Throws<MockException>(() => mock.VerifyNoOtherCalls());
+
+			// HINT TO IMPLEMENTERS: One relatively easy way to implement this, given the way Moq is currently
+			// build, would be to record all invocations with a globally unique, steadily increasing sequence
+			// number. This would make it possible to say, for any two invocations (regardless of the mock on
+			// which they occurred), which one happened earlier. Let's look at two calls of method X. The
+			// earlier invocation happens at "time" t0, the later invocation happens at "time" t1 (t0 < t1).
+			// If X returns a mock object, and that object has no invocations happening between t0 and t1,
+			// then the first invocation of X was non-transitive. Likewise, the very last invocation of method
+			// X is non-transitive if there are no invocations on the sub-object that occur later.
+		}
+
 		public interface IBar
 		{
 			int? Value { get; set; }

--- a/Moq.Tests/VerifyFixture.cs
+++ b/Moq.Tests/VerifyFixture.cs
@@ -1229,9 +1229,40 @@ namespace Moq.Tests
 			Assert.Contains(".Submit()", ex.Message);
 		}
 
+		[Fact]
+		public void VerifyNoOtherCalls_succeeds_with_DefaultValue_Mock_and_multi_dot_Verify_expression()
+		{
+			var mock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock };
+			mock.Object.Bar.Poke();
+
+			mock.Verify(m => m.Bar.Poke());
+			mock.VerifyNoOtherCalls();
+		}
+
+		[Fact]
+		public void VerifyNoOtherCalls_succeeds_with_DefaultValue_Mock_and_multi_dot_VerifyGet_expression()
+		{
+			var mock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock };
+			var value = mock.Object.Bar.Value;
+
+			mock.VerifyGet(m => m.Bar.Value);
+			mock.VerifyNoOtherCalls();
+		}
+
+		[Fact]
+		public void VerifyNoOtherCalls_succeeds_with_DefaultValue_Mock_and_multi_dot_VerifySet_expression()
+		{
+			var mock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock };
+			mock.Object.Bar.Value = 42;
+
+			mock.VerifySet(m => m.Bar.Value = 42);
+			mock.VerifyNoOtherCalls();
+		}
+
 		public interface IBar
 		{
 			int? Value { get; set; }
+			void Poke();
 		}
 
 		public interface IFoo

--- a/Source/InvocationCollection.cs
+++ b/Source/InvocationCollection.cs
@@ -61,6 +61,11 @@ namespace Moq
 			}
 		}
 
+		public bool Any()
+		{
+			return this.invocations.Count > 0;
+		}
+
 		public void Clear()
 		{
 			lock (this.invocations)

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -431,6 +431,13 @@ namespace Moq
 							string.Join<Invocation>(Environment.NewLine, remainingUnverifiedInvocations)));
 				}
 			}
+
+			// Perform verification for all automatically created sub-objects (that is, those
+			// created by "transitive" invocations):
+			foreach (var inner in mock.InnerMocks.Values)
+			{
+				VerifyNoOtherCalls(inner.Mock);
+			}
 		}
 
 		private static void VerifyCalls(

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -395,14 +395,41 @@ namespace Moq
 		internal static void VerifyNoOtherCalls(Mock mock)
 		{
 			var unverifiedInvocations = mock.Invocations.ToArray(invocation => !invocation.Verified);
+
 			if (unverifiedInvocations.Any())
 			{
-				throw new MockException(
-					MockException.ExceptionReason.VerificationFailed,
-					string.Format(
-						CultureInfo.CurrentCulture,
-						Resources.UnverifiedInvocations,
-						string.Join<Invocation>(Environment.NewLine, unverifiedInvocations)));
+				// There are some invocations that shouldn't require explicit verification by the user.
+				// The intent behind a `Verify` call for a call expression like `m.A.B.C.X` is probably
+				// to verify `X`. If that succeeds, it's reasonable to expect that `m.A`, `m.A.B`, and
+				// `m.A.B.C` have implicitly been verified as well. Below, invocations such as those to
+				// the left of `X` are referred to as "transitive" (for lack of a better word).
+				if (mock.InnerMocks.Any())
+				{
+					for (int i = 0, n = unverifiedInvocations.Length; i < n; ++i)
+					{
+						// In order for an invocation to be "transitive", its return value has to be a
+						// sub-object (inner mock); and that sub-object has to have received at least
+						// one call:
+						var wasTransitiveInvocation = mock.InnerMocks.TryGetValue(unverifiedInvocations[i].Method, out MockWithWrappedMockObject inner)
+						                              && inner.Mock.Invocations.Any();
+						if (wasTransitiveInvocation)
+						{
+							unverifiedInvocations[i] = null;
+						}
+					}
+				}
+
+				// "Transitive" invocations have been nulled out. Let's see what's left:
+				var remainingUnverifiedInvocations = unverifiedInvocations.Where(i => i != null);
+				if (remainingUnverifiedInvocations.Any())
+				{
+					throw new MockException(
+						MockException.ExceptionReason.VerificationFailed,
+						string.Format(
+							CultureInfo.CurrentCulture,
+							Resources.UnverifiedInvocations,
+							string.Join<Invocation>(Environment.NewLine, remainingUnverifiedInvocations)));
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR ensures that `VerifyNoOtherCalls` gets along more or less nicely with multi-dot ("recursive") verification expressions.

Recursive expressions are generally a pain point in Moq, and the way they are implemented lead to all sorts of trouble. Quite a few of the currently remaining bug reports are directly related to that particular aspect of Moq. I'm expecting that despite the improvements in this PR, people might sooner or later discover that `VerifyNoOtherCalls` acts a little weird in circumstances where multi-dot expressions and automatically mocked sub-objects are involved.

(Fixing these multi-dot expression troubles is semi-planned for Moq 4.9 or 4.10.)

This solves the second of two issues with the initial `VerifyNoOtherCalls` implementation, as tracked in https://github.com/moq/moq4/issues/527#issuecomment-348697314.