### PR TITLE
Expose invocations on mock object

### DIFF
--- a/Moq.Tests/VerifyFixture.cs
+++ b/Moq.Tests/VerifyFixture.cs
@@ -1097,7 +1097,7 @@ namespace Moq.Tests
 			var mock = new Mock<IFoo>();
 			mock.Object.Submit();
 
-			var invocation = mock.Invocations.ToArray()[0];
+			var invocation = mock.InvocationCollection.GetSnapshot()[0];
 			Assert.False(invocation.Verified);
 
 			mock.Verify(m => m.Submit());
@@ -1112,7 +1112,7 @@ namespace Moq.Tests
 			mock.Object.Echo(2);
 			mock.Object.Echo(3);
 
-			var invocations = mock.Invocations.ToArray();
+			var invocations = mock.InvocationCollection.GetSnapshot();
 			Assert.False(invocations[0].Verified);
 			Assert.False(invocations[1].Verified);
 			Assert.False(invocations[2].Verified);
@@ -1131,7 +1131,7 @@ namespace Moq.Tests
 			mock.Object.Echo(2);
 			mock.Object.Echo(3);
 
-			var invocations = mock.Invocations.ToArray();
+			var invocations = mock.InvocationCollection.GetSnapshot();
 			Assert.False(invocations[0].Verified);
 			Assert.False(invocations[1].Verified);
 			Assert.False(invocations[2].Verified);

--- a/Source/AsInterface.cs
+++ b/Source/AsInterface.cs
@@ -65,7 +65,7 @@ namespace Moq
 			get { return this.owner.InnerMocks; }
 		}
 
-		internal override InvocationCollection Invocations => this.owner.Invocations;
+		internal override InvocationCollection InvocationCollection => this.owner.InvocationCollection;
 
 		internal override bool IsObjectInitialized => this.owner.IsObjectInitialized;
 

--- a/Source/Interception/InterceptionAspects.cs
+++ b/Source/Interception/InterceptionAspects.cs
@@ -75,7 +75,7 @@ namespace Moq
 		{
 			if (IsObjectMethod(invocation.Method) && !mock.Setups.Any(c => IsObjectMethod(c.Method, "Equals")))
 			{
-				invocation.Return(ReferenceEquals(invocation.Arguments.First(), mock.Object));
+				invocation.Return(ReferenceEquals(invocation.ArgumentsArray.First(), mock.Object));
 				return InterceptionAction.Stop;
 			}
 			else
@@ -224,7 +224,7 @@ namespace Moq
 							invocation.ReturnBase();
 							return InterceptionAction.Stop;
 						}
-						else if (invocation.Arguments.Length > 0 && invocation.Arguments[0] is Delegate delegateInstance)
+						else if (invocation.ArgumentsArray.Length > 0 && invocation.ArgumentsArray[0] is Delegate delegateInstance)
 						{
 							mock.EventHandlers.Add(eventInfo.Name, delegateInstance);
 							invocation.Return();
@@ -246,7 +246,7 @@ namespace Moq
 							invocation.ReturnBase();
 							return InterceptionAction.Stop;
 						}
-						else if (invocation.Arguments.Length > 0 && invocation.Arguments[0] is Delegate delegateInstance)
+						else if (invocation.ArgumentsArray.Length > 0 && invocation.ArgumentsArray[0] is Delegate delegateInstance)
 						{
 							mock.EventHandlers.Remove(eventInfo.Name, delegateInstance);
 							invocation.Return();
@@ -257,7 +257,7 @@ namespace Moq
 			}
 
 			// Save to support Verify[expression] pattern.
-			mock.Invocations.Add(invocation);
+			mock.InvocationCollection.Add(invocation);
 			return InterceptionAction.Continue;
 		}
 

