### PR TITLE
Add convenience method ReturnsSequence

### DIFF
--- a/Source/SequenceExtensions.cs
+++ b/Source/SequenceExtensions.cs
@@ -73,5 +73,18 @@ namespace Moq
 
 			return setup.Returns(tcs.Task);
 		}
+		
+		/// <summary>
+		/// Returns a sequence of items, once per call.
+		/// </summary>
+		public static ISetupSequentialResult<T> ReturnsSequence<T>(this ISetupSequentialResult<T> setup, IEnumerable<T> results)
+        {
+            foreach (var item in results)
+            {
+                setup.Returns(item);
+            }
+
+            return setup;
+        }
 	}
 }

--- a/Source/SequenceExtensions.cs
+++ b/Source/SequenceExtensions.cs
@@ -39,6 +39,7 @@
 // http://www.opensource.org/licenses/bsd-license.php]
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading.Tasks;
 


### PR DESCRIPTION
A simple convenience method to simply setup so that a sequence of items is returned, once per call.