### PR TITLE
`IInvocation` and `IInvocationList`

### DIFF
--- a/Moq.Tests/ExtensionsFixture.cs
+++ b/Moq.Tests/ExtensionsFixture.cs
@@ -23,7 +23,7 @@ namespace Moq.Tests
 			mock.Setup(foo => foo.Execute("ping")).Returns("ack");
 
 			mock.Object.Execute("ping");
-			mock.ResetCalls();
+			mock.Invocations.Clear();
 			mock.Object.Execute("ping");
 			mock.Verify(o => o.Execute("ping"), Times.Once());
 		}

--- a/Moq.Tests/InvocationsFixture.cs
+++ b/Moq.Tests/InvocationsFixture.cs
@@ -76,7 +76,7 @@ namespace Moq.Tests
 
 		    mock.Object.CompareTo(new object());
 
-			mock.ResetCalls();
+			mock.Invocations.Clear();
 
 		    Assert.Equal(0, mock.Invocations.Count);
 	    }

--- a/Source/IInvocation.cs
+++ b/Source/IInvocation.cs
@@ -6,7 +6,7 @@ namespace Moq
 	/// <summary>
 	/// Provides information about an invocation of a mock object.
 	/// </summary>
-	public interface IReadOnlyInvocation
+	public interface IInvocation
 	{
 		/// <summary>
 		/// Gets the method of the invocation.

--- a/Source/IInvocationList.cs
+++ b/Source/IInvocationList.cs
@@ -1,0 +1,55 @@
+﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//https://github.com/moq/moq4
+//All rights reserved.
+//
+//Redistribution and use in source and binary forms,
+//with or without modification, are permitted provided
+//that the following conditions are met:
+//
+//    * Redistributions of source code must retain the
+//    above copyright notice, this list of conditions and
+//    the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce
+//    the above copyright notice, this list of conditions
+//    and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
+//    names of its contributors may be used to endorse
+//    or promote products derived from this software
+//    without specific prior written permission.
+//
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+//SUCH DAMAGE.
+//
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System.Collections.Generic;
+
+namespace Moq
+{
+	/// <summary>
+	/// A list of invocations which have been performed on a mock.
+	/// </summary>
+	public interface IInvocationList : IReadOnlyList<IInvocation>
+	{
+		/// <summary>
+		/// Resets all invocations recorded for this mock.
+		/// </summary>
+		void Clear();
+	}
+}

--- a/Source/Invocation.cs
+++ b/Source/Invocation.cs
@@ -46,7 +46,7 @@ using System.Text;
 
 namespace Moq
 {
-	internal abstract class Invocation : IReadOnlyInvocation
+	internal abstract class Invocation : IInvocation
 	{
 		private object[] arguments;
 		private MethodInfo method;
@@ -80,7 +80,7 @@ namespace Moq
 		/// </remarks>
 		public object[] Arguments => this.arguments;
 
-		IReadOnlyList<object> IReadOnlyInvocation.Arguments => this.arguments;
+		IReadOnlyList<object> IInvocation.Arguments => this.arguments;
 
 		internal bool Verified => this.verified;
 

--- a/Source/InvocationCollection.cs
+++ b/Source/InvocationCollection.cs
@@ -45,7 +45,7 @@ using System.Linq;
 
 namespace Moq
 {
-	internal sealed class InvocationCollection : IReadOnlyList<IReadOnlyInvocation>
+	internal sealed class InvocationCollection : IInvocationList
 	{
 		private Invocation[] invocations;
 
@@ -65,7 +65,7 @@ namespace Moq
 			}
 		}
 
-		public IReadOnlyInvocation this[int index]
+		public IInvocation this[int index]
 		{
 			get
 			{
@@ -149,7 +149,7 @@ namespace Moq
 			}
 		}
 
-		public IEnumerator<IReadOnlyInvocation> GetEnumerator()
+		public IEnumerator<IInvocation> GetEnumerator()
 		{
 			// Take local copies of collection and count so they are isolated from changes by other threads.
 			Invocation[] collection;

--- a/Source/Linq/Mock.cs
+++ b/Source/Linq/Mock.cs
@@ -85,10 +85,10 @@ namespace Moq
 			//
 			// TODO: Make LINQ to Mocks set up mocks without causing invocations of its own, then remove this hack.
 			var mock = Mock.Get(mocked);
-			mock.ResetCalls();
+			mock.Invocations.Clear();
 			foreach (var inner in mock.InnerMocks.Values)
 			{
-				inner.Mock.ResetCalls();
+				inner.Mock.Invocations.Clear();
 			}
 
 			return mocked;

--- a/Source/Mock.cs
+++ b/Source/Mock.cs
@@ -196,7 +196,7 @@ namespace Moq
 		/// <summary>
 		/// Gets list of invocations which have been performed on this mock.
 		/// </summary>
-		public IReadOnlyList<IReadOnlyInvocation> Invocations => MutableInvocations;
+		public IInvocationList Invocations => MutableInvocations;
 
 		internal abstract InvocationCollection MutableInvocations { get; }
 

--- a/Source/MockExtensions.cs
+++ b/Source/MockExtensions.cs
@@ -2,22 +2,12 @@
 
 namespace Moq
 {
-
 	/// <summary>
 	/// Provides additional methods on mocks.
 	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
-	public static class MockExtensions
+	public static partial class MockExtensions
 	{
-		/// <summary>
-		/// Resets all invocations recorded for this mock.
-		/// </summary>
-		/// <param name="mock">The mock whose recorded invocations should be reset.</param>
-		public static void ResetCalls(this Mock mock)
-		{
-			mock.MutableInvocations.Clear();
-		}
-
 		/// <summary>
 		/// Resets this mock's state. This includes its setups, configured default return values, registered event handlers, and all recorded invocations.
 		/// </summary>
@@ -27,7 +17,7 @@ namespace Moq
 			mock.ConfiguredDefaultValues.Clear();
 			mock.Setups.Clear();
 			mock.EventHandlers.Clear();
-			mock.ResetCalls();
+			mock.Invocations.Clear();
 		}
 	}
 }

--- a/Source/Obsolete/MockExtensions.cs
+++ b/Source/Obsolete/MockExtensions.cs
@@ -1,0 +1,56 @@
+﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//https://github.com/moq/moq4
+//All rights reserved.
+//
+//Redistribution and use in source and binary forms,
+//with or without modification, are permitted provided
+//that the following conditions are met:
+//
+//    * Redistributions of source code must retain the
+//    above copyright notice, this list of conditions and
+//    the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce
+//    the above copyright notice, this list of conditions
+//    and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
+//    names of its contributors may be used to endorse
+//    or promote products derived from this software
+//    without specific prior written permission.
+//
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+//SUCH DAMAGE.
+//
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System;
+using System.ComponentModel;
+
+namespace Moq
+{
+	static partial class MockExtensions
+	{
+		/// <summary>
+		/// Resets all invocations recorded for this mock.
+		/// </summary>
+		/// <param name="mock">The mock whose recorded invocations should be reset.</param>
+		[Obsolete("Use `mock.Invocations.Clear()` instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void ResetCalls(this Mock mock) => mock.Invocations.Clear();
+	}
+}

--- a/Source/ProxyFactories/CastleProxyFactory.cs
+++ b/Source/ProxyFactories/CastleProxyFactory.cs
@@ -202,7 +202,7 @@ namespace Moq
 				this.underlying = underlying;
 			}
 
-			public void Intercept(IInvocation invocation)
+			public void Intercept(Castle.DynamicProxy.IInvocation invocation)
 			{
 				this.underlying.Intercept(new Invocation(underlying: invocation));
 			}
@@ -210,9 +210,9 @@ namespace Moq
 
 		private sealed class Invocation : Moq.Invocation
 		{
-			private IInvocation underlying;
+			private Castle.DynamicProxy.IInvocation underlying;
 
-			internal Invocation(IInvocation underlying) : base(underlying.Method, underlying.Arguments)
+			internal Invocation(Castle.DynamicProxy.IInvocation underlying) : base(underlying.Method, underlying.Arguments)
 			{
 				this.underlying = underlying;
 			}


### PR DESCRIPTION
Rename `IReadOnlyInvocation` to `IInvocation` and introduce a new type `IInvocationList` instead of using `IReadOnlyList<>`. The rationale behind this is that we may want to publish methods in the future that are not read-only; naming interfaces as "read-only" would essentially block us from doing so.

Deprecate `mock.ResetCalls()` in favor of `mock.Invocations.Clear()`, which is more in line with Moq 5's API.