### PR TITLE
Replace `.ToLambda()` conversions with static typing

### DIFF
--- a/Moq.Tests/ExpressionExtensionsFixture.cs
+++ b/Moq.Tests/ExpressionExtensionsFixture.cs
@@ -49,7 +49,7 @@ namespace Moq.Tests
 		[Fact]
 		public void IsPropertyLambdaTrue()
 		{
-			var expr = ToExpression<IFoo, int>(f => f.Value).StripConversion();
+			var expr = ToExpression<IFoo, int>(f => f.Value);
 
 			Assert.True(expr.IsProperty());
 		}
@@ -57,7 +57,7 @@ namespace Moq.Tests
 		[Fact]
 		public void IsPropertyLambdaFalse()
 		{
-			var expr = ToExpression<IFoo>(f => f.Do()).StripConversion();
+			var expr = ToExpression<IFoo>(f => f.Do());
 
 			Assert.False(expr.IsProperty());
 		}
@@ -65,7 +65,7 @@ namespace Moq.Tests
 		[Fact]
 		public void IsPropertyIndexerLambdaTrue()
 		{
-			var expr = ToExpression<IFoo, object>(f => f[5]).StripConversion();
+			var expr = ToExpression<IFoo, object>(f => f[5]);
 
 			Assert.True(expr.IsPropertyIndexer());
 		}
@@ -73,7 +73,7 @@ namespace Moq.Tests
 		[Fact]
 		public void ToMethodCallThrowsIfNotMethodCall()
 		{
-			var expr = ToExpression<IFoo, object>(f => f.Value).StripConversion();
+			var expr = ToExpression<IFoo, object>(f => f.Value);
 
 			Assert.Throws<ArgumentException>(() => expr.ToMethodCall());
 		}
@@ -81,7 +81,7 @@ namespace Moq.Tests
 		[Fact]
 		public void ToMethodCallConvertsLambda()
 		{
-			var expr = ToExpression<IFoo>(f => f.Do()).StripConversion();
+			var expr = ToExpression<IFoo>(f => f.Do());
 
 			Assert.Equal(typeof(IFoo).GetMethod("Do"), expr.ToMethodCall().Method);
 		}

--- a/Moq.Tests/ExpressionExtensionsFixture.cs
+++ b/Moq.Tests/ExpressionExtensionsFixture.cs
@@ -37,18 +37,6 @@ namespace Moq.Tests
 		}
 
 		[Fact]
