### PR TITLE
Invocations collection improvements

### DIFF
--- a/Moq.Tests/InvocationsFixture.cs
+++ b/Moq.Tests/InvocationsFixture.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Moq.Tests
@@ -58,9 +54,31 @@ namespace Moq.Tests
 		    mock.Object.CompareTo(0);
 		    mock.Object.CompareTo(1);
 
-		    var count = mock.Invocations.Count();
+		    var count = 0;
 
-			Assert.Equal(mock.Invocations.Count, count);
+		    using (var enumerator = mock.Invocations.GetEnumerator())
+		    {
+			    while (enumerator.MoveNext())
+			    {
+				    Assert.NotNull(enumerator.Current);
+
+				    count++;
+			    }
+		    }
+
+			Assert.Equal(3, count);
+	    }
+
+	    [Fact]
+	    public void MockInvocationsCanBeCleared()
+	    {
+		    var mock = new Mock<IComparable>();
+
+		    mock.Object.CompareTo(new object());
+
+			mock.ResetCalls();
+
+		    Assert.Equal(0, mock.Invocations.Count);
 	    }
 	}
 }

--- a/Moq.Tests/InvocationsFixture.cs
+++ b/Moq.Tests/InvocationsFixture.cs
@@ -80,5 +80,29 @@ namespace Moq.Tests
 
 		    Assert.Equal(0, mock.Invocations.Count);
 	    }
+
+		[Fact]
+	    public void MockInvocationsCanBeRetrievedByIndex()
+	    {
+			var mock = new Mock<IComparable>();
+
+		    mock.Object.CompareTo(-1);
+		    mock.Object.CompareTo(0);
+		    mock.Object.CompareTo(1);
+
+		    var invocation = mock.Invocations[1];
+
+		    var arg = invocation.Arguments[0];
+
+			Assert.Equal(0, arg);
+	    }
+
+		[Fact]
+	    public void MockInvocationsIndexerThrowsIndexOutOfRangeWhenCollectionIsEmpty()
+	    {
+			var mock = new Mock<IComparable>();
+
+			Assert.Throws<IndexOutOfRangeException>(() => mock.Invocations[0]);
+	    }
 	}
 }

--- a/Moq.Tests/InvocationsFixture.cs
+++ b/Moq.Tests/InvocationsFixture.cs
@@ -48,5 +48,19 @@ namespace Moq.Tests
 
 			Assert.Equal(expectedArguments, invocation.Arguments);
 	    }
+
+	    [Fact]
+	    public void MockInvocationsCanBeEnumerated()
+	    {
+			var mock = new Mock<IComparable>();
+
+		    mock.Object.CompareTo(-1);
+		    mock.Object.CompareTo(0);
+		    mock.Object.CompareTo(1);
+
+		    var count = mock.Invocations.Count();
+
+			Assert.Equal(mock.Invocations.Count, count);
+	    }
 	}
 }

--- a/Moq.Tests/InvocationsFixture.cs
+++ b/Moq.Tests/InvocationsFixture.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Moq.Tests
+{
+    public class InvocationsFixture
+    {
+	    [Fact]
+	    public void MockInvocationsAreRecorded()
+	    {
+		    var mock = new Mock<IComparable>();
+
+		    mock.Object.CompareTo(new object());
+
+		    Assert.Equal(1, mock.Invocations.Count);
+	    }
+
+		[Fact]
+	    public void MockInvocationsIncludeInvokedMethod()
+		{
+			var mock = new Mock<IComparable>();
+
+			mock.Object.CompareTo(new object());
+
+			var invocation = mock.Invocations[0];
+
+			var expectedMethod = typeof(IComparable).GetMethod(nameof(mock.Object.CompareTo));
+
+			Assert.Equal(expectedMethod, invocation.Method);
+		}
+
+	    [Fact]
+	    public void MockInvocationsIncludeArguments()
+	    {
+			var mock = new Mock<IComparable>();
+
+		    var obj = new object();
+
+			mock.Object.CompareTo(obj);
+
+		    var invocation = mock.Invocations[0];
+
+		    var expectedArguments = new[] {obj};
+
+			Assert.Equal(expectedArguments, invocation.Arguments);
+	    }
+	}
+}

