### PR TITLE
Fix `CallBase` regression with explicitly implemented interface methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
+## Unreleased
+
+#### Fixed
+
+* `CallBase` regression with explicitly implemented interface methods (@stakx, #558)
+
+
 ## 4.8.0 (2017-12-24)
 
 Same as 4.8.0-rc1 (see below), plus some significant speed improvements.

--- a/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -1748,6 +1748,34 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 557
+
+		public sealed class Issue557
+		{
+			[Fact]
+			public void CallBase_works_when_called_on_AsInterface_mock()
+			{
+				var mock = new Mock<MyClass>().As<IMyClass>();
+				mock.CallBase = true;
+				Assert.NotNull(mock.Object.DoSomething());
+			}
+
+			public interface IMyClass
+			{
+				object DoSomething();
+			}
+
+			public class MyClass : IMyClass
+			{
+				public object DoSomething()
+				{
+					return new object();
+				}
+			}
+		}
+
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47


### PR DESCRIPTION
This fixes #557.