### PR TITLE
Remove superfluous `.StripConversion` helper method

### DIFF
--- a/Moq.Tests/ExpressionExtensionsFixture.cs
+++ b/Moq.Tests/ExpressionExtensionsFixture.cs
@@ -36,15 +36,6 @@ namespace Moq.Tests
 			Assert.Contains("ExpressionExtensionsFixture.DoStaticGeneric<Int32>(5)", value);
 		}
 
-		public void StripConversionLambdaRemovesConvert()
-		{
-			var lambda = ToExpression<object>(() => (object)5);
-
-			var result = lambda.StripConversion();
-
-			Assert.Equal(typeof(int), result.Compile().GetMethodInfo().ReturnType);
-		}
-
 		[Fact]
 		public void IsPropertyLambdaTrue()
 		{

--- a/Moq.Tests/ExpressionExtensionsFixture.cs
+++ b/Moq.Tests/ExpressionExtensionsFixture.cs
@@ -36,7 +36,6 @@ namespace Moq.Tests
 			Assert.Contains("ExpressionExtensionsFixture.DoStaticGeneric<Int32>(5)", value);
 		}
 
-		[Fact]
 		public void StripConversionLambdaRemovesConvert()
 		{
 			var lambda = ToExpression<object>(() => (object)5);

--- a/Source/ExpressionExtensions.cs
+++ b/Source/ExpressionExtensions.cs
@@ -51,19 +51,6 @@ namespace Moq
 {
 	internal static class ExpressionExtensions
 	{
-		public static LambdaExpression StripConversion(this LambdaExpression lambda)
-		{
-			// Remove convert expressions which are passed-in by the MockProtectedExtensions.
-			// They are passed because LambdaExpression constructor checks the type of 
-			// the returned values, even if the return type is Object and everything 
-			// is able to convert to it. It forces you to be explicit about the conversion.
-			var convert = lambda.Body as UnaryExpression;
-			if (convert != null && convert.NodeType == ExpressionType.Convert)
-				lambda = Expression.Lambda(convert.Operand, lambda.Parameters.ToArray());
-
-			return lambda;
-		}
-
 		/// <summary>
 		/// Converts the body of the lambda expression into the <see cref="PropertyInfo"/> referenced by it.
 		/// </summary>

--- a/Source/MethodCall.cs
+++ b/Source/MethodCall.cs
@@ -468,7 +468,7 @@ namespace Moq
 				message.Append(this.failMessage).Append(": ");
 			}
 
-			var lambda = this.originalExpression.PartialMatcherAwareEval().StripConversion();
+			var lambda = this.originalExpression.PartialMatcherAwareEval();
 			var targetTypeName = lambda.Parameters[0].Type.Name;
 
 			message.Append(targetTypeName).Append(" ").Append(lambda.ToStringFixed());
@@ -490,7 +490,7 @@ namespace Moq
 		public string Format()
 		{
 			var builder = new StringBuilder();
-			builder.Append(this.originalExpression.PartialMatcherAwareEval().StripConversion().ToStringFixed());
+			builder.Append(this.originalExpression.PartialMatcherAwareEval().ToStringFixed());
 
 			if (this.expectedMaxCallCount != null)
 			{

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -450,21 +450,8 @@ namespace Moq
 				}
 			}
 
-			bool AreSameMethod(LambdaExpression left, LambdaExpression right)
-			{
-				Debug.Assert(left != null);
-				Debug.Assert(right != null);
-
-				var leftLambda = left;
-				var rightLambda = right;
-				if (leftLambda != null && rightLambda != null &&
-					leftLambda.Body is MethodCallExpression leftCall && rightLambda.Body is MethodCallExpression rightCall)
-				{
-					return leftCall.Method == rightCall.Method;
-				}
-
-				return false;
-			}
+			bool AreSameMethod(LambdaExpression l, LambdaExpression r) =>
+				l.Body is MethodCallExpression lc && r.Body is MethodCallExpression rc && lc.Method == rc.Method;
 		}
 
 		private static void ThrowVerifyException(

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -380,22 +380,6 @@ namespace Moq
 			VerifyCalls(targetMock, expected, expression, times);
 		}
 
-		private static bool AreSameMethod(LambdaExpression left, LambdaExpression right)
-		{
-			Debug.Assert(left != null);
-			Debug.Assert(right != null);
-
-			var leftLambda = left.StripConversion();
-			var rightLambda = right.StripConversion();
-			if (leftLambda != null && rightLambda != null &&
-				leftLambda.Body is MethodCallExpression leftCall && rightLambda.Body is MethodCallExpression rightCall)
-			{
-				return leftCall.Method == rightCall.Method;
-			}
-
-			return false;
-		}
-
 		internal static void VerifyNoOtherCalls(Mock mock)
 		{
 			var unverifiedInvocations = mock.MutableInvocations.ToArray(invocation => !invocation.Verified);
@@ -464,6 +448,22 @@ namespace Moq
 				{
 					matchingInvocation.MarkAsVerified();
 				}
+			}
+
+			bool AreSameMethod(LambdaExpression left, LambdaExpression right)
+			{
+				Debug.Assert(left != null);
+				Debug.Assert(right != null);
+
+				var leftLambda = left.StripConversion();
+				var rightLambda = right.StripConversion();
+				if (leftLambda != null && rightLambda != null &&
+					leftLambda.Body is MethodCallExpression leftCall && rightLambda.Body is MethodCallExpression rightCall)
+				{
+					return leftCall.Method == rightCall.Method;
+				}
+
+				return false;
 			}
 		}
 

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -455,8 +455,8 @@ namespace Moq
 				Debug.Assert(left != null);
 				Debug.Assert(right != null);
 
-				var leftLambda = left.StripConversion();
-				var rightLambda = right.StripConversion();
+				var leftLambda = left;
+				var rightLambda = right;
 				if (leftLambda != null && rightLambda != null &&
 					leftLambda.Body is MethodCallExpression leftCall && rightLambda.Body is MethodCallExpression rightCall)
 				{

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -475,7 +475,7 @@ namespace Moq
 			Times times,
 			int callCount)
 		{
-			var message = times.GetExceptionMessage(expected.FailMessage, expression.PartialMatcherAwareEval().StripConversion().ToStringFixed(), callCount) +
+			var message = times.GetExceptionMessage(expected.FailMessage, expression.PartialMatcherAwareEval().ToStringFixed(), callCount) +
 				Environment.NewLine + FormatSetupsInfo(setups) +
 				Environment.NewLine + FormatInvocations(actualCalls);
 			throw new MockException(MockException.ExceptionReason.VerificationFailed, message);


### PR DESCRIPTION
There's a helper method `ExpressionExtensions.StripConversion(this LambdaExpression)` that doesn't appear to have any effect whatsoever. It can be turned into an identity function and none of the unit tests break.

A closer inspection reveals the following:

* The comment it contains about the `LambdaExpression` ctor introducing a cast no longer appears to hold true today. Also, the reference to `ProtectedMockExtensions` is rather vague. It looks a lot like things have changed so much since this code was added that it just no longer makes any sense.

* The method is used *only* in diagnostic scenarios (i.e. when an exception is about to be thrown). It is strange that automatically added conversions would only have to be removed when we're about to error already, but not in normal operation. So if it's not needed during normal operation, it is very probably that we can remove it for diagnostics, too.