### PR TITLE
Extract invocation matching logic into `InvocationShape`

### DIFF
--- a/src/Moq/InvocationShape.cs
+++ b/src/Moq/InvocationShape.cs
@@ -40,7 +40,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 
 namespace Moq
@@ -52,6 +54,12 @@ namespace Moq
 	{
 		private readonly MethodInfo method;
 		private readonly IMatcher[] argumentMatchers;
+
+		public InvocationShape(MethodInfo method, IReadOnlyList<Expression> arguments)
+		{
+			this.method = method;
+			this.argumentMatchers = GetArgumentMatchers(arguments, method.GetParameters());
+		}
 
 		public InvocationShape(MethodInfo method, IMatcher[] argumentMatchers)
 		{
@@ -115,6 +123,21 @@ namespace Moq
 			}
 
 			return false;
+		}
+
+		private static IMatcher[] GetArgumentMatchers(IReadOnlyList<Expression> arguments, ParameterInfo[] parameters)
+		{
+			Debug.Assert(arguments != null);
+			Debug.Assert(parameters != null);
+			Debug.Assert(arguments.Count == parameters.Length);
+
+			var n = parameters.Length;
+			var argumentMatchers = new IMatcher[n];
+			for (int i = 0; i < n; ++i)
+			{
+				argumentMatchers[i] = MatcherFactory.CreateMatcher(arguments[i], parameters[i]);
+			}
+			return argumentMatchers;
 		}
 
 		private sealed class AssignmentCompatibilityTypeComparer : IEqualityComparer<Type>

