### PR TITLE
Build script: Fix xUnit test run for .NET Core

### DIFF
--- a/Moq.Tests.VisualBasic/Moq.Tests.VisualBasic.vbproj
+++ b/Moq.Tests.VisualBasic/Moq.Tests.VisualBasic.vbproj
@@ -12,6 +12,10 @@
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0" />
   </ItemGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <RuntimeFrameworkVersion>2.0.3</RuntimeFrameworkVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Source\Moq.csproj" />
   </ItemGroup>

--- a/Moq.Tests/Moq.Tests.csproj
+++ b/Moq.Tests/Moq.Tests.csproj
@@ -15,6 +15,7 @@
 		<DefineConstants>$(DefineConstants);DESKTOP;FEATURE_CAS;FEATURE_CODEDOM;FEATURE_COM;FEATURE_SERIALIZATION</DefineConstants>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+		<RuntimeFrameworkVersion>2.0.3</RuntimeFrameworkVersion>
 		<DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
 	</PropertyGroup>
 


### PR DESCRIPTION
Sadly, .NET Core tooling doesn't seem to be smart enough anymore to choose an appropriate .NET Core runtime host version itself when it is given `netcoreapp2.0` as the target platform. If we don't explicitly
tell it which precise host version to use, it'll flat out refuse to execute code (the xUnit tests, in our case).

Alternatively, I'm not smart enough to understand .NET Core. But I seem to remember that things used to just work not too long ago.

See https://github.com/dotnet/cli/issues/7901.