-		public void AssertIsLambdaThrowsIfNullExpression()
-		{
-			Assert.Throws<ArgumentNullException>(() => ExpressionExtensions.AssertIsLambda(null));
-		}
-
-		[Fact]
-		public void AssertIsLambdaThrowsIfExpressionNotLambda()
-		{
-			Assert.Throws<ArgumentException>(() => Expression.Constant(5).AssertIsLambda());
-		}
-
-		[Fact]
 		public void StripConversionLambdaRemovesConvert()
 		{
 			var lambda = ToExpression<object>(() => (object)5);

--- a/Moq.Tests/ExpressionExtensionsFixture.cs
+++ b/Moq.Tests/ExpressionExtensionsFixture.cs
@@ -51,7 +51,7 @@ namespace Moq.Tests
 		[Fact]
 		public void StripConversionLambdaRemovesConvert()
 		{
-			var lambda = ToExpression<object>(() => (object)5).AssertIsLambda();
+			var lambda = ToExpression<object>(() => (object)5);
 
 			var result = lambda.StripConversion();
 
@@ -61,7 +61,7 @@ namespace Moq.Tests
 		[Fact]
 		public void IsPropertyLambdaTrue()
 		{
-			var expr = ToExpression<IFoo, int>(f => f.Value).AssertIsLambda().StripConversion();
+			var expr = ToExpression<IFoo, int>(f => f.Value).StripConversion();
 
 			Assert.True(expr.IsProperty());
 		}
@@ -69,7 +69,7 @@ namespace Moq.Tests
 		[Fact]
 		public void IsPropertyLambdaFalse()
 		{
-			var expr = ToExpression<IFoo>(f => f.Do()).AssertIsLambda().StripConversion();
+			var expr = ToExpression<IFoo>(f => f.Do()).StripConversion();
 
 			Assert.False(expr.IsProperty());
 		}
@@ -77,7 +77,7 @@ namespace Moq.Tests
 		[Fact]
 		public void IsPropertyIndexerLambdaTrue()
 		{
-			var expr = ToExpression<IFoo, object>(f => f[5]).AssertIsLambda().StripConversion();
+			var expr = ToExpression<IFoo, object>(f => f[5]).StripConversion();
 
 			Assert.True(expr.IsPropertyIndexer());
 		}
@@ -85,7 +85,7 @@ namespace Moq.Tests
 		[Fact]
 		public void ToMethodCallThrowsIfNotMethodCall()
 		{
-			var expr = ToExpression<IFoo, object>(f => f.Value).AssertIsLambda().StripConversion();
+			var expr = ToExpression<IFoo, object>(f => f.Value).StripConversion();
 
 			Assert.Throws<ArgumentException>(() => expr.ToMethodCall());
 		}
@@ -93,7 +93,7 @@ namespace Moq.Tests
 		[Fact]
 		public void ToMethodCallConvertsLambda()
 		{
-			var expr = ToExpression<IFoo>(f => f.Do()).AssertIsLambda().StripConversion();
+			var expr = ToExpression<IFoo>(f => f.Do()).StripConversion();
 
 			Assert.Equal(typeof(IFoo).GetMethod("Do"), expr.ToMethodCall().Method);
 		}
@@ -145,17 +145,17 @@ namespace Moq.Tests
 			Assert.Same(expected, actual);
 		}
 
-		private Expression ToExpression<T>(Expression<Func<T>> expression)
+		private LambdaExpression ToExpression<T>(Expression<Func<T>> expression)
 		{
 			return expression;
 		}
 
-		private Expression ToExpression<T>(Expression<Action<T>> expression)
+		private LambdaExpression ToExpression<T>(Expression<Action<T>> expression)
 		{
 			return expression;
 		}
 
-		private Expression ToExpression<T, TResult>(Expression<Func<T, TResult>> expression)
+		private LambdaExpression ToExpression<T, TResult>(Expression<Func<T, TResult>> expression)
 		{
 			return expression;
 		}

--- a/Moq.Tests/ExpressionExtensionsFixture.cs
+++ b/Moq.Tests/ExpressionExtensionsFixture.cs
@@ -37,23 +37,23 @@ namespace Moq.Tests
 		}
 
 		[Fact]
-		public void ToLambdaThrowsIfNullExpression()
+		public void AssertIsLambdaThrowsIfNullExpression()
 		{
-			Assert.Throws<ArgumentNullException>(() => ExpressionExtensions.ToLambda(null));
+			Assert.Throws<ArgumentNullException>(() => ExpressionExtensions.AssertIsLambda(null));
 		}
 
 		[Fact]
-		public void ToLambdaThrowsIfExpressionNotLambda()
+		public void AssertIsLambdaThrowsIfExpressionNotLambda()
 		{
-			Assert.Throws<ArgumentException>(() => Expression.Constant(5).ToLambda());
+			Assert.Throws<ArgumentException>(() => Expression.Constant(5).AssertIsLambda());
 		}
 
 		[Fact]
-		public void ToLambdaRemovesConvert()
+		public void StripConversionLambdaRemovesConvert()
 		{
-			var lambda = ToExpression<object>(() => (object)5);
+			var lambda = ToExpression<object>(() => (object)5).AssertIsLambda();
 
-			var result = lambda.ToLambda();
+			var result = lambda.StripConversion();
 
 			Assert.Equal(typeof(int), result.Compile().GetMethodInfo().ReturnType);
 		}
@@ -61,7 +61,7 @@ namespace Moq.Tests
 		[Fact]
 		public void IsPropertyLambdaTrue()
 		{
-			var expr = ToExpression<IFoo, int>(f => f.Value).ToLambda();
+			var expr = ToExpression<IFoo, int>(f => f.Value).AssertIsLambda().StripConversion();
 
 			Assert.True(expr.IsProperty());
 		}