--- a/src/Moq/InvocationShape.cs
+++ b/src/Moq/InvocationShape.cs
@@ -1,0 +1,132 @@
+//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//https://github.com/moq/moq4
+//All rights reserved.
+//
+//Redistribution and use in source and binary forms,
+//with or without modification, are permitted provided
+//that the following conditions are met:
+//
+//    * Redistributions of source code must retain the
+//    above copyright notice, this list of conditions and
+//    the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce
+//    the above copyright notice, this list of conditions
+//    and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
+//    names of its contributors may be used to endorse
+//    or promote products derived from this software
+//    without specific prior written permission.
+//
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+//SUCH DAMAGE.
+//
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Moq
+{
+	/// <summary>
+	///   Describes the "shape" of an invocation against which concrete <see cref="Invocation"/>s can be matched.
+	/// </summary>
+	internal readonly struct InvocationShape
+	{
+		private readonly MethodInfo method;
+		private readonly IMatcher[] argumentMatchers;
+
+		public InvocationShape(MethodInfo method, IMatcher[] argumentMatchers)
+		{
+			this.method = method;
+			this.argumentMatchers = argumentMatchers;
+		}
+
+		public IReadOnlyList<IMatcher> ArgumentMatchers => this.argumentMatchers;
+
+		public MethodInfo Method => this.method;
+
+		public bool IsMatch(Invocation invocation)
+		{
+			var arguments = invocation.Arguments;
+			if (this.argumentMatchers.Length != arguments.Length)
+			{
+				return false;
+			}
+
+			if (this.IsEqualMethodOrOverride(invocation.Method))
+			{
+				for (int i = 0, n = this.argumentMatchers.Length; i < n; ++i)
+				{
+					if (this.argumentMatchers[i].Matches(arguments[i]) == false)
+					{
+						return false;
+					}
+				}
+
+				return true;
+			}
+
+			return false;
+		}
+
+		private bool IsEqualMethodOrOverride(MethodInfo invocationMethod)
+		{
+			var method = this.method;
+
+			if (invocationMethod == method)
+			{
+				return true;
+			}
+
+			if (method.DeclaringType.IsAssignableFrom(invocationMethod.DeclaringType))
+			{
+				if (!method.Name.Equals(invocationMethod.Name, StringComparison.Ordinal) ||
+					method.ReturnType != invocationMethod.ReturnType ||
+					!method.IsGenericMethod &&
+					!invocationMethod.HasSameParameterTypesAs(method))
+				{
+					return false;
+				}
+
+				if (method.IsGenericMethod && !invocationMethod.GetGenericArguments().SequenceEqual(method.GetGenericArguments(), AssignmentCompatibilityTypeComparer.Instance))
+				{
+					return false;
+				}
+
+				return true;
+			}
+
+			return false;
+		}
+
+		private sealed class AssignmentCompatibilityTypeComparer : IEqualityComparer<Type>
+		{
+			public static readonly AssignmentCompatibilityTypeComparer Instance = new AssignmentCompatibilityTypeComparer();
+
+			public bool Equals(Type x, Type y)
+			{
+				return y.IsAssignableFrom(x);
+			}
+
+			int IEqualityComparer<Type>.GetHashCode(Type obj) => throw new NotSupportedException();
+		}
+	}
+}

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -82,13 +82,12 @@ namespace Moq
 
 	internal partial class MethodCall : ICallbackResult, IVerifies, IThrowsResult
 	{
-		private IMatcher[] argumentMatchers;
 		private Action<object[]> callbackResponse;
 		private int callCount;
 		private Condition condition;
+		private InvocationShape expectation;
 		private int? expectedMaxCallCount;
 		private string failMessage;
-		private MethodInfo method;
 		private Mock mock;
 #if !NETCORE
 		private string originalCallerFilePath;
@@ -108,23 +107,20 @@ namespace Moq
 		public MethodCall(Mock mock, Condition condition, LambdaExpression originalExpression, MethodInfo method, IMatcher[] argumentMatchers)
 		{
 			this.condition = condition;
-			this.method = method;
+			this.expectation = new InvocationShape(method, argumentMatchers);
 			this.mock = mock;
 			this.originalExpression = originalExpression;
-
-			this.argumentMatchers = argumentMatchers;
 			this.outValues = null;
 		}
 
 		public MethodCall(Mock mock, Condition condition, LambdaExpression originalExpression, MethodInfo method, IReadOnlyList<Expression> arguments)
 		{
+			var parameters = method.GetParameters();
+
 			this.condition = condition;
-			this.method = method;
+			this.expectation = new InvocationShape(method, GetArgumentMatchers(arguments, parameters));
 			this.mock = mock;
 			this.originalExpression = originalExpression;
-
-			var parameters = method.GetParameters();
-			this.argumentMatchers = GetArgumentMatchers(arguments, parameters);
 			this.outValues = GetOutValues(arguments, parameters);
 
 			this.SetFileInfo();
@@ -179,7 +175,7 @@ namespace Moq
 			set => this.failMessage = value;
 		}
 
-		public MethodInfo Method => this.method;
+		public MethodInfo Method => this.expectation.Method;
 
 		public Mock Mock => this.mock;
 
@@ -241,26 +237,7 @@ namespace Moq
 
 		public bool Matches(Invocation invocation)
 		{
-			var arguments = invocation.Arguments;
-			if  (this.argumentMatchers.Length != arguments.Length)
-			{
-				return false;
-			}
-
-			if (this.IsEqualMethodOrOverride(invocation.Method))
-			{
-				for (int i = 0, n = this.argumentMatchers.Length; i < n; ++i)
-				{
-					if (this.argumentMatchers[i].Matches(arguments[i]) == false)
-					{
-						return false;
-					}
-				}
-
-				return condition == null || condition.IsTrue;
-			}
-
-			return false;
+			return this.expectation.IsMatch(invocation) && (condition == null || condition.IsTrue);
 		}
 
 		public void EvaluatedSuccessfully()
@@ -336,7 +313,7 @@ namespace Moq
 
 		protected virtual void SetCallbackWithArguments(Delegate callback)
 		{
-			var expectedParams = this.method.GetParameters();
+			var expectedParams = this.Method.GetParameters();
 			var actualParams = callback.GetMethodInfo().GetParameters();
 
 			if (!callback.HasCompatibleParameterList(expectedParams))
@@ -366,36 +343,6 @@ namespace Moq
 		{
 			this.verifiable = true;
 			this.failMessage = failMessage;
-		}
-
-		private bool IsEqualMethodOrOverride(MethodInfo invocationMethod)
-		{
-			var method = this.method;
-
-			if (invocationMethod == method)
-			{
-				return true;
-			}
-
-			if (method.DeclaringType.IsAssignableFrom(invocationMethod.DeclaringType))
-			{
-				if (!method.Name.Equals(invocationMethod.Name, StringComparison.Ordinal) ||
-					method.ReturnType != invocationMethod.ReturnType ||
-					!method.IsGenericMethod &&
-					!invocationMethod.HasSameParameterTypesAs(method))
-				{
-					return false;
-				}
-
-				if (method.IsGenericMethod && !invocationMethod.GetGenericArguments().SequenceEqual(method.GetGenericArguments(), AssignmentCompatibilityTypeComparer.Instance))
-				{
-					return false;
-				}
-
-				return true;
-			}
-
-			return false;
 		}
 
 		public IVerifies AtMostOnce() => this.AtMost(1);
@@ -486,18 +433,6 @@ namespace Moq
 			}
 
 			return builder.ToString();
-		}
-
-		private sealed class AssignmentCompatibilityTypeComparer : IEqualityComparer<Type>
-		{
-			public static AssignmentCompatibilityTypeComparer Instance { get; } = new AssignmentCompatibilityTypeComparer();
-
-			public bool Equals(Type x, Type y)
-			{
-				return y.IsAssignableFrom(x);
-			}
-
-			int IEqualityComparer<Type>.GetHashCode(Type obj) => throw new NotSupportedException();
 		}
 
 		private sealed class RaiseEventResponse

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -115,30 +115,13 @@ namespace Moq
 
 		public MethodCall(Mock mock, Condition condition, LambdaExpression originalExpression, MethodInfo method, IReadOnlyList<Expression> arguments)
 		{
-			var parameters = method.GetParameters();
-
 			this.condition = condition;
-			this.expectation = new InvocationShape(method, GetArgumentMatchers(arguments, parameters));
+			this.expectation = new InvocationShape(method, arguments);
 			this.mock = mock;
 			this.originalExpression = originalExpression;
-			this.outValues = GetOutValues(arguments, parameters);
+			this.outValues = GetOutValues(arguments, method.GetParameters());
 
 			this.SetFileInfo();
-		}
-
-		private static IMatcher[] GetArgumentMatchers(IReadOnlyList<Expression> arguments, ParameterInfo[] parameters)
-		{
-			Debug.Assert(arguments != null);
-			Debug.Assert(parameters != null);
-			Debug.Assert(arguments.Count == parameters.Length);
-
-			var n = parameters.Length;
-			var argumentMatchers = new IMatcher[n];
-			for (int i = 0; i < n; ++i)
-			{
-				argumentMatchers[i] = MatcherFactory.CreateMatcher(arguments[i], parameters[i]);
-			}
-			return argumentMatchers;
 		}
 
 		private static List<KeyValuePair<int, object>> GetOutValues(IReadOnlyList<Expression> arguments, ParameterInfo[] parameters)

