### PR TITLE
Fix `VerifyAll` + `VerifyNoOtherCalls` for sequence setups

### DIFF
--- a/src/Moq/Interception/InterceptionAspects.cs
+++ b/src/Moq/Interception/InterceptionAspects.cs
@@ -155,6 +155,16 @@ namespace Moq
 			if (matchedSetup != null)
 			{
 				matchedSetup.Condition?.EvaluatedSuccessfully();
+
+				if (matchedSetup.IsVerifiable)
+				{
+					invocation.MarkAsMatchedByVerifiableSetup();
+				}
+				else
+				{
+					invocation.MarkAsMatchedBySetup();
+				}
+
 				matchedSetup.SetOutParameters(invocation);
 
 				// We first execute, as there may be a Throws 

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -90,7 +90,7 @@ namespace Moq
 
 		public override Condition Condition => this.condition;
 
-		protected override bool IsVerifiable => this.verifiable;
+		public override bool IsVerifiable => this.verifiable;
 
 		[Conditional("DESKTOP")]
 		[SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
@@ -130,15 +130,6 @@ namespace Moq
 		public override void Execute(Invocation invocation)
 		{
 			++this.callCount;
-
-			if (this.verifiable)
-			{
-				invocation.MarkAsMatchedByVerifiableSetup();
-			}
-			else
-			{
-				invocation.MarkAsMatchedBySetup();
-			}
 
 			if (expectedMaxCallCount.HasValue && this.callCount > expectedMaxCallCount)
 			{

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -62,9 +62,9 @@ namespace Moq
 
 		public LambdaExpression Expression => this.expression;
 
-		public MethodInfo Method => this.expectation.Method;
+		public virtual bool IsVerifiable => false;
 
-		protected virtual bool IsVerifiable => false;
+		public MethodInfo Method => this.expectation.Method;
 
 		public abstract void Execute(Invocation invocation);
 

--- a/tests/Moq.Tests/VerifyFixture.cs
+++ b/tests/Moq.Tests/VerifyFixture.cs
@@ -1376,6 +1376,18 @@ namespace Moq.Tests
 			cat.VerifyNoOtherCalls();
 		}
 
+		[Fact]
+		public void VerifyNoOtherCalls_works_together_with_parameterless_VerifyAll_for_sequence_setups()
+		{
+			var mock = new Mock<ICat>();
+			mock.SetupSequence(x => x.Hiss());
+
+			mock.Object.Hiss();
+
+			mock.VerifyAll();
+			mock.VerifyNoOtherCalls();
+		}
+
 		public interface IBar
 		{
 			int? Value { get; set; }


### PR DESCRIPTION
The previous refactoring (#671) has broken the combination of using `VerifyAll` followed by `VerifyNoOtherCalls` for sequence setups. This PR adds a regression test for such a scenario, and fixes it.