### PR TITLE
Add `setup.CallBase()` for void methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 #### Added
 
 * `ExpressionCompiler`: An extensibility point for setting up alternate LINQ expression tree compilation strategies (@stakx, #647)
+* `setup.CallBase()` for `void` methods (@stakx, #664)
 
 #### Fixed
 

--- a/src/Moq/Language/Flow/ICallBaseResult.cs
+++ b/src/Moq/Language/Flow/ICallBaseResult.cs
@@ -1,0 +1,52 @@
+//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//https://github.com/moq/moq4
+//All rights reserved.
+//
+//Redistribution and use in source and binary forms,
+//with or without modification, are permitted provided
+//that the following conditions are met:
+//
+//    * Redistributions of source code must retain the
+//    above copyright notice, this list of conditions and
+//    the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce
+//    the above copyright notice, this list of conditions
+//    and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
+//    names of its contributors may be used to endorse
+//    or promote products derived from this software
+//    without specific prior written permission.
+//
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+//SUCH DAMAGE.
+//
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System.ComponentModel;
+
+namespace Moq.Language.Flow
+{
+	/// <summary>
+	/// Implements the fluent API.
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public interface ICallBaseResult : IThrows, IThrowsResult, IFluentInterface
+	{
+	}
+}

--- a/src/Moq/Language/Flow/ICallbackResult.cs
+++ b/src/Moq/Language/Flow/ICallbackResult.cs
@@ -46,7 +46,7 @@ namespace Moq.Language.Flow
 	/// Implements the fluent API.
 	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
-	public interface ICallbackResult : IThrows, IThrowsResult, IFluentInterface
+	public interface ICallbackResult : ICallBase, ICallBaseResult, IThrows, IThrowsResult, IFluentInterface
 	{
 	}
 }

--- a/src/Moq/Language/Flow/NonVoidSetupPhrase.cs
+++ b/src/Moq/Language/Flow/NonVoidSetupPhrase.cs
@@ -162,9 +162,9 @@ namespace Moq.Language.Flow
 			return this;
 		}
 
-		public IReturnsResult<T> CallBase()
+		public new IReturnsResult<T> CallBase()
 		{
-			this.Setup.CallBase();
+			this.Setup.SetCallBaseResponse();
 			return this;
 		}
 

--- a/src/Moq/Language/Flow/SetupPhrase.cs
+++ b/src/Moq/Language/Flow/SetupPhrase.cs
@@ -172,6 +172,12 @@ namespace Moq.Language.Flow
 			return this;
 		}
 
+		public ICallBaseResult CallBase()
+		{
+			this.setup.SetCallBaseResponse();
+			return this;
+		}
+
 		public IThrowsResult Throws(Exception exception)
 		{
 			this.setup.SetThrowExceptionResponse(exception);

--- a/src/Moq/Language/ICallBase.cs
+++ b/src/Moq/Language/ICallBase.cs
@@ -1,0 +1,58 @@
+//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//https://github.com/moq/moq4
+//All rights reserved.
+//
+//Redistribution and use in source and binary forms,
+//with or without modification, are permitted provided
+//that the following conditions are met:
+//
+//    * Redistributions of source code must retain the
+//    above copyright notice, this list of conditions and
+//    the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce
+//    the above copyright notice, this list of conditions
+//    and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
+//    names of its contributors may be used to endorse
+//    or promote products derived from this software
+//    without specific prior written permission.
+//
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+//SUCH DAMAGE.
+//
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System.ComponentModel;
+
+using Moq.Language.Flow;
+
+namespace Moq.Language
+{
+	/// <summary>
+	/// Defines the <c>CallBase</c> verb.
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public interface ICallBase : IFluentInterface
+	{
+		/// <summary>
+		/// Calls the real method of the object.
+		/// </summary>
+		ICallBaseResult CallBase();
+	}
+}

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -228,6 +228,11 @@ namespace Moq
 			}
 		}
 
+		public virtual void SetCallBaseResponse()
+		{
+			throw new NotImplementedException();
+		}
+
 		public virtual void SetCallbackResponse(Delegate callback)
 		{
 			if (callback == null)

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -56,6 +56,7 @@ namespace Moq
 	internal partial class MethodCall
 	{
 		private Action<object[]> callbackResponse;
+		private bool callBase;
 		private int callCount;
 		private Condition condition;
 		private InvocationShape expectation;
@@ -220,6 +221,11 @@ namespace Moq
 
 			this.callbackResponse?.Invoke(invocation.Arguments);
 
+			if (this.callBase)
+			{
+				invocation.ReturnBase();
+			}
+
 			this.raiseEventResponse?.RespondTo(invocation);
 
 			if (this.throwExceptionResponse != null)
@@ -230,7 +236,7 @@ namespace Moq
 
 		public virtual void SetCallBaseResponse()
 		{
-			throw new NotImplementedException();
+			this.callBase = true;
 		}
 
 		public virtual void SetCallbackResponse(Delegate callback)

--- a/src/Moq/MethodCallReturn.cs
+++ b/src/Moq/MethodCallReturn.cs
@@ -74,11 +74,6 @@ namespace Moq
 
 		public Type ReturnType => this.Method.ReturnType;
 
-		public void CallBase()
-		{
-			this.returnValueKind = ReturnValueKind.CallBase;
-		}
-
 		public override void SetCallbackResponse(Delegate callback)
 		{
 			if (this.ProvidesReturnValue())
@@ -96,6 +91,11 @@ namespace Moq
 			{
 				base.SetCallbackResponse(callback);
 			}
+		}
+
+		public override void SetCallBaseResponse()
+		{
+			this.returnValueKind = ReturnValueKind.CallBase;
 		}
 
 		public void SetReturnsResponse(Delegate value)

--- a/tests/Moq.Tests/CallBaseFixture.cs
+++ b/tests/Moq.Tests/CallBaseFixture.cs
@@ -1,0 +1,48 @@
+using Xunit;
+
+namespace Moq.Tests
+{
+	public class CallBaseFixture
+	{
+		[Fact]
+		public void Void_method_in_base_class_not_called_when_CallBase_not_specified()
+		{
+			var mock = new Mock<Base>();
+
+			mock.Object.Method();
+
+			Assert.False(mock.Object.MethodInvoked);
+		}
+
+		[Fact]
+		public void Void_method_in_base_class_called_when_CallBase_specified_on_mock()
+		{
+			var mock = new Mock<Base>() { CallBase = true };
+
+			mock.Object.Method();
+
+			Assert.True(mock.Object.MethodInvoked);
+		}
+
+		[Fact]
+		public void Void_method_in_base_class_called_when_CallBase_specified_on_setup()
+		{
+			var mock = new Mock<Base>();
+			mock.Setup(m => m.Method()).CallBase();
+
+			mock.Object.Method();
+
+			Assert.True(mock.Object.MethodInvoked);
+		}
+
+		public class Base
+		{
+			public bool MethodInvoked { get; private set; }
+
+			public virtual void Method()
+			{
+				this.MethodInvoked = true;
+			}
+		}
+	}
+}


### PR DESCRIPTION
This closes #615.

Note that this adds a new minor inconsistency in the API: For non-void methods, it is possible to specify a `.Callback()` both before *and after* `.CallBase()`. The change proposed here only adds `.CallBase()` for void methods, but without the option of a subsequent call to `.Callback()`. It is left to a future PR to rectify this. (However, judging from [the original feature request on Google Code](https://code.google.com/archive/p/moq/issues/19) and the preceding discussion linked there, it seems unlikely that anyone would actually need this.)