--- a/src/Moq/MockException.cs
+++ b/src/Moq/MockException.cs
@@ -103,7 +103,7 @@ namespace Moq
 		///   Returns the exception to be thrown when <see cref="Mock.Verify"/> finds no invocations (or the wrong number of invocations) that match the specified expectation.
 		/// </summary>
 		internal static MockException NoMatchingCalls(
-			MethodCall expected,
+			string failMessage,
 			IEnumerable<MethodCall> setups,
 			IEnumerable<Invocation> invocations,
 			LambdaExpression expression,
@@ -112,7 +112,7 @@ namespace Moq
 		{
 			return new MockException(
 				MockExceptionReason.NoMatchingCalls,
-				times.GetExceptionMessage(expected.FailMessage, expression.PartialMatcherAwareEval().ToStringFixed(), callCount) +
+				times.GetExceptionMessage(failMessage, expression.PartialMatcherAwareEval().ToStringFixed(), callCount) +
 				Environment.NewLine + FormatSetupsInfo() +
 				Environment.NewLine + FormatInvocations());
 

--- a/src/Moq/Obsolete/Mock.Legacy.cs
+++ b/src/Moq/Obsolete/Mock.Legacy.cs
@@ -41,6 +41,8 @@
 using System;
 using System.Linq.Expressions;
 
+using Moq.Matchers;
+
 namespace Moq
 {
 	// Keeps legacy implementations.
@@ -57,11 +59,8 @@ namespace Moq
 			var method = expression.ToPropertyInfo().SetMethod;
 			ThrowIfVerifyExpressionInvolvesUnsupportedMember(expression, method);
 
-			var expected = new SetterMethodCall<T, TProperty>(mock, expression, method)
-			{
-				FailMessage = failMessage
-			};
-			VerifyCalls(GetTargetMock(((MemberExpression)expression.Body).Expression, mock), expected, expression, times);
+			var expectation = new InvocationShape(method, new IMatcher[] { AnyMatcher.Instance });
+			VerifyCalls(GetTargetMock(((MemberExpression)expression.Body).Expression, mock), expectation, expression, times, failMessage);
 		}
 	}
 }


### PR DESCRIPTION
This refactoring moves all logic from `MethodCall` that is related to invocation matching into a dedicated new type, `InvocationShape`. This is useful mainly because of two reasons:

 1. The invocation matching becomes more easily testable once it is better isolated.

 2. Verification methods such as `mock.Verify(expression)` no longer need to instantiate a transient `MethodCall` (which at its heart really represents a setup) in order to match invocations. They will be able to use the much lighter-weight `InvocationShape` instead.