--- a/Source/Invocation.cs
+++ b/Source/Invocation.cs
@@ -39,13 +39,17 @@
 // http://www.opensource.org/licenses/bsd-license.php]
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text;
 
 namespace Moq
 {
-	internal abstract class Invocation
+	/// <summary>
+	/// Represents the invocation of a method.
+	/// </summary>
+	public abstract class Invocation
 	{
 		private object[] arguments;
 		private MethodInfo method;
@@ -73,11 +77,16 @@ namespace Moq
 		/// <summary>
 		/// Gets the arguments of the invocation.
 		/// </summary>
+		public IReadOnlyList<object> Arguments => this.ArgumentsArray;
+
+		/// <summary>
+		/// Gets the arguments of the invocation.
+		/// </summary>
 		/// <remarks>
 		/// Arguments may be modified. Derived classes must ensure that by-reference parameters are written back
 		/// when the invocation is ended by a call to any of the three <c>Returns</c> methods.
 		/// </remarks>
-		public object[] Arguments => this.arguments;
+		internal object[] ArgumentsArray => this.arguments;
 
 		internal bool Verified => this.verified;
 
@@ -88,10 +97,10 @@ namespace Moq
 		/// Implementations may assume that this method is only called for a <see langword="void"/> method,
 		/// and that no more calls to any of the three <c>Return</c> methods will be made.
 		/// <para>
-		/// Implementations must ensure that any by-reference parameters are written back from <see cref="Arguments"/>.
+		/// Implementations must ensure that any by-reference parameters are written back from <see cref="ArgumentsArray"/>.
 		/// </para>
 		/// </remarks>
-		public abstract void Return();
+		internal abstract void Return();
 
 		/// <summary>
 		/// Ends the invocation as if a tail call to the base method were made.
@@ -100,10 +109,10 @@ namespace Moq
 		/// Implementations may assume that this method is only called for a method having a callable (non-<see langword="abstract"/>) base method,
 		/// and that no more calls to any of the three <c>Return</c> methods will be made.
 		/// <para>
-		/// Implementations must ensure that any by-reference parameters are written back from <see cref="Arguments"/>.
+		/// Implementations must ensure that any by-reference parameters are written back from <see cref="ArgumentsArray"/>.
 		/// </para>
 		/// </remarks>
-		public abstract void ReturnBase();
+		internal abstract void ReturnBase();
 
 		/// <summary>
 		/// Ends the invocation as if a <see langword="return"/> statement with the specified return value occurred.
@@ -112,7 +121,7 @@ namespace Moq
 		/// Implementations may assume that this method is only called for a non-<see langword="void"/> method,
 		/// and that no more calls to any of the three <c>Return</c> methods will be made.
 		/// <para>
-		/// Implementations must ensure that any by-reference parameters are written back from <see cref="Arguments"/>.
+		/// Implementations must ensure that any by-reference parameters are written back from <see cref="ArgumentsArray"/>.
 		/// </para>
 		/// </remarks>
 		public abstract void Return(object value);
@@ -136,7 +145,7 @@ namespace Moq
 			{
 				builder.Append(method.Name, 4, method.Name.Length - 4);
 				builder.Append(" = ");
-				builder.AppendValueOf(this.Arguments[0]);
+				builder.AppendValueOf(this.ArgumentsArray[0]);
 			}
 			else
 			{
@@ -144,13 +153,13 @@ namespace Moq
 
 				// append argument list:
 				builder.Append('(');
-				for (int i = 0, n = this.Arguments.Length; i < n; ++i)
+				for (int i = 0, n = this.ArgumentsArray.Length; i < n; ++i)
 				{
 					if (i > 0)
 					{
 						builder.Append(", ");
 					}
-					builder.AppendValueOf(this.Arguments[i]);
+					builder.AppendValueOf(this.ArgumentsArray[i]);
 				}
 
 				builder.Append(')');

--- a/Source/InvocationCollection.cs
+++ b/Source/InvocationCollection.cs
@@ -74,7 +74,7 @@ namespace Moq
 			}
 		}
 
-		public Invocation[] ToArray()
+		public IReadOnlyList<Invocation> GetSnapshot()
 		{
 			lock (this.invocations)
 			{
@@ -82,7 +82,7 @@ namespace Moq
 			}
 		}
 
-		public Invocation[] ToArray(Func<Invocation, bool> predicate)
+		public IReadOnlyList<Invocation> GetSnapshot(Func<Invocation, bool> predicate)
 		{
 			lock (this.invocations)
 			{

--- a/Source/MethodCall.cs
+++ b/Source/MethodCall.cs
@@ -252,13 +252,13 @@ namespace Moq
 
 			foreach (var item in this.outValues)
 			{
-				invocation.Arguments[item.Key] = item.Value;
+				invocation.ArgumentsArray[item.Key] = item.Value;
 			}
 		}
 
 		public bool Matches(Invocation invocation)
 		{
-			var arguments = invocation.Arguments;
+			var arguments = invocation.ArgumentsArray;
 			if  (this.argumentMatchers.Length != arguments.Length)
 			{
 				return false;
@@ -306,7 +306,7 @@ namespace Moq
 				}
 			}
 
-			this.callbackResponse?.Invoke(invocation.Arguments);
+			this.callbackResponse?.Invoke(invocation.ArgumentsArray);
 
 			this.raiseEventResponse?.RespondTo(invocation);
 
@@ -555,7 +555,7 @@ namespace Moq
 					}
 					else
 					{
-						this.mock.DoRaise(this.@event, (EventArgs)this.eventArgsFunc.InvokePreserveStack(invocation.Arguments));
+						this.mock.DoRaise(this.@event, (EventArgs)this.eventArgsFunc.InvokePreserveStack(invocation.ArgumentsArray));
 					}
 				}
 			}

