### PR TITLE
Upgrade dependency on System.ValueTuple to version 4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 ## Unreleased
 
+#### Changed
+
+* Upgraded `System.ValueTuple` dependency to version 4.4.0 in order to reestablish Moq compatibility with .NET 4.7 (and later), which already include the `ValueTuple` types (@stakx, #591)
+
 #### Fixed
 
 * Wrong parameters count for extension methods in `Callback` and `Returns` (@Caraul, #575)

--- a/Moq.nuspec
+++ b/Moq.nuspec
@@ -16,7 +16,7 @@
 			<group targetFramework=".NETFramework4.5">
 				<dependency id="Castle.Core" version="4.2.1" />
 				<dependency id="System.Threading.Tasks.Extensions" version="4.3.0" />
-				<dependency id="System.ValueTuple" version="4.3.0" />
+				<dependency id="System.ValueTuple" version="4.4.0" />
 			</group>
 			<group targetFramework=".NETStandard1.3">
 				<dependency id="NETStandard.Library" version="1.6.1" />
@@ -24,7 +24,7 @@
 				<dependency id="System.Reflection.TypeExtensions" version="4.3.0" />
 				<dependency id="Castle.Core" version="4.2.1" />
 				<dependency id="System.Threading.Tasks.Extensions" version="4.3.0" />
-				<dependency id="System.ValueTuple" version="4.3.0" />
+				<dependency id="System.ValueTuple" version="4.4.0" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/Source/Moq.csproj
+++ b/Source/Moq.csproj
@@ -32,7 +32,7 @@
 		<PackageReference Include="IFluentInterface" Version="2.0.4" />
 		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.7.3" PrivateAssets="All" />
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
-		<PackageReference Include="System.ValueTuple" Version="4.3.0" />
+		<PackageReference Include="System.ValueTuple" Version="4.4.0" />
 		<DotNetCliToolReference Include="dotnet-sourcelink" Version="2.2.1" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
This resolves #578.

(This change also bears the potential to retrigger problems similar to #566, which is why I tested this against different target frameworks&mdash;from `net45` up to `net471` and both `netcoreapp1.0` and `netcoreapp2.0`. Visual Studio didn't report any assembly versioning conflicts, so I am reasonably confident that this is good to go.)