@@ -69,7 +69,7 @@ namespace Moq.Tests
 		[Fact]
 		public void IsPropertyLambdaFalse()
 		{
-			var expr = ToExpression<IFoo>(f => f.Do()).ToLambda();
+			var expr = ToExpression<IFoo>(f => f.Do()).AssertIsLambda().StripConversion();
 
 			Assert.False(expr.IsProperty());
 		}
@@ -77,7 +77,7 @@ namespace Moq.Tests
 		[Fact]
 		public void IsPropertyIndexerLambdaTrue()
 		{
-			var expr = ToExpression<IFoo, object>(f => f[5]).ToLambda();
+			var expr = ToExpression<IFoo, object>(f => f[5]).AssertIsLambda().StripConversion();
 
 			Assert.True(expr.IsPropertyIndexer());
 		}
@@ -85,7 +85,7 @@ namespace Moq.Tests
 		[Fact]
 		public void ToMethodCallThrowsIfNotMethodCall()
 		{
-			var expr = ToExpression<IFoo, object>(f => f.Value).ToLambda();
+			var expr = ToExpression<IFoo, object>(f => f.Value).AssertIsLambda().StripConversion();
 
 			Assert.Throws<ArgumentException>(() => expr.ToMethodCall());
 		}
@@ -93,7 +93,7 @@ namespace Moq.Tests
 		[Fact]
 		public void ToMethodCallConvertsLambda()
 		{
-			var expr = ToExpression<IFoo>(f => f.Do()).ToLambda();
+			var expr = ToExpression<IFoo>(f => f.Do()).AssertIsLambda().StripConversion();
 
 			Assert.Equal(typeof(IFoo).GetMethod("Do"), expr.ToMethodCall().Method);
 		}

