### PR TITLE
Verify that `in` parameter modifier is supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 #### Added
 
 * Add `ISetupSequentialResult<TResult>.Returns` method overload that support delegate for deferred results (@snrnats, #594)
+* Support for C# 7.2's `in` parameter modifier (@stakx, #624, #625)
 
 #### Changed
 

--- a/Moq.Tests/Moq.Tests.csproj
+++ b/Moq.Tests/Moq.Tests.csproj
@@ -9,6 +9,7 @@
 		<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
 		<PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
 		<SignAssembly>true</SignAssembly>
+		<LangVersion>7.2</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">

--- a/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -1906,6 +1906,71 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 605
+
+		public class Issue605
+		{
+			// Taken from https://github.com/castleproject/Core/issues/339.
+
+			public readonly struct Struct
+			{
+			}
+
+			public interface IStructByRefConsumer
+			{
+				void Consume(in Struct message);
+			}
+
+			public interface IGenericStructByRefConsumer<T>
+			{
+				T Consume(in Struct message);
+			}
+
+			public interface IStructByValueConsumer
+			{
+				void Consume(Struct message);
+			}
+
+			[Fact]
+			public void Struct_ByRef_Moq_Test()
+			{
+				_ = Mock.Of<IStructByRefConsumer>();
+			}
+
+			[Fact(Skip = "Currently not supported due to a bug in the runtime, see https://github.com/dotnet/corefx/issues/29254.")]
+			public void Struct_ByRef_Generic_Moq_Test()
+			{
+				_ = Mock.Of<IGenericStructByRefConsumer<int>>();
+			}
+
+			[Fact]
+			public void Struct_ByValue_Moq_Test()
+			{
+				_ = Mock.Of<IStructByValueConsumer>();
+			}
+
+			// Moq performs its own System.Reflection.Emit-ting for mocking delegate types,
+			// so add some tests that target that:
+
+			public delegate void StructByValueDelegate(Struct message);
+
+			public delegate void StructByRefDelegate(in Struct message);
+
+			[Fact]
+			public void Struct_ByValue_Delegate()
+			{
+				_ = Mock.Of<StructByValueDelegate>();
+			}
+
+			[Fact]
+			public void Struct_ByRef_Delegate()
+			{
+				_ = Mock.Of<StructByRefDelegate>();
+			}
+		}
+
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47


### PR DESCRIPTION
This adds a few tests, including those mentioned in https://github.com/castleproject/Core/issues/339#issue-304443306 and https://github.com/castleproject/Core/issues/339#issuecomment-372605885, to document the state of `in` parameter modifier support.

As it turns out, the previous update of Castle.Core to 4.3.0 makes `in` parameter modifiers work on .NET Core even though Moq doesn't specifically target .NET Standard 1.5 or above... it suffices that Castle.Core does that.

(.NET Standard 1.3 vs 1.5 is important because the latter includes the System.Reflection.Emit facilities required for mocking `in`; more specifically, the ability to emit custom modifiers.)

This closes #605.