### PR TITLE
Add missing dependency to `System.Reflection.Emit`

### DIFF
--- a/Moq.nuspec
+++ b/Moq.nuspec
@@ -21,6 +21,7 @@
 			<group targetFramework=".NETStandard1.3">
 				<dependency id="NETStandard.Library" version="1.6.1" />
 				<dependency id="System.Linq.Queryable" version="4.3.0" />
+				<dependency id="System.Reflection.Emit" version="4.3.0" />
 				<dependency id="System.Reflection.TypeExtensions" version="4.3.0" />
 				<dependency id="Castle.Core" version="4.3.1" />
 				<dependency id="System.Threading.Tasks.Extensions" version="4.3.0" />

--- a/Source/Moq.csproj
+++ b/Source/Moq.csproj
@@ -42,6 +42,7 @@
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
 		<PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
+		<PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
 		<PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
Moq doesn't just require the `System.Reflection.Emit` package because `Castle.Core` requires it; Moq also uses the functionality provided by that package directly when mocking delegate types. Therefore, add it
as an explicit dependency.