### PR TITLE
Ignore CallBase for members of additional interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 #### Fixed
 
 * Wrong parameters count for extension methods in `Callback` and `Returns` (@Caraul, #575)
+* `CallBase` regression with members of additional interfaces (@stakx, #583)
 
 
 ## 4.8.1 (2018-01-08)

--- a/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -1810,6 +1810,31 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 582
+
+		public sealed class Issue582
+		{
+			public interface IFoo
+			{
+				void Method();
+			}
+
+			public class Bar
+			{
+			}
+
+			[Fact]
+			public void CallBase_has_no_effect_for_methods_of_additional_interfaces()
+			{
+				var bar = new Mock<Bar>() { CallBase = true };
+				var foo = bar.As<IFoo>().Object;
+
+				foo.Method();
+			}
+		}
+
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47

--- a/Source/Interception/InterceptionAspects.cs
+++ b/Source/Interception/InterceptionAspects.cs
@@ -345,11 +345,23 @@ namespace Moq
 						Debug.Assert(mock.ImplementsInterface(declaringType));
 
 						// Case 2: Explicitly implemented interface method of a class proxy.
-						// Only call base method if it isn't an event accessor.
-						if (!method.LooksLikeEventAttach() && !method.LooksLikeEventDetach())
+
+						if (mock.InheritedInterfaces.Contains(declaringType))
 						{
-							invocation.ReturnBase();
-							return InterceptionAction.Stop;
+							// Case 2a: Re-implemented interface.
+							// The base class has its own implementation. Only call base method if it isn't an event accessor.
+							if (!method.LooksLikeEventAttach() && !method.LooksLikeEventDetach())
+							{
+								invocation.ReturnBase();
+								return InterceptionAction.Stop;
+							}
+						}
+						else
+						{
+							Debug.Assert(mock.AdditionalInterfaces.Contains(declaringType));
+
+							// Case 2b: Additional interface.
+							// There is no base method to call, so fall through.
 						}
 					}
 				}


### PR DESCRIPTION
This fixes #582. (See commit messages for details.)