### PR TITLE
Reduce use of reflection in `SetupAllProperties`

### DIFF
--- a/Source/MethodCall.cs
+++ b/Source/MethodCall.cs
@@ -102,6 +102,19 @@ namespace Moq
 		private Exception throwExceptionResponse;
 		private bool verifiable;
 
+		/// <remarks>
+		///   Only use this constructor when you know that the specified <paramref name="method"/> has no `out` parameters,
+		///   and when you want to avoid the <see cref="MatcherFactory"/>-related overhead of the other constructor overload.
+		/// </remarks>
+		public MethodCall(Mock mock, Condition condition, Expression originalExpression, MethodInfo method, IMatcher[] argumentMatchers)
+		{
+			this.argumentMatchers = argumentMatchers;
+			this.condition = condition;
+			this.method = method;
+			this.mock = mock;
+			this.originalExpression = originalExpression;
+		}
+
 		public MethodCall(Mock mock, Condition condition, Expression originalExpression, MethodInfo method, params Expression[] arguments)
 		{
 			this.mock = mock;

--- a/Source/PropertyGetterMethodCall.cs
+++ b/Source/PropertyGetterMethodCall.cs
@@ -1,0 +1,67 @@
+﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//https://github.com/moq/moq4
+//All rights reserved.
+
+//Redistribution and use in source and binary forms, 
+//with or without modification, are permitted provided 
+//that the following conditions are met:
+
+//    * Redistributions of source code must retain the 
+//    above copyright notice, this list of conditions and 
+//    the following disclaimer.
+
+//    * Redistributions in binary form must reproduce 
+//    the above copyright notice, this list of conditions 
+//    and the following disclaimer in the documentation 
+//    and/or other materials provided with the distribution.
+
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
+//    names of its contributors may be used to endorse 
+//    or promote products derived from this software 
+//    without specific prior written permission.
+
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+//SUCH DAMAGE.
+
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System;
+using System.Diagnostics;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Moq
+{
+	internal sealed class PropertyGetterMethodCall : MethodCall
+	{
+		private static IMatcher[] noArgumentMatchers = new IMatcher[0];
+
+		private Func<object> getter;
+
+		public PropertyGetterMethodCall(Mock mock, Expression originalExpression, MethodInfo method, Func<object> getter)
+			: base(mock, null, originalExpression, method, noArgumentMatchers)
+		{
+			this.getter = getter;
+		}
+
+		public override void Execute(Invocation invocation)
+		{
+			base.Execute(invocation);
+
+			invocation.Return(this.getter.Invoke());
+		}
+	}
+}

--- a/Source/PropertySetterMethodCall.cs
+++ b/Source/PropertySetterMethodCall.cs
@@ -1,0 +1,70 @@
+﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//https://github.com/moq/moq4
+//All rights reserved.
+
+//Redistribution and use in source and binary forms, 
+//with or without modification, are permitted provided 
+//that the following conditions are met:
+
+//    * Redistributions of source code must retain the 
+//    above copyright notice, this list of conditions and 
+//    the following disclaimer.
+
+//    * Redistributions in binary form must reproduce 
+//    the above copyright notice, this list of conditions 
+//    and the following disclaimer in the documentation 
+//    and/or other materials provided with the distribution.
+
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
+//    names of its contributors may be used to endorse 
+//    or promote products derived from this software 
+//    without specific prior written permission.
+
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
+//SUCH DAMAGE.
+
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System;
+using System.Diagnostics;
+using System.Linq.Expressions;
+using System.Reflection;
+
+using Moq.Matchers;
+
+namespace Moq
+{
+	internal sealed class PropertySetterMethodCall : MethodCall
+	{
+		private static IMatcher[] anyMatcherForSingleArgument = new IMatcher[] { AnyMatcher.Instance };
+
+		private Action<object> setter;
+
+		public PropertySetterMethodCall(Mock mock, Expression originalExpression, MethodInfo method, Action<object> setter)
+			: base(mock, null, originalExpression, method, anyMatcherForSingleArgument)
+		{
+			this.setter = setter;
+		}
+
+		public override void Execute(Invocation invocation)
+		{
+			base.Execute(invocation);
+
+			this.setter.Invoke(invocation.Arguments[0]);
+			invocation.Return();
+		}
+	}
+}


### PR DESCRIPTION
Excessive reflection in `SetupAllProperties` contributes to `Mock.Of<T>`'s bad performance (#547).

This PR reduces use of reflection in this method by adding instances of specialized `MethodCall` types directly to `mock.Setups`, instead of installing setups by making calls to `mock.SetupProperty(m => m.Property, initialValue)` or `mock.SetupGet(m => m.Property).Returns(value)` through reflection.