### PR TITLE
Added `ISetupSequentialResult<TResult>.Returns` method overload that support delegate for deferred results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
+## Unreleased
+
+#### Added
+
+* Add `ISetupSequentialResult<TResult>.Returns` method overload that support delegate for deferred results (@snrnats, #594)
+
 ## 4.8.2 (2018-02-23)
 
 #### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 * Add `ISetupSequentialResult<TResult>.Returns` method overload that support delegate for deferred results (@snrnats, #594)
 
+
 ## 4.8.2 (2018-02-23)
 
 #### Changed

--- a/Moq.Tests/SequenceExtensionsFixture.cs
+++ b/Moq.Tests/SequenceExtensionsFixture.cs
@@ -14,10 +14,12 @@ namespace Moq.Tests
 			mock.SetupSequence(x => x.Do())
 				.Returns(2)
 				.Returns(3)
+				.Returns(() => 4)
 				.Throws<InvalidOperationException>();
 
 			Assert.Equal(2, mock.Object.Do());
 			Assert.Equal(3, mock.Object.Do());
+			Assert.Equal(4, mock.Object.Do());
 			Assert.Throws<InvalidOperationException>(() => mock.Object.Do());
 		}
 

--- a/Moq.Tests/SequenceExtensionsFixture.cs
+++ b/Moq.Tests/SequenceExtensionsFixture.cs
@@ -155,6 +155,30 @@ namespace Moq.Tests
 			mock.Verify(m => m.Do(), Times.Exactly(2));
 		}
 
+		[Fact]
+		public void Func_are_invoked_deferred()
+		{
+			var mock = new Mock<IFoo>();
+			var i = 0;
+			mock.SetupSequence(m => m.Do())
+				.Returns(() => i);
+
+			i++;
+
+			Assert.Equal(i, mock.Object.Do());
+		}
+
+		[Fact]
+		public void Func_can_be_treated_as_return_value()
+		{
+			var mock = new Mock<IFoo>();
+			Func<int> func = () => 1;
+			mock.SetupSequence(m => m.GetFunc())
+				.Returns(func);
+
+			Assert.Equal(func, mock.Object.GetFunc());
+		}
+
 		public interface IFoo
 		{
 			string Value { get; set; }
@@ -162,6 +186,8 @@ namespace Moq.Tests
 			int Do();
 
 			Task<int> DoAsync();
+
+			Func<int> GetFunc();
 		}
 
 		public class Foo

--- a/Moq.Tests/SequenceExtensionsFixture.cs
+++ b/Moq.Tests/SequenceExtensionsFixture.cs
@@ -179,6 +179,22 @@ namespace Moq.Tests
 			Assert.Equal(func, mock.Object.GetFunc());
 		}
 
+		[Fact]
+		public void Keep_Func_as_return_value_when_setup_method_returns_implicitly_casted_type()
+		{
+			var mock = new Mock<IFoo>();
+			Func<object> funcObj = () => 1;
+			Func<Delegate> funcDel = () => new Action(() => { });
+			Func<MulticastDelegate> funcMulticastDel = () => new Action(() => { });
+			mock.SetupSequence(m => m.GetObj()).Returns(funcObj);
+			mock.SetupSequence(m => m.GetDel()).Returns(funcDel);
+			mock.SetupSequence(m => m.GetMulticastDel()).Returns(funcMulticastDel);
+
+			Assert.Equal(funcObj, mock.Object.GetObj());
+			Assert.Equal(funcDel, mock.Object.GetDel());
+			Assert.Equal(funcMulticastDel, mock.Object.GetMulticastDel());
+		}
+
 		public interface IFoo
 		{
 			string Value { get; set; }
@@ -188,6 +204,12 @@ namespace Moq.Tests
 			Task<int> DoAsync();
 
 			Func<int> GetFunc();
+
+			object GetObj();
+
+			Delegate GetDel();
+
+			MulticastDelegate GetMulticastDel();
 		}
 
 		public class Foo

--- a/Source/Language/Flow/SetupSequencePhrase.cs
+++ b/Source/Language/Flow/SetupSequencePhrase.cs
@@ -96,8 +96,8 @@ namespace Moq.Language.Flow
 			// If `TResult` is `Func<>`, that is someone is setting up the return value of a method
 			// that returns a `Func<>`, then we need to make sure that the passed Func will be treated 
 			// as a return value. We don't want to invoke the passed Func to get a return value; the 
