### PR TITLE
`SetupAllProperties`: Defer property initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 * **Breaking change:** `SetupSequence` now overrides pre-existing setups like all other `Setup` methods do. This means that exhausted sequences no longer fall back to previous setups to produce a "default" action or return value. (@stakx, #476)
 * Delegates passed to `Returns` are validated a little more strictly than before (return type and parameter count must match with method being set up) (@stakx, #520)
+* `SetupAllProperties` now fully supports property type recursion / loops in the object graph, thanks to deferred property initialization (@stakx, #550).
 
 #### Fixed
 

--- a/Moq.Tests/Regressions/FluentMockIssues.cs
+++ b/Moq.Tests/Regressions/FluentMockIssues.cs
@@ -30,10 +30,9 @@ namespace Moq.Tests.Regressions
 			var foo = new Mock<IOne> {DefaultValue = DefaultValue.Mock};
 			foo.SetupGet(m => m.Two.Three.SomeString).Returns("blah");
 
-			// the default value of the loopback property is not mocked
-			Assert.Null(foo.Object.Two.Three.LoopBack);
-			foo.SetupGet(m => m.Two.Three.LoopBack).Returns(Mock.Of<ITwo>());
+			// the default value of the loopback property is mocked
 			Assert.NotNull(foo.Object.Two.Three.LoopBack);
+			Assert.NotSame(foo.Object.Two, foo.Object.Two.Three.LoopBack);
 		}
 
 #if FEATURE_SERIALIZATION

--- a/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -1531,7 +1531,7 @@ namespace Moq.Tests.Regressions
 			{
 				var mock = new Mock<INode>() { DefaultValue = DefaultValue.Mock };
 				mock.SetupAllProperties();
-				Assert.Null(mock.Object.Parent);
+				Assert.NotNull(mock.Object.Parent);
 			}
 
 			public interface INode
@@ -1544,8 +1544,14 @@ namespace Moq.Tests.Regressions
 			{
 				var mock = new Mock<IPing>() { DefaultValue = DefaultValue.Mock };
 				mock.SetupAllProperties();
+
 				Assert.NotNull(mock.Object.Pong);
-				Assert.Null(mock.Object.Pong.Ping);
+
+				Assert.NotNull(mock.Object.Pong.Ping);
+				Assert.NotSame(mock.Object, mock.Object.Pong.Ping);
+
+				Assert.NotNull(mock.Object.Pong.Ping.Pong);
+				Assert.NotSame(mock.Object.Pong, mock.Object.Pong.Ping.Pong);
 			}
 
 			public interface IPing

--- a/Source/PexProtector.cs
+++ b/Source/PexProtector.cs
@@ -64,6 +64,12 @@ namespace Moq
 		}
 
 		[DebuggerHidden]
+		public static void Invoke<T1, T2>(Action<T1, T2> action, T1 arg1, T2 arg2)
+		{
+			action(arg1, arg2);
+		}
+
+		[DebuggerHidden]
 		public static TResult Invoke<T1, T2, T3, TResult>(Func<T1, T2, T3, TResult> function, T1 arg1, T2 arg2, T3 arg3)
 		{
 			return function(arg1, arg2, arg3);


### PR DESCRIPTION
Let `SetupAllProperties` defer initialization of set up properties to the point when they are queried for the very first time. Doing this has two advantages:

 1. There is no more immediate difference in execution speed between `DefaultValue.Empty` and `DefaultValue.Mock`. (Up until now, `SetupAllProperties` could be orders of magnitude slower when used with the latter default value mode.)

 2. Type recursion / loops in the object graph are no longer an issue (hence the changes to the unit tests). We no longer need to keep track of already mocked types, so we can get rid of `GetInitialValue` and call `GetDefaultValue` directly.