### PR TITLE
WIP: Mock only the explicitly implemented method when another method with the same signature is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 * More precise `out` parameter detection for mocking COM interfaces with `[in,out]` parameters (@koutinho, #645)
 * Prevent false 'Different number of parameters' error with `Returns` callback methods that have been compiled from `Expression`s (@stakx, #654)
+* Mock only the explicitly implemented method when another method with the same signature is present (@stakx, #658)
 
 
 ## 4.9.0 (2018-07-13)

--- a/tests/Moq.Tests/AsInterfaceFixture.cs
+++ b/tests/Moq.Tests/AsInterfaceFixture.cs
@@ -168,6 +168,33 @@ namespace Moq.Tests
 			bag.Get("test");
 		}
 
+		[Fact]
+		public void Setup_targets_method_implementing_interface_not_other_method_with_same_signature()
+		{
+			var mock = new Mock<Service>() { CallBase = true };
+			mock.As<IService>().Setup(m => m.GetValue()).Returns(3);
+
+			// The public method should have been left alone since it's not the one implementing `IService`:
+			var valueOfOtherMethod = mock.Object.GetValue();
+			Assert.Equal(1, valueOfOtherMethod);
+
+			// The method implementing the interface method should have be mocked:
+			var valueOfSetupMethod = ((IService)mock.Object).GetValue();
+			Assert.Equal(3, valueOfSetupMethod);
+		}
+
+		public class Service : IService
+		{
+			public virtual int GetValue() => 1;
+
+			int IService.GetValue() => 2;
+		}
+
+		public interface IService
+		{
+			int GetValue();
+		}
+
 		// see also test fixture `Issue458` in `IssueReportsFixture`
 
 		public interface IFoo


### PR DESCRIPTION
**This is a work in progress; not to be merged just yet.**

Given two mockable methods with the same signature (same name and same parameters), where one implements an interface method explicitly, setting up that one via `.As<TInterface>()` leads to the other method being mocked, too. Seems like Moq incorrect matches methods somewhere.

This will fix #657.