### PR TITLE
The condition determining whether a parameter is 'out' parameter is changed

### DIFF
--- a/Source/MethodCall.cs
+++ b/Source/MethodCall.cs
@@ -130,7 +130,8 @@ namespace Moq
 				var argument = arguments[index];
 				if (parameter.ParameterType.IsByRef)
 				{
-					if ((parameter.Attributes & ParameterAttributes.Out) == ParameterAttributes.Out)
+					if ((parameter.Attributes & ParameterAttributes.Out) == ParameterAttributes.Out &&
+						(parameter.Attributes & ParameterAttributes.In) != ParameterAttributes.In)
 					{
 						// `out` parameter
 

--- a/Source/MethodCall.cs
+++ b/Source/MethodCall.cs
@@ -130,8 +130,7 @@ namespace Moq
 				var argument = arguments[index];
 				if (parameter.ParameterType.IsByRef)
 				{
-					if ((parameter.Attributes & ParameterAttributes.Out) == ParameterAttributes.Out &&
-						(parameter.Attributes & ParameterAttributes.In) != ParameterAttributes.In)
+					if ((parameter.Attributes & (ParameterAttributes.In | ParameterAttributes.Out)) == ParameterAttributes.Out)
 					{
 						// `out` parameter
 


### PR DESCRIPTION
According to [that](https://www.codeproject.com/Articles/990/Understanding-Classic-COM-Interoperability-With-NE) rules ('Mapping method parameter keywords in C# to IDL's Directional attributes' section) and [MSDN description](https://docs.microsoft.com/en-us/previous-versions/visualstudio/visual-studio-2008/77e6taeh(v=vs.90)) about Directional Attributes, the c# 'out' method parameter keyword maps to only [out] directional attribute. But in the current implementation if the parameter has [in,out] directional attributes the Moq framework is gonna take it as 'out' parameter, which is wrong, because according to the rules in the article and msdn reference i posted above it gotta take it as 'ref' parameter, not the out. This situation may ocuur for example when you try to mock the COM interface, which has a method with [in,out] directional attributes in COM layer. In interop assembly this method wil be presented as 'ref' parameter, but moq framework is gonna see it as 'out' therefore you are not gonna be able to mock this method propperly and use it unit tests. So when determining the 'out' parameter we need to see not only that 'out' directional attribute is present, but that 'In' directional attribute is not present or otherwise it is the 'ref' parameter not the 'out'.