### PR TITLE
Add SkipVerifyAll on MethodCall

### DIFF
--- a/src/Moq/Language/Flow/SetupPhrase.cs
+++ b/src/Moq/Language/Flow/SetupPhrase.cs
@@ -199,5 +199,10 @@ namespace Moq.Language.Flow
 		{
 			this.setup.Verifiable(failMessage);
 		}
+
+		public void SkipVerifyAll()
+		{
+			this.setup.SkipVerifyAll();
+		}
 	}
 }

--- a/src/Moq/Language/IVerifies.cs
+++ b/src/Moq/Language/IVerifies.cs
@@ -77,5 +77,18 @@ namespace Moq.Language
 		/// </code>
 		/// </example>
 		void Verifiable(string failMessage);
+
+		/// <summary>
+		/// Marks the expectation as skip-able for <see cref="Mock.VerifyAll()"/>
+		/// </summary>
+		/// <example>
+		/// The following example marks the expectation as skip-able:
+		/// <code>
+		/// mock.Expect(x => x.Execute("ping"))
+		///     .Returns(true)
+		///     .SkipVerifyAll();
+		/// </code>
+		/// </example>
+		void SkipVerifyAll();
 	}
 }

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -70,6 +70,7 @@ namespace Moq
 		private RaiseEventResponse raiseEventResponse;
 		private Exception throwExceptionResponse;
 		private bool verifiable;
+		private bool skipVerifyAll;
 
 		public MethodCall(Mock mock, Condition condition, LambdaExpression originalExpression, MethodInfo method, IReadOnlyList<Expression> arguments)
 			: base(method, arguments, originalExpression)
@@ -238,7 +239,7 @@ namespace Moq
 
 		public override bool TryVerifyAll()
 		{
-			return this.callCount > 0;
+			return skipVerifyAll || callCount > 0;
 		}
 
 		public void Verifiable()
@@ -250,6 +251,11 @@ namespace Moq
 		{
 			this.verifiable = true;
 			this.failMessage = failMessage;
+		}
+
+		public void SkipVerifyAll()
+		{
+			skipVerifyAll = true;
 		}
 
 		public void AtMostOnce() => this.AtMost(1);

--- a/tests/Moq.Tests/VerifyFixture.cs
+++ b/tests/Moq.Tests/VerifyFixture.cs
@@ -1388,6 +1388,28 @@ namespace Moq.Tests
 			mock.VerifyNoOtherCalls();
 		}
 
+		[Fact]
+		public void SkipVerifyAll_PreventsVerificationException_OnVerifyAll_WhenNotCalled()
+		{
+			var mock = new Mock<IFoo>();
+
+			mock.Setup(x => x.Submit()).SkipVerifyAll();
+
+			mock.VerifyAll();
+		}
+
+		[Fact]
+		public void SkipVerifyAll_PreventsVerificationException_OnVerifyAll_WhenCalled()
+		{
+			var mock = new Mock<IFoo>();
+
+			mock.Setup(x => x.Submit()).SkipVerifyAll();
+
+			mock.Object.Submit();
+
+			mock.VerifyAll();
+		}
+
 		public interface IBar
 		{
 			int? Value { get; set; }


### PR DESCRIPTION
This enables a setup to state that a VerifyAll will not fail when called if no invocation has occured

My current workaround

![image](https://user-images.githubusercontent.com/1046836/45037066-0a393f00-b056-11e8-9248-ad49e5012359.png)

Which is not nice as when i actually want to use this mock, i have to reset the value.