--- a/Source/InvocationCollection.cs
+++ b/Source/InvocationCollection.cs
@@ -69,7 +69,6 @@ namespace Moq
 		{
 			get
 			{
-				// Test 
 				if (this.invocations == null)
 				{
 					throw new IndexOutOfRangeException();
@@ -95,14 +94,6 @@ namespace Moq
 
 				this.invocations[this.count] = invocation;
 				this.count++;
-			}
-		}
-
-		public bool Any()
-		{
-			lock (this.invocationsLock)
-			{
-				return this.count > 0;
 			}
 		}
 

--- a/Source/InvocationCollection.cs
+++ b/Source/InvocationCollection.cs
@@ -69,6 +69,12 @@ namespace Moq
 		{
 			get
 			{
+				// Test 
+				if (this.invocations == null)
+				{
+					throw new IndexOutOfRangeException();
+				}
+
 				lock (this.invocationsLock)
 				{
 					return this.invocations[index];

--- a/Source/InvocationCollection.cs
+++ b/Source/InvocationCollection.cs
@@ -133,25 +133,19 @@ namespace Moq
 				{
 					return new Invocation[0];
 				}
-
-				var result = new Invocation[this.count];
-				var resultIndex = 0;
-				var resultSize = 0;
+				
+				var result = new List<Invocation>(this.count);
 
 				for (var i = 0; i < this.count; i++)
 				{
 					var invocation = this.invocations[i];
 					if (predicate(invocation))
 					{
-						result[resultIndex] = invocation;
-						resultIndex++;
-						resultSize++;
+						result.Add(invocation);
 					}
 				}
 
-				Array.Resize(ref result, resultSize);
-
-				return result;
+				return result.ToArray();
 			}
 		}
 

--- a/Source/InvocationCollection.cs
+++ b/Source/InvocationCollection.cs
@@ -120,7 +120,11 @@ namespace Moq
 					return new Invocation[0];
 				}
 
-				return this.invocations.Take(this.count).ToArray();
+				var result = new Invocation[this.count];
+
+				Array.Copy(this.invocations, result, this.count);
+
+				return result;
 			}
 		}
 
@@ -133,7 +137,24 @@ namespace Moq
 					return new Invocation[0];
 				}
 
-				return this.invocations.Take(this.count).Where(predicate).ToArray();
+				var result = new Invocation[this.count];
+				var resultIndex = 0;
+				var resultSize = 0;
+
+				for (var i = 0; i < this.count; i++)
+				{
+					var invocation = this.invocations[i];
+					if (predicate(invocation))
+					{
+						result[resultIndex] = invocation;
+						resultIndex++;
+						resultSize++;
+					}
+				}
+
+				Array.Resize(ref result, resultSize);
+
+				return result;
 			}
 		}
 

--- a/Source/InvocationCollection.cs
+++ b/Source/InvocationCollection.cs
@@ -69,13 +69,13 @@ namespace Moq
 		{
 			get
 			{
-				if (this.invocations == null)
-				{
-					throw new IndexOutOfRangeException();
-				}
-
 				lock (this.invocationsLock)
 				{
+					if (this.count >= index || index < 0)
+					{
+						throw new IndexOutOfRangeException();
+					}
+
 					return this.invocations[index];
 				}
 			}

--- a/Source/InvocationCollection.cs
+++ b/Source/InvocationCollection.cs
@@ -71,7 +71,7 @@ namespace Moq
 			{
 				lock (this.invocationsLock)
 				{
-					if (this.count >= index || index < 0)
+					if (this.count <= index || index < 0)
 					{
 						throw new IndexOutOfRangeException();
 					}


### PR DESCRIPTION
Add tests for `Mock.Invocations` property.
Improved `InvocationCollection` to no longer allocate a copy of the collection on enumeration.