### PR TITLE
Downgrade System.ValueTuple & System.Threading.Tasks.Extensions

### DIFF
--- a/Moq.nuspec
+++ b/Moq.nuspec
@@ -15,7 +15,7 @@
 		<dependencies>
 			<group targetFramework=".NETFramework4.5">
 				<dependency id="Castle.Core" version="4.2.1" />
-				<dependency id="System.Threading.Tasks.Extensions" version="4.4.0" />
+				<dependency id="System.Threading.Tasks.Extensions" version="4.3.0" />
 				<dependency id="System.ValueTuple" version="4.4.0" />
 			</group>
 			<group targetFramework=".NETStandard1.3">
@@ -23,7 +23,7 @@
 				<dependency id="System.Linq.Queryable" version="4.3.0" />
 				<dependency id="System.Reflection.TypeExtensions" version="4.3.0" />
 				<dependency id="Castle.Core" version="4.2.1" />
-				<dependency id="System.Threading.Tasks.Extensions" version="4.4.0" />
+				<dependency id="System.Threading.Tasks.Extensions" version="4.3.0" />
 				<dependency id="System.ValueTuple" version="4.4.0" />
 			</group>
 		</dependencies>

--- a/Moq.nuspec
+++ b/Moq.nuspec
@@ -16,6 +16,7 @@
 			<group targetFramework=".NETFramework4.5">
 				<dependency id="Castle.Core" version="4.2.1" />
 				<dependency id="System.Threading.Tasks.Extensions" version="4.4.0" />
+				<dependency id="System.ValueTuple" version="4.4.0" />
 			</group>
 			<group targetFramework=".NETStandard1.3">
 				<dependency id="NETStandard.Library" version="1.6.1" />
@@ -23,6 +24,7 @@
 				<dependency id="System.Reflection.TypeExtensions" version="4.3.0" />
 				<dependency id="Castle.Core" version="4.2.1" />
 				<dependency id="System.Threading.Tasks.Extensions" version="4.4.0" />
+				<dependency id="System.ValueTuple" version="4.4.0" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/Moq.nuspec
+++ b/Moq.nuspec
@@ -16,7 +16,7 @@
 			<group targetFramework=".NETFramework4.5">
 				<dependency id="Castle.Core" version="4.2.1" />
 				<dependency id="System.Threading.Tasks.Extensions" version="4.3.0" />
-				<dependency id="System.ValueTuple" version="4.4.0" />
+				<dependency id="System.ValueTuple" version="4.3.0" />
 			</group>
 			<group targetFramework=".NETStandard1.3">
 				<dependency id="NETStandard.Library" version="1.6.1" />
@@ -24,7 +24,7 @@
 				<dependency id="System.Reflection.TypeExtensions" version="4.3.0" />
 				<dependency id="Castle.Core" version="4.2.1" />
 				<dependency id="System.Threading.Tasks.Extensions" version="4.3.0" />
-				<dependency id="System.ValueTuple" version="4.4.0" />
+				<dependency id="System.ValueTuple" version="4.3.0" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/Source/Moq.csproj
+++ b/Source/Moq.csproj
@@ -31,7 +31,7 @@
 		<PackageReference Include="GitInfo" Version="2.0.8" />
 		<PackageReference Include="IFluentInterface" Version="2.0.4" />
 		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.7.3" PrivateAssets="All" />
-		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.4.0" />
+		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
 		<PackageReference Include="System.ValueTuple" Version="4.4.0" />
 		<DotNetCliToolReference Include="dotnet-sourcelink" Version="2.2.1" />
 	</ItemGroup>

--- a/Source/Moq.csproj
+++ b/Source/Moq.csproj
@@ -32,7 +32,7 @@
 		<PackageReference Include="IFluentInterface" Version="2.0.4" />
 		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.7.3" PrivateAssets="All" />
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
-		<PackageReference Include="System.ValueTuple" Version="4.4.0" />
+		<PackageReference Include="System.ValueTuple" Version="4.3.0" />
 		<DotNetCliToolReference Include="dotnet-sourcelink" Version="2.2.1" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
Hopefully, this will take care of the better part of #566 and #567 and restore better compatibility of Moq with the full .NET Framework <4.7.1.