-			// passed func already is the return value. To do so we need to wrap up this func because 
-			// `SequenceMethodCall.Execute` will invoke every func it encounters
+			// passed func already is the return value. To prevent it we need to wrap up this func because 
+			// `SequenceMethodCall.Execute` invokes every func it encounters
 			if (typeof(TResult).IsConstructedGenericType && typeof(TResult).GetGenericTypeDefinition() == typeof(Func<>))
 			{
 				return this.Returns(() => value);

--- a/Source/Language/Flow/SetupSequencePhrase.cs
+++ b/Source/Language/Flow/SetupSequencePhrase.cs
@@ -40,6 +40,8 @@
 
 using System;
 using System.ComponentModel;
+using System.Reflection;
+using Moq.Properties;
 
 namespace Moq.Language.Flow
 {
@@ -91,6 +93,38 @@ namespace Moq.Language.Flow
 		public ISetupSequentialResult<TResult> Returns(TResult value)
 		{
 			this.setup.AddReturns(value);
+			return this;
+		}
+		public ISetupSequentialResult<TResult> Returns(Delegate valueFunction)
+		{
+			// If `TResult` is `Delegate`, that is someone is setting up the return value of a method
+			// that returns a `Delegate`, then we have arrived here because C# picked the wrong overload:
+			// We don't want to invoke the passed delegate to get a return value; the passed delegate
+			// already is the return value.
+			if (typeof(TResult) == typeof(Delegate))
+			{
+				return this.Returns(() => (TResult)(object)valueFunction);
+			}
+
+			// The following may seem overly cautious, but we don't throw an `ArgumentNullException`
+			// here because Moq has been very forgiving with incorrect `Returns` in the past.
+			if (valueFunction == null)
+			{
+				return this.Returns(() => default(TResult));
+			}
+
+			if (valueFunction.GetMethodInfo().ReturnType == typeof(void))
+			{
+				throw new ArgumentException(Resources.InvalidReturnsCallbackNotADelegateWithReturnType, nameof(valueFunction));
+			}
+
+			this.setup.AddReturns(valueFunction);
+			return this;
+		}
+
+		public ISetupSequentialResult<TResult> Returns(Func<TResult> valueExpression)
+		{
+			this.setup.AddReturns(valueExpression);
 			return this;
 		}
 

--- a/Source/Language/ISetupSequentialResult.cs
+++ b/Source/Language/ISetupSequentialResult.cs
@@ -22,12 +22,6 @@ namespace Moq.Language
 		/// Uses delegate to get return value
 		/// </summary>
 		/// <returns></returns>
-		ISetupSequentialResult<TResult> Returns(Delegate valueFunction);
-
-		/// <summary>
-		/// Uses delegate to get return value
-		/// </summary>
-		/// <returns></returns>
 		ISetupSequentialResult<TResult> Returns(Func<TResult> valueExpression);
 
 		/// <summary>

--- a/Source/Language/ISetupSequentialResult.cs
+++ b/Source/Language/ISetupSequentialResult.cs
@@ -21,8 +21,8 @@ namespace Moq.Language
 		/// <summary>
 		/// Uses delegate to get return value
 		/// </summary>
-		/// <returns></returns>
-		ISetupSequentialResult<TResult> Returns(Func<TResult> valueExpression);
+		/// <param name="valueFunction">The function that will calculate the return value.</param> 
+		ISetupSequentialResult<TResult> Returns(Func<TResult> valueFunction);
 
 		/// <summary>
 		/// Throws an exception

--- a/Source/Language/ISetupSequentialResult.cs
+++ b/Source/Language/ISetupSequentialResult.cs
@@ -19,6 +19,18 @@ namespace Moq.Language
 		ISetupSequentialResult<TResult> Returns(TResult value);
 
 		/// <summary>
+		/// Uses delegate to get return value
+		/// </summary>
+		/// <returns></returns>
+		ISetupSequentialResult<TResult> Returns(Delegate valueFunction);
+
+		/// <summary>
+		/// Uses delegate to get return value
+		/// </summary>
+		/// <returns></returns>
+		ISetupSequentialResult<TResult> Returns(Func<TResult> valueExpression);
+
+		/// <summary>
 		/// Throws an exception
 		/// </summary>
 		ISetupSequentialResult<TResult> Throws(Exception exception);

--- a/Source/SequenceMethodCall.cs
+++ b/Source/SequenceMethodCall.cs
@@ -72,6 +72,11 @@ namespace Moq
 			this.responses.Enqueue((ResponseKind.Returns, value));
 		}
 
+		public void AddReturns(Func<object> valueFunction)
+		{
+			this.responses.Enqueue((ResponseKind.InvokeFunc, valueFunction));
+		}
+
 		public void AddThrows(Exception exception)
 		{
 			this.responses.Enqueue((ResponseKind.Throws, (object)exception));
@@ -95,18 +100,15 @@ namespace Moq
 						break;
 
 					case ResponseKind.Returns:
-						if (arg is Delegate func)
-						{
-							invocation.Return(func.DynamicInvoke());
-						}
-						else
-						{
-							invocation.Return(arg);
-						}
+						invocation.Return(arg);
 						break;
 
 					case ResponseKind.Throws:
 						throw (Exception)arg;
+
+					case ResponseKind.InvokeFunc:
+						invocation.Return(((Func<object>)arg)());
+						break;
 				}
 			}
 			else
@@ -133,6 +135,7 @@ namespace Moq
 			CallBase,
 			Returns,
 			Throws,
+			InvokeFunc
 		}
 	}
 }

--- a/Source/SequenceMethodCall.cs
+++ b/Source/SequenceMethodCall.cs
@@ -95,7 +95,14 @@ namespace Moq
 						break;
 
 					case ResponseKind.Returns:
-						invocation.Return(arg);
+						if (arg is Delegate func)
+						{
+							invocation.Return(func.DynamicInvoke());
+						}
+						else
+						{
+							invocation.Return(arg);
+						}
 						break;
 
 					case ResponseKind.Throws:


### PR DESCRIPTION
Added new method overloads:
```
public interface ISetupSequentialResult<TResult>
{
    ...
    ISetupSequentialResult<TResult> Returns(Delegate valueFunction);

    ISetupSequentialResult<TResult> Returns(Func<TResult> valueExpression);
    ...
}
```
 They are needed to resolve #592