--- a/Source/MethodCallReturn.cs
+++ b/Source/MethodCallReturn.cs
@@ -231,7 +231,7 @@ namespace Moq
 			{
 				invocation.Return(this.valueDel.HasCompatibleParameterList(new ParameterInfo[0])
 					? valueDel.InvokePreserveStack()                //we need this, for the user to be able to use parameterless methods
-					: valueDel.InvokePreserveStack(invocation.Arguments)); //will throw if parameters mismatch
+					: valueDel.InvokePreserveStack(invocation.ArgumentsArray)); //will throw if parameters mismatch
 			}
 			else if (this.Mock.Behavior == MockBehavior.Strict)
 			{
@@ -242,7 +242,7 @@ namespace Moq
 				invocation.Return(default(TResult));
 			}
 
-			this.afterReturnCallback?.Invoke(invocation.Arguments);
+			this.afterReturnCallback?.Invoke(invocation.ArgumentsArray);
 		}
 	}
 }

--- a/Source/Mock.Generic.cs
+++ b/Source/Mock.Generic.cs
@@ -222,7 +222,7 @@ namespace Moq
 
 		internal override List<Type> AdditionalInterfaces => this.additionalInterfaces;
 
-		internal override InvocationCollection Invocations => this.invocations;
+		internal override InvocationCollection InvocationCollection => this.invocations;
 
 		internal override bool IsObjectInitialized => this.instance != null;
 

--- a/Source/MockExtensions.cs
+++ b/Source/MockExtensions.cs
@@ -15,7 +15,7 @@ namespace Moq
 		/// <param name="mock">The mock whose recorded invocations should be reset.</param>
 		public static void ResetCalls(this Mock mock)
 		{
-			mock.Invocations.Clear();
+			mock.InvocationCollection.Clear();
 		}
 
 		/// <summary>

--- a/Source/PropertySetterMethodCall.cs
+++ b/Source/PropertySetterMethodCall.cs
@@ -63,7 +63,7 @@ namespace Moq
 		{
 			base.Execute(invocation);
 
-			this.setter.Invoke(invocation.Arguments[0]);
+			this.setter.Invoke(invocation.ArgumentsArray[0]);
 			invocation.Return();
 		}
 	}

--- a/Source/ProxyFactories/CastleProxyFactory.cs
+++ b/Source/ProxyFactories/CastleProxyFactory.cs
@@ -186,7 +186,7 @@ namespace Moq
 				this.underlying = underlying;
 			}
 
-			public override void Return()
+			internal override void Return()
 			{
 				Debug.Assert(this.underlying != null);
 				Debug.Assert(this.underlying.Method.ReturnType == typeof(void));
@@ -194,7 +194,7 @@ namespace Moq
 				this.underlying = null;
 			}
 
-			public override void ReturnBase()
+			internal override void ReturnBase()
 			{
 				Debug.Assert(this.underlying != null);
 

--- a/Source/ProxyFactories/InterfaceProxy.cs
+++ b/Source/ProxyFactories/InterfaceProxy.cs
@@ -105,14 +105,14 @@ namespace Moq.Internals
 
 			public object ReturnValue => this.returnValue;
 
-			public override void Return() { }
+			internal override void Return() { }
 
 			public override void Return(object value)
 			{
 				this.returnValue = value;
 			}
 
-			public override void ReturnBase() { }
+			internal override void ReturnBase() { }
 		}
 	}
 }


### PR DESCRIPTION
First take at exposing invocation information.
Mock invocations exposed as `IReadOnlyList<Invocation>` property.
Internal abstract `Invocation` type exposed.