### PR TITLE
Round-trip floats in diagnostic messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 #### Changed
 
 * Update package reference to `Castle.Core` (DynamicProxy) from version 4.3.0 to 4.3.1 (@stakx, #635)
+* Floating point values are formatted with higher precision (satisfying round-tripping) in diagnostic messages (@stakx, #637)
+
 
 #### Obsoleted
 

--- a/Source/StringBuilderExtensions.cs
+++ b/Source/StringBuilderExtensions.cs
@@ -114,6 +114,14 @@ namespace Moq
 			{
 				stringBuilder.Append('"').Append(str).Append('"');
 			}
+			else if (obj is float f)
+			{
+				stringBuilder.Append(f.ToString("G9"));
+			}
+			else if (obj is double d)
+			{
+				stringBuilder.Append(d.ToString("G17"));
+			}
 			else if (obj is IEnumerable enumerable && !(obj is IMocked))
 			{                                      // ^^^^^^^^^^^^^^^^^
 			                                       // This second check ensures that we have a usable implementation of IEnumerable.


### PR DESCRIPTION
`Single.ToString()` and `Double.ToString()` use the `"G"` format specifier by default, which does not include all significant digits in the produced output.

Change the diagnostic formatting code so that it uses a round tripping representation for floating point numbers (like e.g. the Visual Studio debugger does, too). Instead of the somewhat unreliable `"R"` specifier, use `"G9"` (for singles) and `"G17"` (for doubles) as documented on [Standard Numeric Format Strings: The General ("G") Format Specifier](https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#the-general-g-format-specifier).

This closes #636.