### PR TITLE
Move matcher selection logic into `MatcherFactory`

### DIFF
--- a/src/Moq/MatcherFactory.cs
+++ b/src/Moq/MatcherFactory.cs
@@ -89,20 +89,18 @@ namespace Moq
 					return new RefMatcher(constant.Value);
 				}
 			}
+			else if (parameter.IsDefined(typeof(ParamArrayAttribute), true) && (argument.NodeType == ExpressionType.NewArrayInit || !argument.Type.IsArray))
+			{
+				return new ParamArrayMatcher((NewArrayExpression)argument);
+			}
 			else
 			{
-				var isParamArray = parameter.IsDefined(typeof(ParamArrayAttribute), true);
-				return MatcherFactory.CreateMatcher(argument, isParamArray);
+				return MatcherFactory.CreateMatcher(argument);
 			}
 		}
 
-		public static IMatcher CreateMatcher(Expression expression, bool isParams)
+		public static IMatcher CreateMatcher(Expression expression)
 		{
-			if (isParams && (expression.NodeType == ExpressionType.NewArrayInit || !expression.Type.IsArray))
-			{
-				return new ParamArrayMatcher((NewArrayExpression)expression);
-			}
-
 			// Type inference on the call might 
 			// do automatic conversion to the desired 
 			// method argument type, and a Convert expression type 

--- a/src/Moq/MatcherFactory.cs
+++ b/src/Moq/MatcherFactory.cs
@@ -43,14 +43,59 @@ using System.Globalization;
 using System.Linq.Expressions;
 using Moq.Properties;
 using Moq.Matchers;
-#if NETCORE
 using System.Reflection;
-#endif
 
 namespace Moq
 {
 	internal static class MatcherFactory
 	{
+		public static IMatcher CreateMatcher(Expression argument, ParameterInfo parameter)
+		{
+			if (parameter.ParameterType.IsByRef)
+			{
+				if ((parameter.Attributes & (ParameterAttributes.In | ParameterAttributes.Out)) == ParameterAttributes.Out)
+				{
+					// `out` parameter
+					return AnyMatcher.Instance;
+				}
+				else
+				{
+					// `ref` parameter
+
+					// Test for special case: `It.Ref<TValue>.IsAny`
+					if (argument is MemberExpression memberExpression)
+					{
+						var member = memberExpression.Member;
+						if (member.Name == nameof(It.Ref<object>.IsAny))
+						{
+							var memberDeclaringType = member.DeclaringType;
+							if (memberDeclaringType.GetTypeInfo().IsGenericType)
+							{
+								var memberDeclaringTypeDefinition = memberDeclaringType.GetGenericTypeDefinition();
+								if (memberDeclaringTypeDefinition == typeof(It.Ref<>))
+								{
+									return AnyMatcher.Instance;
+								}
+							}
+						}
+					}
+
+					var constant = argument.PartialEval() as ConstantExpression;
+					if (constant == null)
+					{
+						throw new NotSupportedException(Resources.RefExpressionMustBeConstantValue);
+					}
+
+					return new RefMatcher(constant.Value);
+				}
+			}
+			else
+			{
+				var isParamArray = parameter.IsDefined(typeof(ParamArrayAttribute), true);
+				return MatcherFactory.CreateMatcher(argument, isParamArray);
+			}
+		}
+
 		public static IMatcher CreateMatcher(Expression expression, bool isParams)
 		{
 			if (isParams && (expression.NodeType == ExpressionType.NewArrayInit || !expression.Type.IsArray))

--- a/src/Moq/Matchers/ParamArrayMatcher.cs
+++ b/src/Moq/Matchers/ParamArrayMatcher.cs
@@ -53,7 +53,7 @@ namespace Moq.Matchers
 			if (expression != null)
 			{
 				this.matchers = expression.Expressions
-					.Select(e => MatcherFactory.CreateMatcher(e, false)).ToArray();
+					.Select(e => MatcherFactory.CreateMatcher(e)).ToArray();
 			}
 			else
 			{

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -133,19 +133,6 @@ namespace Moq
 					if ((parameter.Attributes & (ParameterAttributes.In | ParameterAttributes.Out)) == ParameterAttributes.Out)
 					{
 						// `out` parameter
-
-						var constant = argument.PartialEval() as ConstantExpression;
-						if (constant == null)
-						{
-							throw new NotSupportedException(Resources.OutExpressionMustBeConstantValue);
-						}
-
-						if (outValues == null)
-						{
-							outValues = new List<KeyValuePair<int, object>>();
-						}
-
-						outValues.Add(new KeyValuePair<int, object>(index, constant.Value));
 						this.argumentMatchers[index] = AnyMatcher.Instance;
 					}
 					else
@@ -184,6 +171,29 @@ namespace Moq
 				{
 					var isParamArray = parameter.IsDefined(typeof(ParamArrayAttribute), true);
 					this.argumentMatchers[index] = MatcherFactory.CreateMatcher(argument, isParamArray);
+				}
+			}
+
+			for (int index = 0; index < parameters.Length; index++)
+			{
+				var parameter = parameters[index];
+				if (parameter.ParameterType.IsByRef)
+				{
+					if ((parameter.Attributes & (ParameterAttributes.In | ParameterAttributes.Out)) == ParameterAttributes.Out)
+					{
+						var constant = arguments[index].PartialEval() as ConstantExpression;
+						if (constant == null)
+						{
+							throw new NotSupportedException(Resources.OutExpressionMustBeConstantValue);
+						}
+
+						if (outValues == null)
+						{
+							outValues = new List<KeyValuePair<int, object>>();
+						}
+
+						outValues.Add(new KeyValuePair<int, object>(index, constant.Value));
+					}
 				}
 			}
 

--- a/tests/Moq.Tests/Matchers/AnyMatcherFixture.cs
+++ b/tests/Moq.Tests/Matchers/AnyMatcherFixture.cs
@@ -11,7 +11,7 @@ namespace Moq.Tests.Matchers
 		{
 			var expr = ToExpression<object>(() => It.IsAny<object>()).Body;
 
-			var matcher = MatcherFactory.CreateMatcher(expr, false);
+			var matcher = MatcherFactory.CreateMatcher(expr);
 
 			Assert.True(matcher.Matches(null));
 		}
@@ -21,7 +21,7 @@ namespace Moq.Tests.Matchers
 		{
 			var expr = ToExpression<object>(() => It.IsAny<object>()).Body;
 
-			var matcher = MatcherFactory.CreateMatcher(expr, false);
+			var matcher = MatcherFactory.CreateMatcher(expr);
 
 			Assert.True(matcher.Matches("foo"));
 		}
@@ -31,7 +31,7 @@ namespace Moq.Tests.Matchers
 		{
 			var expr = ToExpression<IDisposable>(() => It.IsAny<IDisposable>()).Body;
 
-			var matcher = MatcherFactory.CreateMatcher(expr, false);
+			var matcher = MatcherFactory.CreateMatcher(expr);
 
 			Assert.True(matcher.Matches(new Disposable()));
 		}
@@ -41,7 +41,7 @@ namespace Moq.Tests.Matchers
 		{
 			var expr = ToExpression<IFormatProvider>(() => It.IsAny<IFormatProvider>()).Body;
 
-			var matcher = MatcherFactory.CreateMatcher(expr, false);
+			var matcher = MatcherFactory.CreateMatcher(expr);
 
 			Assert.False(matcher.Matches("foo"));
 		}


### PR DESCRIPTION
Logic for creating argument matchers from argument expressions has so far been spread over `MatcherFactory` and one `MethodCall` ctor. This refactoring places all of it where it belongs: into `MatcherFactory`.
    
This comes at the small additional cost of iterating over arguments a second time to identify `out` parameters and gather their values, but the added code clarity and clearer responsibilities seem worth it.