### PR TITLE
Expose invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+#### Added
+
+* Add `Mock.Invocations` property to support inspection of invocations on a mock (@Tragedian, #560)
 
 ## 4.8.3 (2018-06-09)
 

--- a/Moq.Tests/VerifyFixture.cs
+++ b/Moq.Tests/VerifyFixture.cs
@@ -1097,7 +1097,7 @@ namespace Moq.Tests
 			var mock = new Mock<IFoo>();
 			mock.Object.Submit();
 
-			var invocation = mock.Invocations.ToArray()[0];
+			var invocation = mock.MutableInvocations.ToArray()[0];
 			Assert.False(invocation.Verified);
 
 			mock.Verify(m => m.Submit());
@@ -1112,7 +1112,7 @@ namespace Moq.Tests
 			mock.Object.Echo(2);
 			mock.Object.Echo(3);
 
-			var invocations = mock.Invocations.ToArray();
+			var invocations = mock.MutableInvocations.ToArray();
 			Assert.False(invocations[0].Verified);
 			Assert.False(invocations[1].Verified);
 			Assert.False(invocations[2].Verified);
@@ -1131,7 +1131,7 @@ namespace Moq.Tests
 			mock.Object.Echo(2);
 			mock.Object.Echo(3);
 
-			var invocations = mock.Invocations.ToArray();
+			var invocations = mock.MutableInvocations.ToArray();
 			Assert.False(invocations[0].Verified);
 			Assert.False(invocations[1].Verified);
 			Assert.False(invocations[2].Verified);

--- a/Source/AsInterface.cs
+++ b/Source/AsInterface.cs
@@ -65,7 +65,7 @@ namespace Moq
 			get { return this.owner.InnerMocks; }
 		}
 
-		internal override InvocationCollection Invocations => this.owner.Invocations;
+		internal override InvocationCollection MutableInvocations => this.owner.MutableInvocations;
 
 		internal override bool IsObjectInitialized => this.owner.IsObjectInitialized;
 

--- a/Source/IReadOnlyInvocation.cs
+++ b/Source/IReadOnlyInvocation.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+
+namespace Moq
+{
+	/// <summary>
+	/// Provides information about an invocation of a mock object.
+	/// </summary>
+	public interface IReadOnlyInvocation
+	{
+		/// <summary>
+		/// Gets the method of the invocation.
+		/// </summary>
+		MethodInfo Method { get; }
+
+		/// <summary>
+		/// Gets the arguments of the invocation.
+		/// </summary>
+		IReadOnlyList<object> Arguments { get; }
+	}
+}

--- a/Source/Interception/InterceptionAspects.cs
+++ b/Source/Interception/InterceptionAspects.cs
@@ -257,7 +257,7 @@ namespace Moq
 			}
 
 			// Save to support Verify[expression] pattern.
-			mock.Invocations.Add(invocation);
+			mock.MutableInvocations.Add(invocation);
 			return InterceptionAction.Continue;
 		}
 

