### PR TITLE
Align Returns with Callback method signature matching by being permissive about when HasCompatibleParameterList returned true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 * More precise `out` parameter detection for mocking COM interfaces with `[in,out]` parameters (@koutinho, #645)
 * Prevent false 'Different number of parameters' error with `Returns` callback methods that have been compiled from `Expression`s (@stakx, #654)
+* Align `Returns` with `Callback` method signature matching by being permissive about when `HasCompatibleParameterList` returned true (@idigra, #654).
 
 
 ## 4.9.0 (2018-07-13)

--- a/src/Moq/MethodCallReturn.cs
+++ b/src/Moq/MethodCallReturn.cs
@@ -171,6 +171,13 @@ namespace Moq
 		{
 			var callbackMethod = callback.GetMethodInfo();
 
+			var expectedParams = this.Method.GetParameters();
+			var actualParams = callback.GetMethodInfo().GetParameters();
+			if (callback.HasCompatibleParameterList(expectedParams))
+			{
+				return;
+			}
+
 			// validate number of parameters:
 
 			var numberOfActualParameters = callbackMethod.GetParameters().Length;


### PR DESCRIPTION
Opened following a discussion in https://github.com/moq/moq4/issues/652.
Can be pulled depends on the decision in this discussion.