--- a/Moq.Tests/Matchers/AnyMatcherFixture.cs
+++ b/Moq.Tests/Matchers/AnyMatcherFixture.cs
@@ -9,7 +9,7 @@ namespace Moq.Tests.Matchers
 		[Fact]
 		public void MatchesNull()
 		{
-			var expr = ToExpression<object>(() => It.IsAny<object>()).AssertIsLambda().StripConversion().Body;
+			var expr = ToExpression<object>(() => It.IsAny<object>()).StripConversion().Body;
 
 			var matcher = MatcherFactory.CreateMatcher(expr, false);
 
@@ -19,7 +19,7 @@ namespace Moq.Tests.Matchers
 		[Fact]
 		public void MatchesIfAssignableType()
 		{
-			var expr = ToExpression<object>(() => It.IsAny<object>()).AssertIsLambda().StripConversion().Body;
+			var expr = ToExpression<object>(() => It.IsAny<object>()).StripConversion().Body;
 
 			var matcher = MatcherFactory.CreateMatcher(expr, false);
 
@@ -29,7 +29,7 @@ namespace Moq.Tests.Matchers
 		[Fact]
 		public void MatchesIfAssignableInterface()
 		{
-			var expr = ToExpression<IDisposable>(() => It.IsAny<IDisposable>()).AssertIsLambda().StripConversion().Body;
+			var expr = ToExpression<IDisposable>(() => It.IsAny<IDisposable>()).StripConversion().Body;
 
 			var matcher = MatcherFactory.CreateMatcher(expr, false);
 
@@ -39,14 +39,14 @@ namespace Moq.Tests.Matchers
 		[Fact]
 		public void DoesntMatchIfNotAssignableType()
 		{
-			var expr = ToExpression<IFormatProvider>(() => It.IsAny<IFormatProvider>()).AssertIsLambda().StripConversion().Body;
+			var expr = ToExpression<IFormatProvider>(() => It.IsAny<IFormatProvider>()).StripConversion().Body;
 
 			var matcher = MatcherFactory.CreateMatcher(expr, false);
 
 			Assert.False(matcher.Matches("foo"));
 		}
 
-		private Expression ToExpression<TResult>(Expression<Func<TResult>> expr)
+		private LambdaExpression ToExpression<TResult>(Expression<Func<TResult>> expr)
 		{
 			return expr;
 		}

--- a/Moq.Tests/Matchers/AnyMatcherFixture.cs
+++ b/Moq.Tests/Matchers/AnyMatcherFixture.cs
@@ -9,7 +9,7 @@ namespace Moq.Tests.Matchers
 		[Fact]
 		public void MatchesNull()
 		{
-			var expr = ToExpression<object>(() => It.IsAny<object>()).StripConversion().Body;
+			var expr = ToExpression<object>(() => It.IsAny<object>()).Body;
 
 			var matcher = MatcherFactory.CreateMatcher(expr, false);
 
@@ -19,7 +19,7 @@ namespace Moq.Tests.Matchers
 		[Fact]
 		public void MatchesIfAssignableType()
 		{
-			var expr = ToExpression<object>(() => It.IsAny<object>()).StripConversion().Body;
+			var expr = ToExpression<object>(() => It.IsAny<object>()).Body;
 
 			var matcher = MatcherFactory.CreateMatcher(expr, false);
 
@@ -29,7 +29,7 @@ namespace Moq.Tests.Matchers
 		[Fact]
 		public void MatchesIfAssignableInterface()
 		{
-			var expr = ToExpression<IDisposable>(() => It.IsAny<IDisposable>()).StripConversion().Body;
+			var expr = ToExpression<IDisposable>(() => It.IsAny<IDisposable>()).Body;
 
 			var matcher = MatcherFactory.CreateMatcher(expr, false);
 
@@ -39,7 +39,7 @@ namespace Moq.Tests.Matchers
 		[Fact]
 		public void DoesntMatchIfNotAssignableType()
 		{
-			var expr = ToExpression<IFormatProvider>(() => It.IsAny<IFormatProvider>()).StripConversion().Body;
+			var expr = ToExpression<IFormatProvider>(() => It.IsAny<IFormatProvider>()).Body;
 
 			var matcher = MatcherFactory.CreateMatcher(expr, false);
 

--- a/Moq.Tests/Matchers/AnyMatcherFixture.cs
+++ b/Moq.Tests/Matchers/AnyMatcherFixture.cs
@@ -9,7 +9,7 @@ namespace Moq.Tests.Matchers
 		[Fact]
 		public void MatchesNull()
 		{
-			var expr = ToExpression<object>(() => It.IsAny<object>()).ToLambda().Body;
+			var expr = ToExpression<object>(() => It.IsAny<object>()).AssertIsLambda().StripConversion().Body;
 
 			var matcher = MatcherFactory.CreateMatcher(expr, false);
 
@@ -19,7 +19,7 @@ namespace Moq.Tests.Matchers
 		[Fact]
 		public void MatchesIfAssignableType()
 		{
-			var expr = ToExpression<object>(() => It.IsAny<object>()).ToLambda().Body;
+			var expr = ToExpression<object>(() => It.IsAny<object>()).AssertIsLambda().StripConversion().Body;
 
 			var matcher = MatcherFactory.CreateMatcher(expr, false);
 
@@ -29,7 +29,7 @@ namespace Moq.Tests.Matchers
 		[Fact]
 		public void MatchesIfAssignableInterface()
 		{
-			var expr = ToExpression<IDisposable>(() => It.IsAny<IDisposable>()).ToLambda().Body;
+			var expr = ToExpression<IDisposable>(() => It.IsAny<IDisposable>()).AssertIsLambda().StripConversion().Body;
 
 			var matcher = MatcherFactory.CreateMatcher(expr, false);
 
@@ -39,7 +39,7 @@ namespace Moq.Tests.Matchers
 		[Fact]
 		public void DoesntMatchIfNotAssignableType()
 		{
-			var expr = ToExpression<IFormatProvider>(() => It.IsAny<IFormatProvider>()).ToLambda().Body;
+			var expr = ToExpression<IFormatProvider>(() => It.IsAny<IFormatProvider>()).AssertIsLambda().StripConversion().Body;
 
 			var matcher = MatcherFactory.CreateMatcher(expr, false);
 

--- a/Source/ExpressionExtensions.cs
+++ b/Source/ExpressionExtensions.cs
@@ -167,9 +167,9 @@ namespace Moq
 			return Evaluator.PartialEval(expression);
 		}
 
-		public static Expression PartialMatcherAwareEval(this Expression expression)
+		public static LambdaExpression PartialMatcherAwareEval(this LambdaExpression expression)
 		{
-			return Evaluator.PartialEval(
+			return (LambdaExpression)Evaluator.PartialEval(
 				expression,
 				PartialMatcherAwareEval_ShouldEvaluate);
 		}

--- a/Source/ExpressionExtensions.cs
+++ b/Source/ExpressionExtensions.cs
@@ -57,6 +57,11 @@ namespace Moq
 		/// </summary>
 		public static LambdaExpression ToLambda(this Expression expression)
 		{
+			return expression.AssertIsLambda().StripConversion();
+		}
+
+		private static LambdaExpression AssertIsLambda(this Expression expression)
+		{
 			Guard.NotNull(expression, nameof(expression));
 
 			LambdaExpression lambda = expression as LambdaExpression;
@@ -64,6 +69,11 @@ namespace Moq
 				throw new ArgumentException(String.Format(CultureInfo.CurrentCulture,
 					Properties.Resources.UnsupportedExpression, expression));
 
+			return lambda;
+		}
+
+		private static LambdaExpression StripConversion(this LambdaExpression lambda)
+		{
 			// Remove convert expressions which are passed-in by the MockProtectedExtensions.
 			// They are passed because LambdaExpression constructor checks the type of 
 			// the returned values, even if the return type is Object and everything 

--- a/Source/ExpressionExtensions.cs
+++ b/Source/ExpressionExtensions.cs
@@ -51,16 +51,7 @@ namespace Moq
 {
 	internal static class ExpressionExtensions
 	{
-		/// <summary>
-		/// Casts the expression to a lambda expression, removing 
-		/// a cast if there's any.
-		/// </summary>
-		public static LambdaExpression ToLambda(this Expression expression)
-		{
-			return expression.AssertIsLambda().StripConversion();
-		}
-
-		private static LambdaExpression AssertIsLambda(this Expression expression)
+		public static LambdaExpression AssertIsLambda(this Expression expression)
 		{
 			Guard.NotNull(expression, nameof(expression));
 
@@ -72,7 +63,7 @@ namespace Moq
 			return lambda;
 		}
 
-		private static LambdaExpression StripConversion(this LambdaExpression lambda)
+		public static LambdaExpression StripConversion(this LambdaExpression lambda)
 		{
 			// Remove convert expressions which are passed-in by the MockProtectedExtensions.
 			// They are passed because LambdaExpression constructor checks the type of 

--- a/Source/ExpressionExtensions.cs
+++ b/Source/ExpressionExtensions.cs
@@ -51,18 +51,6 @@ namespace Moq
 {
 	internal static class ExpressionExtensions
 	{
-		public static LambdaExpression AssertIsLambda(this Expression expression)
-		{
-			Guard.NotNull(expression, nameof(expression));
-
-			LambdaExpression lambda = expression as LambdaExpression;
-			if (lambda == null)
-				throw new ArgumentException(String.Format(CultureInfo.CurrentCulture,
-					Properties.Resources.UnsupportedExpression, expression));
-
-			return lambda;
-		}
-
 		public static LambdaExpression StripConversion(this LambdaExpression lambda)
 		{
 			// Remove convert expressions which are passed-in by the MockProtectedExtensions.

--- a/Source/MethodCall.cs
+++ b/Source/MethodCall.cs
@@ -468,7 +468,7 @@ namespace Moq
 				message.Append(this.failMessage).Append(": ");
 			}
 
-			var lambda = this.originalExpression.PartialMatcherAwareEval().ToLambda();
+			var lambda = this.originalExpression.PartialMatcherAwareEval().AssertIsLambda().StripConversion();
 			var targetTypeName = lambda.Parameters[0].Type.Name;
 
 			message.Append(targetTypeName).Append(" ").Append(lambda.ToStringFixed());
@@ -490,7 +490,7 @@ namespace Moq
 		public string Format()
 		{
 			var builder = new StringBuilder();
-			builder.Append(this.originalExpression.PartialMatcherAwareEval().ToLambda().ToStringFixed());
+			builder.Append(this.originalExpression.PartialMatcherAwareEval().AssertIsLambda().StripConversion().ToStringFixed());
 
 			if (this.expectedMaxCallCount != null)
 			{

--- a/Source/MethodCall.cs
+++ b/Source/MethodCall.cs
@@ -59,7 +59,7 @@ namespace Moq
 	internal partial class MethodCall<TMock> : MethodCall, ISetup<TMock>
 		where TMock : class
 	{
-		public MethodCall(Mock mock, Condition condition, Expression originalExpression, MethodInfo method,
+		public MethodCall(Mock mock, Condition condition, LambdaExpression originalExpression, MethodInfo method,
 			params Expression[] arguments)
 			: base(mock, condition, originalExpression, method, arguments)
 		{
@@ -96,7 +96,7 @@ namespace Moq
 		private int originalCallerLineNumber;
 		private MethodBase originalCallerMember;
 #endif
-		private Expression originalExpression;
+		private LambdaExpression originalExpression;
 		private List<KeyValuePair<int, object>> outValues;
 		private RaiseEventResponse raiseEventResponse;
 		private Exception throwExceptionResponse;
@@ -106,7 +106,7 @@ namespace Moq
 		///   Only use this constructor when you know that the specified <paramref name="method"/> has no `out` parameters,
 		///   and when you want to avoid the <see cref="MatcherFactory"/>-related overhead of the other constructor overload.
 		/// </remarks>
-		public MethodCall(Mock mock, Condition condition, Expression originalExpression, MethodInfo method, IMatcher[] argumentMatchers)
+		public MethodCall(Mock mock, Condition condition, LambdaExpression originalExpression, MethodInfo method, IMatcher[] argumentMatchers)
 		{
 			this.argumentMatchers = argumentMatchers;
 			this.condition = condition;
@@ -115,7 +115,7 @@ namespace Moq
 			this.originalExpression = originalExpression;
 		}
 
-		public MethodCall(Mock mock, Condition condition, Expression originalExpression, MethodInfo method, params Expression[] arguments)
+		public MethodCall(Mock mock, Condition condition, LambdaExpression originalExpression, MethodInfo method, params Expression[] arguments)
 		{
 			this.mock = mock;
 			this.condition = condition;
@@ -206,7 +206,7 @@ namespace Moq
 
 		public bool Invoked => this.callCount > 0;
 
-		public Expression SetupExpression => this.originalExpression;
+		public LambdaExpression SetupExpression => this.originalExpression;
 
 		[Conditional("DESKTOP")]
 		[SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
@@ -468,7 +468,7 @@ namespace Moq
 				message.Append(this.failMessage).Append(": ");
 			}
 
-			var lambda = this.originalExpression.PartialMatcherAwareEval().AssertIsLambda().StripConversion();
+			var lambda = this.originalExpression.PartialMatcherAwareEval().StripConversion();
 			var targetTypeName = lambda.Parameters[0].Type.Name;
 
 			message.Append(targetTypeName).Append(" ").Append(lambda.ToStringFixed());
@@ -490,7 +490,7 @@ namespace Moq
 		public string Format()
 		{
 			var builder = new StringBuilder();
-			builder.Append(this.originalExpression.PartialMatcherAwareEval().AssertIsLambda().StripConversion().ToStringFixed());
+			builder.Append(this.originalExpression.PartialMatcherAwareEval().StripConversion().ToStringFixed());
 
 			if (this.expectedMaxCallCount != null)
 			{

--- a/Source/MethodCallReturn.cs
+++ b/Source/MethodCallReturn.cs
@@ -67,7 +67,7 @@ namespace Moq
 		private Action<object[]> afterReturnCallback;
 		private ReturnValueKind returnValueKind;
 
-		public MethodCallReturn(Mock mock, Condition condition, Expression originalExpression, MethodInfo method, params Expression[] arguments)
+		public MethodCallReturn(Mock mock, Condition condition, LambdaExpression originalExpression, MethodInfo method, params Expression[] arguments)
 			: base(mock, condition, originalExpression, method, arguments)
 		{
 		}

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -369,7 +369,7 @@ namespace Moq
 			where T : class
 		{
 			Mock targetMock = null;
-			Expression expression = null;
+			LambdaExpression expression = null;
 			var expected = SetupSetImpl<T, MethodCall<T>>(mock, setterExpression, (m, expr, method, value) =>
 				{
 					targetMock = m;
@@ -380,10 +380,13 @@ namespace Moq
 			VerifyCalls(targetMock, expected, expression, times);
 		}
 
-		private static bool AreSameMethod(Expression left, Expression right)
+		private static bool AreSameMethod(LambdaExpression left, LambdaExpression right)
 		{
-			var leftLambda = left.AssertIsLambda().StripConversion();
-			var rightLambda = right.AssertIsLambda().StripConversion();
+			Debug.Assert(left != null);
+			Debug.Assert(right != null);
+
+			var leftLambda = left.StripConversion();
+			var rightLambda = right.StripConversion();
 			if (leftLambda != null && rightLambda != null &&
 				leftLambda.Body is MethodCallExpression && rightLambda.Body is MethodCallExpression)
 			{
@@ -444,7 +447,7 @@ namespace Moq
 		private static void VerifyCalls(
 			Mock targetMock,
 			MethodCall expected,
-			Expression expression,
+			LambdaExpression expression,
 			Times times)
 		{
 			var allInvocations = targetMock.MutableInvocations.ToArray();
@@ -468,11 +471,11 @@ namespace Moq
 			MethodCall expected,
 			IEnumerable<MethodCall> setups,
 			IEnumerable<Invocation> actualCalls,
-			Expression expression,
+			LambdaExpression expression,
 			Times times,
 			int callCount)
 		{
-			var message = times.GetExceptionMessage(expected.FailMessage, expression.PartialMatcherAwareEval().AssertIsLambda().StripConversion().ToStringFixed(), callCount) +
+			var message = times.GetExceptionMessage(expected.FailMessage, expression.PartialMatcherAwareEval().StripConversion().ToStringFixed(), callCount) +
 				Environment.NewLine + FormatSetupsInfo(setups) +
 				Environment.NewLine + FormatInvocations(actualCalls);
 			throw new MockException(MockException.ExceptionReason.VerificationFailed, message);
@@ -662,7 +665,7 @@ namespace Moq
 		private static TCall SetupSetImpl<T, TCall>(
 			Mock<T> mock,
 			Action<T> setterExpression,
-			Func<Mock, Expression, MethodInfo, Expression[], TCall> callFactory)
+			Func<Mock, LambdaExpression, MethodInfo, Expression[], TCall> callFactory)
 			where T : class
 			where TCall : MethodCall
 		{
@@ -877,7 +880,7 @@ namespace Moq
 			}
 		}
 
-		private static Expression GetPropertyExpression(Type mockType, PropertyInfo property)
+		private static LambdaExpression GetPropertyExpression(Type mockType, PropertyInfo property)
 		{
 			var param = Expression.Parameter(mockType, "m");
 			return Expression.Lambda(Expression.MakeMemberAccess(param, property), param);

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -382,8 +382,8 @@ namespace Moq
 
 		private static bool AreSameMethod(Expression left, Expression right)
 		{
-			var leftLambda = left.ToLambda();
-			var rightLambda = right.ToLambda();
+			var leftLambda = left.AssertIsLambda().StripConversion();
+			var rightLambda = right.AssertIsLambda().StripConversion();
 			if (leftLambda != null && rightLambda != null &&
 				leftLambda.Body is MethodCallExpression && rightLambda.Body is MethodCallExpression)
 			{
@@ -472,7 +472,7 @@ namespace Moq
 			Times times,
 			int callCount)
 		{
-			var message = times.GetExceptionMessage(expected.FailMessage, expression.PartialMatcherAwareEval().ToLambda().ToStringFixed(), callCount) +
+			var message = times.GetExceptionMessage(expected.FailMessage, expression.PartialMatcherAwareEval().AssertIsLambda().StripConversion().ToStringFixed(), callCount) +
 				Environment.NewLine + FormatSetupsInfo(setups) +
 				Environment.NewLine + FormatInvocations(actualCalls);
 			throw new MockException(MockException.ExceptionReason.VerificationFailed, message);

--- a/Source/PropertyGetterMethodCall.cs
+++ b/Source/PropertyGetterMethodCall.cs
@@ -51,7 +51,7 @@ namespace Moq
 
 		private Func<object> getter;
 
-		public PropertyGetterMethodCall(Mock mock, Expression originalExpression, MethodInfo method, Func<object> getter)
+		public PropertyGetterMethodCall(Mock mock, LambdaExpression originalExpression, MethodInfo method, Func<object> getter)
 			: base(mock, null, originalExpression, method, noArgumentMatchers)
 		{
 			this.getter = getter;

--- a/Source/PropertySetterMethodCall.cs
+++ b/Source/PropertySetterMethodCall.cs
@@ -53,7 +53,7 @@ namespace Moq
 
 		private Action<object> setter;
 
-		public PropertySetterMethodCall(Mock mock, Expression originalExpression, MethodInfo method, Action<object> setter)
+		public PropertySetterMethodCall(Mock mock, LambdaExpression originalExpression, MethodInfo method, Action<object> setter)
 			: base(mock, null, originalExpression, method, anyMatcherForSingleArgument)
 		{
 			this.setter = setter;

--- a/Source/SequenceMethodCall.cs
+++ b/Source/SequenceMethodCall.cs
@@ -51,7 +51,7 @@ namespace Moq
 		// contains the responses set up with the `CallBase`, `Pass`, `Returns`, and `Throws` verbs
 		private ConcurrentQueue<(ResponseKind, object)> responses;
 
-		public SequenceMethodCall(Mock mock, Expression originalExpression, MethodInfo method, params Expression[] arguments)
+		public SequenceMethodCall(Mock mock, LambdaExpression originalExpression, MethodInfo method, params Expression[] arguments)
 			: base(mock, null, originalExpression, method, arguments)
 		{
 			this.responses = new ConcurrentQueue<(ResponseKind, object)>();

--- a/Source/SetterMethodCall.cs
+++ b/Source/SetterMethodCall.cs
@@ -49,17 +49,17 @@ namespace Moq
 	internal class SetterMethodCall<TMock, TProperty> : MethodCall<TMock>, ISetupSetter<TMock, TProperty>
 		where TMock : class
 	{
-		public SetterMethodCall(Mock mock, Expression originalExpression, MethodInfo method)
+		public SetterMethodCall(Mock mock, LambdaExpression originalExpression, MethodInfo method)
 			: base(mock, null, originalExpression, method, new[] { ItExpr.IsAny<TProperty>() })
 		{
 		}
 
-		public SetterMethodCall(Mock mock, Expression originalExpression, MethodInfo method, TProperty value)
+		public SetterMethodCall(Mock mock, LambdaExpression originalExpression, MethodInfo method, TProperty value)
 			: base(mock, null, originalExpression, method, new[] { ItExpr.Is<TProperty>(arg => Object.Equals(arg, value)) })
 		{
 		}
 
-		public SetterMethodCall(Mock mock, Condition condition, Expression originalExpression, MethodInfo method, Expression value)
+		public SetterMethodCall(Mock mock, Condition condition, LambdaExpression originalExpression, MethodInfo method, Expression value)
 			: base(mock, condition, originalExpression, method, new[] { value })
 		{
 		}


### PR DESCRIPTION
This is the first out of several refactorings that attempt to get rid (as much as possible) of chained expression transforms such as `.PartialMatcherAwareEval().ToLambda()` which are found all over the codebase. They are problematic because it's not immediately clear *when* these transforms are needed, and *which* of them are needed for what reasons.

`.ToLambda()` is a mix-up of two separate concerns:

1. Perform a downcast from `Expression` to `LambdaExpression`
2. Strip a type-cast (if present) from the lambda's body

As it turns out, (1) becomes superfluous if we simply re-declare certain members as `LambdaExpression` instead of `Expression`. Incidentally, this makes visible the heretofore implicit assumption that `MethodCall.SetupExpression` is expected to be a lambda expression.

`ToLambda` is then renamed to `StripConversion` to better reflect its remaining function.