### PR TITLE
Introduce new abstract base class `Setup`

### DIFF
--- a/src/Moq/AutoImplementedPropertyGetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertyGetterSetup.cs
@@ -51,18 +51,14 @@ namespace Moq
 	{
 		private static IMatcher[] noArgumentMatchers = new IMatcher[0];
 
-		private LambdaExpression expression;
 		private Func<object> getter;
 		private bool invoked;
 
 		public AutoImplementedPropertyGetterSetup(LambdaExpression originalExpression, MethodInfo method, Func<object> getter)
-			: base(new InvocationShape(method, noArgumentMatchers))
+			: base(new InvocationShape(method, noArgumentMatchers), originalExpression)
 		{
-			this.expression = originalExpression;
 			this.getter = getter;
 		}
-
-		public override LambdaExpression Expression => this.expression;
 
 		public override void Execute(Invocation invocation)
 		{

--- a/src/Moq/AutoImplementedPropertySetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertySetterSetup.cs
@@ -39,7 +39,6 @@
 // http://www.opensource.org/licenses/bsd-license.php]
 
 using System;
-using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -54,18 +53,14 @@ namespace Moq
 	{
 		private static IMatcher[] anyMatcherForSingleArgument = new IMatcher[] { AnyMatcher.Instance };
 
-		private LambdaExpression expression;
 		private Action<object> setter;
 		private bool invoked;
 
 		public AutoImplementedPropertySetterSetup(LambdaExpression originalExpression, MethodInfo method, Action<object> setter)
-			: base(new InvocationShape(method, anyMatcherForSingleArgument))
+			: base(new InvocationShape(method, anyMatcherForSingleArgument), originalExpression)
 		{
-			this.expression = originalExpression;
 			this.setter = setter;
 		}
-
-		public override LambdaExpression Expression => this.expression;
 
 		public override void Execute(Invocation invocation)
 		{

--- a/src/Moq/Interception/InterceptionAspects.cs
+++ b/src/Moq/Interception/InterceptionAspects.cs
@@ -154,7 +154,7 @@ namespace Moq
 			var matchedSetup = mock.Setups.FindMatchFor(invocation);
 			if (matchedSetup != null)
 			{
-				matchedSetup.EvaluatedSuccessfully();
+				matchedSetup.Condition?.EvaluatedSuccessfully();
 				matchedSetup.SetOutParameters(invocation);
 
 				// We first execute, as there may be a Throws 

--- a/src/Moq/Language/Flow/SetupSequencePhrase.cs
+++ b/src/Moq/Language/Flow/SetupSequencePhrase.cs
@@ -52,9 +52,9 @@ namespace Moq.Language.Flow
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	internal sealed class SetupSequencePhrase : ISetupSequentialAction
 	{
-		private SequenceMethodCall setup;
+		private SequenceSetup setup;
 
-		public SetupSequencePhrase(SequenceMethodCall setup)
+		public SetupSequencePhrase(SequenceSetup setup)
 		{
 			this.setup = setup;
 		}
@@ -78,9 +78,9 @@ namespace Moq.Language.Flow
 
 	internal sealed class SetupSequencePhrase<TResult> : ISetupSequentialResult<TResult>
 	{
-		private SequenceMethodCall setup;
+		private SequenceSetup setup;
 
-		public SetupSequencePhrase(SequenceMethodCall setup)
+		public SetupSequencePhrase(SequenceSetup setup)
 		{
 			this.setup = setup;
 		}

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -133,7 +133,7 @@ namespace Moq
 
 		public Mock Mock => this.mock;
 
-		public override LambdaExpression SetupExpression => this.originalExpression;
+		public override LambdaExpression Expression => this.originalExpression;
 
 		public override Condition Condition => this.condition;
 

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -53,7 +53,7 @@ using Moq.Properties;
 
 namespace Moq
 {
-	internal partial class MethodCall
+	internal partial class MethodCall : Setup
 	{
 		private Action<object[]> callbackResponse;
 		private bool callBase;
@@ -132,17 +132,17 @@ namespace Moq
 			set => this.failMessage = value;
 		}
 
-		public MethodInfo Method => this.expectation.Method;
+		public override MethodInfo Method => this.expectation.Method;
 
 		public Mock Mock => this.mock;
 
-		public bool IsConditional => this.condition != null;
+		public override bool IsConditional => this.condition != null;
 
-		public bool IsVerifiable => this.verifiable;
+		public override bool IsVerifiable => this.verifiable;
 
-		public bool Invoked => this.callCount > 0;
+		public override bool Invoked => this.callCount > 0;
 
-		public LambdaExpression SetupExpression => this.originalExpression;
+		public override LambdaExpression SetupExpression => this.originalExpression;
 
 		[Conditional("DESKTOP")]
 		[SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
@@ -179,7 +179,7 @@ namespace Moq
 #endif
 		}
 
-		public void SetOutParameters(Invocation invocation)
+		public override void SetOutParameters(Invocation invocation)
 		{
 			if (this.outValues == null)
 			{
@@ -192,18 +192,18 @@ namespace Moq
 			}
 		}
 
-		public bool Matches(Invocation invocation)
+		public override bool Matches(Invocation invocation)
 		{
 			return this.expectation.IsMatch(invocation) && (condition == null || condition.IsTrue);
 		}
 
-		public void EvaluatedSuccessfully()
+		public override void EvaluatedSuccessfully()
 		{
 			if (condition != null)
 				condition.EvaluatedSuccessfully();
 		}
 
-		public virtual void Execute(Invocation invocation)
+		public override void Execute(Invocation invocation)
 		{
 			++this.callCount;
 

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -73,19 +73,6 @@ namespace Moq
 		private Exception throwExceptionResponse;
 		private bool verifiable;
 
-		/// <remarks>
-		///   Only use this constructor when you know that the specified <paramref name="method"/> has no `out` parameters,
-		///   and when you want to avoid the <see cref="MatcherFactory"/>-related overhead of the other constructor overload.
-		/// </remarks>
-		public MethodCall(Mock mock, Condition condition, LambdaExpression originalExpression, MethodInfo method, IMatcher[] argumentMatchers)
-			: base(new InvocationShape(method, argumentMatchers))
-		{
-			this.condition = condition;
-			this.mock = mock;
-			this.originalExpression = originalExpression;
-			this.outValues = null;
-		}
-
 		public MethodCall(Mock mock, Condition condition, LambdaExpression originalExpression, MethodInfo method, IReadOnlyList<Expression> arguments)
 			: base(new InvocationShape(method, arguments))
 		{

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -139,7 +139,7 @@ namespace Moq
 
 		public override LambdaExpression SetupExpression => this.originalExpression;
 
-		protected override Condition Condition => this.condition;
+		public override Condition Condition => this.condition;
 
 		[Conditional("DESKTOP")]
 		[SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
@@ -187,12 +187,6 @@ namespace Moq
 			{
 				invocation.Arguments[item.Key] = item.Value;
 			}
-		}
-
-		public override void EvaluatedSuccessfully()
-		{
-			if (condition != null)
-				condition.EvaluatedSuccessfully();
 		}
 
 		public override void Execute(Invocation invocation)

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -67,18 +67,16 @@ namespace Moq
 		private int originalCallerLineNumber;
 		private MethodBase originalCallerMember;
 #endif
-		private LambdaExpression originalExpression;
 		private List<KeyValuePair<int, object>> outValues;
 		private RaiseEventResponse raiseEventResponse;
 		private Exception throwExceptionResponse;
 		private bool verifiable;
 
 		public MethodCall(Mock mock, Condition condition, LambdaExpression originalExpression, MethodInfo method, IReadOnlyList<Expression> arguments)
-			: base(new InvocationShape(method, arguments))
+			: base(new InvocationShape(method, arguments), originalExpression)
 		{
 			this.condition = condition;
 			this.mock = mock;
-			this.originalExpression = originalExpression;
 			this.outValues = GetOutValues(arguments, method.GetParameters());
 
 			this.SetFileInfo();
@@ -119,8 +117,6 @@ namespace Moq
 		}
 
 		public Mock Mock => this.mock;
-
-		public override LambdaExpression Expression => this.originalExpression;
 
 		public override Condition Condition => this.condition;
 

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -133,13 +133,11 @@ namespace Moq
 
 		public Mock Mock => this.mock;
 
-		public override bool IsVerifiable => this.verifiable;
-
-		public override bool Invoked => this.callCount > 0;
-
 		public override LambdaExpression SetupExpression => this.originalExpression;
 
 		public override Condition Condition => this.condition;
+
+		protected override bool IsVerifiable => this.verifiable;
 
 		[Conditional("DESKTOP")]
 		[SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
@@ -305,6 +303,11 @@ namespace Moq
 		public void SetThrowExceptionResponse(Exception exception)
 		{
 			this.throwExceptionResponse = exception;
+		}
+
+		public override bool TryVerifyAll()
+		{
+			return this.callCount > 0;
 		}
 
 		public void Verifiable()

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -334,10 +334,7 @@ namespace Moq
 				message.Append(this.failMessage).Append(": ");
 			}
 
-			var lambda = this.originalExpression.PartialMatcherAwareEval();
-			var targetTypeName = lambda.Parameters[0].Type.Name;
-
-			message.Append(targetTypeName).Append(" ").Append(lambda.ToStringFixed());
+			message.Append(base.ToString());
 
 #if !NETCORE
 			if (this.originalCallerMember != null && this.originalCallerFilePath != null && this.originalCallerLineNumber != 0)

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -258,7 +258,7 @@ namespace Moq
 				invocation.MarkAsVerifiedIfMatchedByVerifiableSetup();
 			}
 
-			var uninvokedVerifiableSetups = this.Setups.ToArrayLive(setup => setup.IsVerifiable && !setup.Invoked);
+			var uninvokedVerifiableSetups = this.Setups.ToArrayLive(setup => !setup.TryVerify());
 			if (uninvokedVerifiableSetups.Length > 0)
 			{
 				error = MockException.UnmatchedSetups(this, uninvokedVerifiableSetups);
@@ -293,7 +293,7 @@ namespace Moq
 				invocation.MarkAsVerifiedIfMatchedBySetup();
 			}
 
-			var uninvokedSetups = this.Setups.ToArrayLive(setup => !setup.Invoked);
+			var uninvokedSetups = this.Setups.ToArrayLive(setup => !setup.TryVerifyAll());
 			if (uninvokedSetups.Length > 0)
 			{
 				error = MockException.UnmatchedSetups(this, uninvokedSetups);

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -732,7 +732,7 @@ namespace Moq
 				ThrowIfSetupExpressionInvolvesUnsupportedMember(expression, propGet);
 				ThrowIfSetupMethodNotVisibleToProxyFactory(propGet);
 
-				var setup = new SequenceMethodCall(mock, expression, propGet, new Expression[0]);
+				var setup = new SequenceSetup(expression, propGet, new Expression[0]);
 				var targetMock = GetTargetMock(((MemberExpression)expression.Body).Expression, mock);
 				targetMock.Setups.Add(setup);
 				return new SetupSequencePhrase<TResult>(setup);
@@ -740,7 +740,7 @@ namespace Moq
 			else
 			{
 				var (obj, method, args) = expression.GetCallInfo(mock);
-				var setup = new SequenceMethodCall(mock, expression, method, args);
+				var setup = new SequenceSetup(expression, method, args);
 				var targetMock = GetTargetMock(obj, mock);
 				targetMock.Setups.Add(setup);
 				return new SetupSequencePhrase<TResult>(setup);
@@ -750,7 +750,7 @@ namespace Moq
 		internal static SetupSequencePhrase SetupSequence(Mock mock, LambdaExpression expression)
 		{
 			var (obj, method, args) = expression.GetCallInfo(mock);
-			var setup = new SequenceMethodCall(mock, expression, method, args);
+			var setup = new SequenceSetup(expression, method, args);
 			var targetMock = GetTargetMock(obj, mock);
 			targetMock.Setups.Add(setup);
 			return new SetupSequencePhrase(setup);

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -797,7 +797,7 @@ namespace Moq
 				object value = null;
 				bool valueNotSet = true;
 
-				mock.Setups.Add(new PropertyGetterMethodCall(mock, expression, getter, () =>
+				mock.Setups.Add(new AutoImplementedPropertyGetterSetup(expression, getter, () =>
 				{
 					if (valueNotSet)
 					{
@@ -827,7 +827,7 @@ namespace Moq
 
 				if (property.CanWrite)
 				{
-					mock.Setups.Add(new PropertySetterMethodCall(mock, expression, property.GetSetMethod(true), (newValue) =>
+					mock.Setups.Add(new AutoImplementedPropertySetterSetup(expression, property.GetSetMethod(true), (newValue) =>
 					{
 						value = newValue;
 						valueNotSet = false;

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -439,7 +439,7 @@ namespace Moq
 			var matchingInvocationCount = matchingInvocations.Length;
 			if (!times.Verify(matchingInvocationCount))
 			{
-				var setups = targetMock.Setups.ToArrayLive(oc => AreSameMethod(oc.SetupExpression, expression));
+				var setups = targetMock.Setups.ToArrayLive(oc => AreSameMethod(oc.Expression, expression));
 				throw MockException.NoMatchingCalls(failMessage, setups, allInvocations, expression, times, matchingInvocationCount);
 			}
 			else

--- a/src/Moq/MockException.cs
+++ b/src/Moq/MockException.cs
@@ -104,7 +104,7 @@ namespace Moq
 		/// </summary>
 		internal static MockException NoMatchingCalls(
 			string failMessage,
-			IEnumerable<MethodCall> setups,
+			IEnumerable<Setup> setups,
 			IEnumerable<Invocation> invocations,
 			LambdaExpression expression,
 			Times times,
@@ -165,7 +165,7 @@ namespace Moq
 		/// <summary>
 		///   Returns the exception to be thrown when <see cref="Mock.Verify"/> or <see cref="MockFactory.Verify"/> find a setup that has not been invoked.
 		/// </summary>
-		internal static MockException UnmatchedSetups(Mock mock, IEnumerable<MethodCall> setups)
+		internal static MockException UnmatchedSetups(Mock mock, IEnumerable<Setup> setups)
 		{
 			return new MockException(
 				MockExceptionReason.UnmatchedSetups,

--- a/src/Moq/MockException.cs
+++ b/src/Moq/MockException.cs
@@ -86,7 +86,7 @@ namespace Moq
 		{
 			return new MockException(
 				MockExceptionReason.MoreThanOneCall,
-				Times.AtMostOnce().GetExceptionMessage(setup.FailMessage, setup.SetupExpression.ToStringFixed(), invocationCount));
+				Times.AtMostOnce().GetExceptionMessage(setup.FailMessage, setup.Expression.ToStringFixed(), invocationCount));
 		}
 
 		/// <summary>
@@ -96,7 +96,7 @@ namespace Moq
 		{
 			return new MockException(
 				MockExceptionReason.MoreThanNCalls,
-				Times.AtMost(maxInvocationCount).GetExceptionMessage(setup.FailMessage, setup.SetupExpression.ToStringFixed(), invocationCount));
+				Times.AtMost(maxInvocationCount).GetExceptionMessage(setup.FailMessage, setup.Expression.ToStringFixed(), invocationCount));
 		}
 
 		/// <summary>

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -40,6 +40,7 @@
 
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Text;
 
 namespace Moq
 {
@@ -52,9 +53,9 @@ namespace Moq
 			this.expectation = expectation;
 		}
 
-		public abstract Condition Condition { get; }
+		public virtual Condition Condition => null;
 
-		public abstract bool IsVerifiable { get; }
+		public virtual bool IsVerifiable => false;
 
 		public abstract bool Invoked { get; }
 
@@ -69,8 +70,21 @@ namespace Moq
 			return this.expectation.IsMatch(invocation) && (this.Condition == null || this.Condition.IsTrue);
 		}
 
-		public abstract void SetOutParameters(Invocation invocation);
+		public virtual void SetOutParameters(Invocation invocation)
+		{
+		}
 
-		public abstract override string ToString();
+		public override string ToString()
+		{
+			var expression = this.SetupExpression.PartialMatcherAwareEval();
+			var mockedType = this.SetupExpression.Parameters[0].Type;
+
+			var builder = new StringBuilder();
+			builder.AppendNameOf(mockedType)
+			       .Append(' ')
+			       .Append(expression.ToStringFixed());
+
+			return builder.ToString();
+		}
 	}
 }

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -1,0 +1,72 @@
+//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//https://github.com/moq/moq4
+//All rights reserved.
+//
+//Redistribution and use in source and binary forms,
+//with or without modification, are permitted provided
+//that the following conditions are met:
+//
+//    * Redistributions of source code must retain the
+//    above copyright notice, this list of conditions and
+//    the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce
+//    the above copyright notice, this list of conditions
+//    and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
+//    names of its contributors may be used to endorse
+//    or promote products derived from this software
+//    without specific prior written permission.
+//
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+//SUCH DAMAGE.
+//
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Moq
+{
+	internal abstract class Setup
+	{
+		protected Setup()
+		{
+		}
+
+		public abstract bool IsConditional { get; }
+
+		public abstract bool IsVerifiable { get; }
+
+		public abstract bool Invoked { get; }
+
+		public abstract MethodInfo Method { get; }
+
+		public abstract LambdaExpression SetupExpression { get; }
+
+		public abstract void EvaluatedSuccessfully();
+
+		public abstract void Execute(Invocation invocation);
+
+		public abstract bool Matches(Invocation invocation);
+
+		public abstract void SetOutParameters(Invocation invocation);
+
+		public abstract override string ToString();
+	}
+}

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -52,9 +52,7 @@ namespace Moq
 			this.expectation = expectation;
 		}
 
-		protected abstract Condition Condition { get; }
-
-		public bool IsConditional => this.Condition != null;
+		public abstract Condition Condition { get; }
 
 		public abstract bool IsVerifiable { get; }
 
@@ -64,13 +62,11 @@ namespace Moq
 
 		public abstract LambdaExpression SetupExpression { get; }
 
-		public abstract void EvaluatedSuccessfully();
-
 		public abstract void Execute(Invocation invocation);
 
 		public bool Matches(Invocation invocation)
 		{
-			return this.expectation.IsMatch(invocation) && (!this.IsConditional || this.Condition.IsTrue);
+			return this.expectation.IsMatch(invocation) && (this.Condition == null || this.Condition.IsTrue);
 		}
 
 		public abstract void SetOutParameters(Invocation invocation);

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -55,13 +55,11 @@ namespace Moq
 
 		public virtual Condition Condition => null;
 
-		public virtual bool IsVerifiable => false;
-
-		public abstract bool Invoked { get; }
-
 		public MethodInfo Method => this.expectation.Method;
 
 		public abstract LambdaExpression SetupExpression { get; }
+
+		protected virtual bool IsVerifiable => false;
 
 		public abstract void Execute(Invocation invocation);
 
@@ -86,5 +84,12 @@ namespace Moq
 
 			return builder.ToString();
 		}
+
+		public bool TryVerify()
+		{
+			return !this.IsVerifiable || this.TryVerifyAll();
+		}
+
+		public abstract bool TryVerifyAll();
 	}
 }

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -38,6 +38,7 @@
 //[This is the BSD license, see
 // http://www.opensource.org/licenses/bsd-license.php]
 
+using System.Diagnostics;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
@@ -47,15 +48,19 @@ namespace Moq
 	internal abstract class Setup
 	{
 		private readonly InvocationShape expectation;
+		private readonly LambdaExpression expression;
 
-		protected Setup(InvocationShape expectation)
+		protected Setup(InvocationShape expectation, LambdaExpression expression)
 		{
+			Debug.Assert(expression != null);
+
 			this.expectation = expectation;
+			this.expression = expression;
 		}
 
 		public virtual Condition Condition => null;
 
-		public abstract LambdaExpression Expression { get; }
+		public LambdaExpression Expression => this.expression;
 
 		public MethodInfo Method => this.expectation.Method;
 
@@ -74,8 +79,8 @@ namespace Moq
 
 		public override string ToString()
 		{
-			var expression = this.Expression.PartialMatcherAwareEval();
-			var mockedType = this.Expression.Parameters[0].Type;
+			var expression = this.expression.PartialMatcherAwareEval();
+			var mockedType = this.expression.Parameters[0].Type;
 
 			var builder = new StringBuilder();
 			builder.AppendNameOf(mockedType)

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -55,9 +55,9 @@ namespace Moq
 
 		public virtual Condition Condition => null;
 
-		public MethodInfo Method => this.expectation.Method;
+		public abstract LambdaExpression Expression { get; }
 
-		public abstract LambdaExpression SetupExpression { get; }
+		public MethodInfo Method => this.expectation.Method;
 
 		protected virtual bool IsVerifiable => false;
 
@@ -74,8 +74,8 @@ namespace Moq
 
 		public override string ToString()
 		{
-			var expression = this.SetupExpression.PartialMatcherAwareEval();
-			var mockedType = this.SetupExpression.Parameters[0].Type;
+			var expression = this.Expression.PartialMatcherAwareEval();
+			var mockedType = this.Expression.Parameters[0].Type;
 
 			var builder = new StringBuilder();
 			builder.AppendNameOf(mockedType)

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -45,17 +45,22 @@ namespace Moq
 {
 	internal abstract class Setup
 	{
-		protected Setup()
+		private readonly InvocationShape expectation;
+
+		protected Setup(InvocationShape expectation)
 		{
+			this.expectation = expectation;
 		}
 
-		public abstract bool IsConditional { get; }
+		protected abstract Condition Condition { get; }
+
+		public bool IsConditional => this.Condition != null;
 
 		public abstract bool IsVerifiable { get; }
 
 		public abstract bool Invoked { get; }
 
-		public abstract MethodInfo Method { get; }
+		public MethodInfo Method => this.expectation.Method;
 
 		public abstract LambdaExpression SetupExpression { get; }
 
@@ -63,7 +68,10 @@ namespace Moq
 
 		public abstract void Execute(Invocation invocation);
 
-		public abstract bool Matches(Invocation invocation);
+		public bool Matches(Invocation invocation)
+		{
+			return this.expectation.IsMatch(invocation) && (!this.IsConditional || this.Condition.IsTrue);
+		}
 
 		public abstract void SetOutParameters(Invocation invocation);
 

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -137,7 +137,7 @@ namespace Moq
 			{
 				foreach (var setup in this.setups)
 				{
-					if (setup.IsConditional)
+					if (setup.Condition != null)
 					{
 						continue;
 					}

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -149,7 +149,7 @@ namespace Moq
 						visitedSetupsPerMethod.Add(setup.Method, visitedSetupsForMethod);
 					}
 
-					var expr = setup.SetupExpression.PartialMatcherAwareEval();
+					var expr = setup.Expression.PartialMatcherAwareEval();
 					if (visitedSetupsForMethod.Any(vc => ExpressionComparer.Default.Equals(vc, expr)))
 					{
 						continue;

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -50,14 +50,14 @@ namespace Moq
 	{
 		// Using a stack has the advantage that enumeration returns the items in reverse order (last added to first added).
 		// This helps in implementing the rule that "given two matching setups, the last one wins."
-		private Stack<MethodCall> setups;
+		private Stack<Setup> setups;
 
 		public SetupCollection()
 		{
-			this.setups = new Stack<MethodCall>();
+			this.setups = new Stack<Setup>();
 		}
 
-		public void Add(MethodCall setup)
+		public void Add(Setup setup)
 		{
 			lock (this.setups)
 			{
@@ -65,7 +65,7 @@ namespace Moq
 			}
 		}
 
-		public bool Any(Func<MethodCall, bool> predicate)
+		public bool Any(Func<Setup, bool> predicate)
 		{
 			lock (this.setups)
 			{
@@ -81,7 +81,7 @@ namespace Moq
 			}
 		}
 
-		public MethodCall FindMatchFor(Invocation invocation)
+		public Setup FindMatchFor(Invocation invocation)
 		{
 			// Fast path (no `lock`) when there are no setups:
 			if (this.setups.Count == 0)
@@ -89,7 +89,7 @@ namespace Moq
 				return null;
 			}
 
-			MethodCall matchingSetup = null;
+			Setup matchingSetup = null;
 
 			lock (this.setups)
 			{
@@ -116,7 +116,7 @@ namespace Moq
 			return matchingSetup;
 		}
 
-		public MethodCall[] ToArray()
+		public Setup[] ToArray()
 		{
 			lock (this.setups)
 			{
@@ -124,9 +124,9 @@ namespace Moq
 			}
 		}
 
-		public MethodCall[] ToArrayLive(Func<MethodCall, bool> predicate)
+		public Setup[] ToArrayLive(Func<Setup, bool> predicate)
 		{
-			var matchingSetups = new Stack<MethodCall>();
+			var matchingSetups = new Stack<Setup>();
 
 			// The following verification logic will remember each processed setup so that duplicate setups
 			// (that is, setups overridden by later setups with an equivalent expression) can be detected.

--- a/src/Moq/SetupWithOutParameterSupport.cs
+++ b/src/Moq/SetupWithOutParameterSupport.cs
@@ -1,0 +1,102 @@
+//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//https://github.com/moq/moq4
+//All rights reserved.
+//
+//Redistribution and use in source and binary forms,
+//with or without modification, are permitted provided
+//that the following conditions are met:
+//
+//    * Redistributions of source code must retain the
+//    above copyright notice, this list of conditions and
+//    the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce
+//    the above copyright notice, this list of conditions
+//    and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
+//    names of its contributors may be used to endorse
+//    or promote products derived from this software
+//    without specific prior written permission.
+//
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+//SUCH DAMAGE.
+//
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq.Expressions;
+using System.Reflection;
+
+using Moq.Properties;
+
+namespace Moq
+{
+	internal abstract class SetupWithOutParameterSupport : Setup
+	{
+		private readonly List<KeyValuePair<int, object>> outValues;
+
+		protected SetupWithOutParameterSupport(MethodInfo method, IReadOnlyList<Expression> arguments, LambdaExpression expression)
+			: base(new InvocationShape(method, arguments), expression)
+		{
+			Debug.Assert(arguments != null);
+
+			this.outValues = GetOutValues(arguments, method.GetParameters());
+		}
+
+		public sealed override void SetOutParameters(Invocation invocation)
+		{
+			if (this.outValues != null)
+			{
+				foreach (var item in this.outValues)
+				{
+					invocation.Arguments[item.Key] = item.Value;
+				}
+			}
+		}
+
+		private static List<KeyValuePair<int, object>> GetOutValues(IReadOnlyList<Expression> arguments, ParameterInfo[] parameters)
+		{
+			List<KeyValuePair<int, object>> outValues = null;
+			for (int i = 0, n = parameters.Length; i < n; ++i)
+			{
+				var parameter = parameters[i];
+				if (parameter.ParameterType.IsByRef)
+				{
+					if ((parameter.Attributes & (ParameterAttributes.In | ParameterAttributes.Out)) == ParameterAttributes.Out)
+					{
+						var constant = arguments[i].PartialEval() as ConstantExpression;
+						if (constant == null)
+						{
+							throw new NotSupportedException(Resources.OutExpressionMustBeConstantValue);
+						}
+
+						if (outValues == null)
+						{
+							outValues = new List<KeyValuePair<int, object>>();
+						}
+
+						outValues.Add(new KeyValuePair<int, object>(i, constant.Value));
+					}
+				}
+			}
+			return outValues;
+		}
+	}
+}

--- a/tests/Moq.Tests/OutRefFixture.cs
+++ b/tests/Moq.Tests/OutRefFixture.cs
@@ -84,6 +84,20 @@ namespace Moq.Tests
 			Assert.True(mock.Object.IntMethod(ref expected));
 		}
 
+		[Fact]
+		public void SetupSequence_setups_assign_out_parameters()
+		{
+			const string expected = "expected";
+
+			var valueForActual = expected;
+			var mock = new Mock<IFoo>();
+			mock.SetupSequence(m => m.Execute(It.IsAny<string>(), out valueForActual));
+
+			mock.Object.Execute(default, out var actual);
+
+			Assert.Equal(expected, actual);
+		}
+
 		// ThrowsIfOutIsNotConstant
 		// ThrowsIfRefIsNotConstant
 


### PR DESCRIPTION
`MethodCall` represents a setup that is programmable through Moq's `Setup` API. There are, however, certain kinds of "internal" setups that are not programmable and have much simpler logic.

The intent behind this refactoring is to create a base class for all setups that has a much smaller memory footprint and contains much less logic. Internal, non-programmable setup types can then eventually be derived from that new `Setup` class.

This PR includes the conversion of `PropertyGetterMethodCall`, `PropertySetterMethodCall`, and `SequenceMethodCall` to the new & lighter-weight `Setup` base class, including renames to more precise & more consistent names:

* `PropertyGetterMethodCall` &rarr; `AutoImplementedPropertyGetterSetup`
* `PropertySetterMethodCall` &rarr; `AutoImplementedPropertySetterSetup`
* `SequenceMethodCall` &rarr; `SequenceSetup`

This PR does *not* change `MethodCall` itself much&mdash;that is left to a separate, future refactoring.