### PR TITLE
Adopt assembly versioning scheme 'major.minor.0.0'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * **Breaking change:** `SetupSequence` now overrides pre-existing setups like all other `Setup` methods do. This means that exhausted sequences no longer fall back to previous setups to produce a "default" action or return value. (@stakx, #476)
 * Delegates passed to `Returns` are validated a little more strictly than before (return type and parameter count must match with method being set up) (@stakx, #520)
 * `SetupAllProperties` now fully supports property type recursion / loops in the object graph, thanks to deferred property initialization (@stakx, #550).
+* Change assembly versioning scheme to `major.minor.0.0` to help prevent assembly version conflicts and to reduce the need for binding redirects (@stakx, #554)
 
 #### Fixed
 

--- a/Source/Properties/AssemblyInfo.cs
+++ b/Source/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Moq")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion (ThisAssembly.Git.SemVer.Major + "." + ThisAssembly.Git.SemVer.Minor + "." + ThisAssembly.Git.SemVer.Patch)]
+[assembly: AssemblyVersion(ThisAssembly.Git.SemVer.Major + "." + ThisAssembly.Git.SemVer.Minor + ".0.0")]
 [assembly: AssemblyFileVersion (ThisAssembly.Git.SemVer.Major + "." + ThisAssembly.Git.SemVer.Minor + "." + ThisAssembly.Git.SemVer.Patch)]
 [assembly: AssemblyInformationalVersion (ThisAssembly.Git.SemVer.Major + "." + ThisAssembly.Git.SemVer.Minor + "." + ThisAssembly.Git.SemVer.Patch + "-" + ThisAssembly.Git.Branch + "+" + ThisAssembly.Git.Commit)]
 


### PR DESCRIPTION
The rationale behind this is that we don't want changes in the patch version to result in a different strong name; patches should be in-place updates and shouldn't lead to version conflicts.

This will help reduce the need for assembly binding redirects.

For now, we only do 'major.minor.0.0' instead of 'major.0.0.0' (which would be even better).

For the next release, we'll have to increase the minor version by 1 to rule out strange-looking binding redirects like these:

    4.0.0.0 - 4.7.145.0  ->  4.0.0.0
    4.0.0.0 - 4.7.145.0  ->  4.7.0.0

In both cases, the following will probably look less suspicious:

    4.0.0.0 - 4.7.145.0  ->  4.8.0.0

Moq 5 will be able to safely make the switch to 'major.0.0.0'.

This closes #424.