--- a/Source/Invocation.cs
+++ b/Source/Invocation.cs
@@ -39,13 +39,14 @@
 // http://www.opensource.org/licenses/bsd-license.php]
 
 using System.Collections;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text;
 
 namespace Moq
 {
-	internal abstract class Invocation
+	internal abstract class Invocation : IReadOnlyInvocation
 	{
 		private object[] arguments;
 		private MethodInfo method;
@@ -78,6 +79,8 @@ namespace Moq
 		/// when the invocation is ended by a call to any of the three <c>Returns</c> methods.
 		/// </remarks>
 		public object[] Arguments => this.arguments;
+
+		IReadOnlyList<object> IReadOnlyInvocation.Arguments => this.arguments;
 
 		internal bool Verified => this.verified;
 

--- a/Source/InvocationCollection.cs
+++ b/Source/InvocationCollection.cs
@@ -39,18 +39,41 @@
 // http://www.opensource.org/licenses/bsd-license.php]
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Moq
 {
-	internal sealed class InvocationCollection
+	internal sealed class InvocationCollection : IReadOnlyList<IReadOnlyInvocation>
 	{
 		private List<Invocation> invocations;
 
 		public InvocationCollection()
 		{
 			this.invocations = new List<Invocation>();
+		}
+
+		public int Count
+		{
+			get
+			{
+				lock (this.invocations)
+				{
+					return this.invocations.Count;
+				}
+			}
+		}
+
+		public IReadOnlyInvocation this[int index]
+		{
+			get
+			{
+				lock (this.invocations)
+				{
+					return this.invocations[index];
+				}
+			}
 		}
 
 		public void Add(Invocation invocation)
@@ -89,5 +112,15 @@ namespace Moq
 				return this.invocations.Where(predicate).ToArray();
 			}
 		}
+
+		public IEnumerator<IReadOnlyInvocation> GetEnumerator()
+		{
+			lock (this.invocations)
+			{
+				return this.invocations.ToList().GetEnumerator();
+			}
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 	}
 }

--- a/Source/Mock.Generic.cs
+++ b/Source/Mock.Generic.cs
@@ -222,7 +222,7 @@ namespace Moq
 
 		internal override List<Type> AdditionalInterfaces => this.additionalInterfaces;
 
-		internal override InvocationCollection Invocations => this.invocations;
+		internal override InvocationCollection MutableInvocations => this.invocations;
 
 		internal override bool IsObjectInitialized => this.instance != null;
 

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -193,7 +193,12 @@ namespace Moq
 
 		internal abstract bool IsObjectInitialized { get; }
 
-		internal abstract InvocationCollection Invocations { get; }
+		/// <summary>
+		/// Gets list of invocations which have been performed on this mock.
+		/// </summary>
+		public IReadOnlyList<IReadOnlyInvocation> Invocations => MutableInvocations;
+
+		internal abstract InvocationCollection MutableInvocations { get; }
 
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.OnGetObject"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "This is actually the protected virtual implementation of the property Object.")]
@@ -390,7 +395,7 @@ namespace Moq
 
 		internal static void VerifyNoOtherCalls(Mock mock)
 		{
-			var unverifiedInvocations = mock.Invocations.ToArray(invocation => !invocation.Verified);
+			var unverifiedInvocations = mock.MutableInvocations.ToArray(invocation => !invocation.Verified);
 
 			if (unverifiedInvocations.Any())
 			{
@@ -407,7 +412,7 @@ namespace Moq
 						// sub-object (inner mock); and that sub-object has to have received at least
 						// one call:
 						var wasTransitiveInvocation = mock.InnerMocks.TryGetValue(unverifiedInvocations[i].Method, out MockWithWrappedMockObject inner)
-						                              && inner.Mock.Invocations.Any();
+						                              && inner.Mock.MutableInvocations.Any();
 						if (wasTransitiveInvocation)
 						{
 							unverifiedInvocations[i] = null;
@@ -442,7 +447,7 @@ namespace Moq
 			Expression expression,
 			Times times)
 		{
-			var allInvocations = targetMock.Invocations.ToArray();
+			var allInvocations = targetMock.MutableInvocations.ToArray();
 			var matchingInvocations = allInvocations.Where(expected.Matches).ToArray();
 			var matchingInvocationCount = matchingInvocations.Length;
 			if (!times.Verify(matchingInvocationCount))

--- a/Source/MockExtensions.cs
+++ b/Source/MockExtensions.cs
@@ -15,7 +15,7 @@ namespace Moq
 		/// <param name="mock">The mock whose recorded invocations should be reset.</param>
 		public static void ResetCalls(this Mock mock)
 		{
-			mock.Invocations.Clear();
+			mock.MutableInvocations.Clear();
 		}
 
 		/// <summary>


### PR DESCRIPTION
Second take at exposing invocation information.
Invocation information exposed via `IReadOnlyInvocation` interface.
Mock invocations exposed via property `IReadOnlyList<IReadOnlyInvocation> Invocations` on `Mock` class.