### PR TITLE
Replace parameter list comparison extension methods

### DIFF
--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -218,11 +218,7 @@ namespace Moq
 			for (int i = 0; i < parameters.Length; i++)
 			{
 				var parameterType = paramTypes[i];
-				if (parameterType == typeof(object))
-				{
-					continue;
-				}
-				else if (exactParameterMatch && parameters[i].ParameterType != parameterType)
+				if (exactParameterMatch && parameters[i].ParameterType != parameterType)
 				{
 					return false;
 				}

--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -200,6 +200,46 @@ namespace Moq
 			return type.GetMember(name).OfType<MethodInfo>();
 		}
 
+		public static bool CompareTo<TTypes, TOtherTypes>(this TTypes types, TOtherTypes otherTypes, bool exact)
+			where TTypes : IReadOnlyList<Type>
+			where TOtherTypes : IReadOnlyList<Type>
+		{
+			var count = otherTypes.Count;
+
+			if (types.Count != count)
+			{
+				return false;
+			}
+
+			if (exact)
+			{
+				for (int i = 0; i < count; ++i)
+				{
+					if (types[i] != otherTypes[i])
+					{
+						return false;
+					}
+				}
+			}
+			else
+			{
+				for (int i = 0; i < count; ++i)
+				{
+					if (types[i].IsAssignableFrom(otherTypes[i]) == false)
+					{
+						return false;
+					}
+				}
+			}
+
+			return true;
+		}
+
+		public static ParameterTypes GetParameterTypes(this MethodInfo method)
+		{
+			return new ParameterTypes(method.GetParameters());
+		}
+
 		public static bool HasSameParameterTypesAs(this MethodInfo method, MethodInfo other)
 		{
 			return Enumerable.SequenceEqual(

--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -240,30 +240,6 @@ namespace Moq
 			return new ParameterTypes(method.GetParameters());
 		}
 
-		public static bool HasCompatibleParameterTypes(this MethodInfo method, Type[] paramTypes, bool exactParameterMatch)
-		{
-			var parameters = method.GetParameters();
-			if (parameters.Length != paramTypes.Length)
-			{
-				return false;
-			}
-
-			for (int i = 0; i < parameters.Length; i++)
-			{
-				var parameterType = paramTypes[i];
-				if (exactParameterMatch && parameters[i].ParameterType != parameterType)
-				{
-					return false;
-				}
-				else if (!parameters[i].ParameterType.IsAssignableFrom(parameterType))
-				{
-					return false;
-				}
-			}
-
-			return true;
-		}
-
 		public static bool HasCompatibleParameterList(this Delegate function, ParameterInfo[] expectedParams)
 		{
 			var method = function.GetMethodInfo();

--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -242,8 +242,10 @@ namespace Moq
 
 		public static bool HasCompatibleParameterList(this Delegate function, ParameterInfo[] expectedParams)
 		{
+			var expectedParamTypes = new ParameterTypes(expectedParams);
+
 			var method = function.GetMethodInfo();
-			if (HasCompatibleParameterList(expectedParams, method))
+			if (method.GetParameterTypes().CompareTo(expectedParamTypes, exact: false))
 			{
 				// the backing method for the literal delegate is compatible, DynamicInvoke(...) will succeed
 				return true;
@@ -254,7 +256,7 @@ namespace Moq
 			// an instance delegate invocation is created for an extension method (bundled with a receiver)
 			// or at times for DLR code generation paths because the CLR is optimized for instance methods.
 			var invokeMethod = GetInvokeMethodFromUntypedDelegateCallback(function);
-			if (invokeMethod != null && HasCompatibleParameterList(expectedParams, invokeMethod))
+			if (invokeMethod != null && invokeMethod.GetParameterTypes().CompareTo(expectedParamTypes, exact: false))
 			{
 				// the Invoke(...) method is compatible instead. DynamicInvoke(...) will succeed.
 				return true;
@@ -263,25 +265,6 @@ namespace Moq
 			// Neither the literal backing field of the delegate was compatible
 			// nor the delegate invoke signature.
 			return false;
-		}
-
-		private static bool HasCompatibleParameterList(ParameterInfo[] expectedParams, MethodInfo method)
-		{
-			var actualParams = method.GetParameters();
-			if (expectedParams.Length != actualParams.Length)
-			{
-				return false;
-			}
-
-			for (int i = 0; i < expectedParams.Length; i++)
-			{
-				if (!actualParams[i].ParameterType.IsAssignableFrom(expectedParams[i].ParameterType))
-				{
-					return false;
-				}
-			}
-
-			return true;
 		}
 
 		private static MethodInfo GetInvokeMethodFromUntypedDelegateCallback(Delegate callback)

--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -240,13 +240,6 @@ namespace Moq
 			return new ParameterTypes(method.GetParameters());
 		}
 
-		public static bool HasSameParameterTypesAs(this MethodInfo method, MethodInfo other)
-		{
-			return Enumerable.SequenceEqual(
-				method.GetParameters().Select(p => p.ParameterType),
-				other.GetParameters().Select(p => p.ParameterType));
-		}
-
 		public static bool HasCompatibleParameterTypes(this MethodInfo method, Type[] paramTypes, bool exactParameterMatch)
 		{
 			var parameters = method.GetParameters();

--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -240,12 +240,11 @@ namespace Moq
 			return new ParameterTypes(method.GetParameters());
 		}
 
-		public static bool HasCompatibleParameterList(this Delegate function, ParameterInfo[] expectedParams)
+		public static bool CompareParameterTypesTo<TOtherTypes>(this Delegate function, TOtherTypes otherTypes)
+			where TOtherTypes : IReadOnlyList<Type>
 		{
-			var expectedParamTypes = new ParameterTypes(expectedParams);
-
 			var method = function.GetMethodInfo();
-			if (method.GetParameterTypes().CompareTo(expectedParamTypes, exact: false))
+			if (method.GetParameterTypes().CompareTo(otherTypes, exact: false))
 			{
 				// the backing method for the literal delegate is compatible, DynamicInvoke(...) will succeed
 				return true;
@@ -256,7 +255,7 @@ namespace Moq
 			// an instance delegate invocation is created for an extension method (bundled with a receiver)
 			// or at times for DLR code generation paths because the CLR is optimized for instance methods.
 			var invokeMethod = GetInvokeMethodFromUntypedDelegateCallback(function);
-			if (invokeMethod != null && invokeMethod.GetParameterTypes().CompareTo(expectedParamTypes, exact: false))
+			if (invokeMethod != null && invokeMethod.GetParameterTypes().CompareTo(otherTypes, exact: false))
 			{
 				// the Invoke(...) method is compatible instead. DynamicInvoke(...) will succeed.
 				return true;

--- a/src/Moq/InvocationShape.cs
+++ b/src/Moq/InvocationShape.cs
@@ -116,7 +116,7 @@ namespace Moq
 
 			if (method.IsGenericMethod)
 			{
-				if (!invocationMethod.GetGenericArguments().SequenceEqual(method.GetGenericArguments(), AssignmentCompatibilityTypeComparer.Instance))
+				if (!method.GetGenericArguments().CompareTo(invocationMethod.GetGenericArguments(), exact: false))
 				{
 					return false;
 				}
@@ -145,18 +145,6 @@ namespace Moq
 				argumentMatchers[i] = MatcherFactory.CreateMatcher(arguments[i], parameters[i]);
 			}
 			return argumentMatchers;
-		}
-
-		private sealed class AssignmentCompatibilityTypeComparer : IEqualityComparer<Type>
-		{
-			public static readonly AssignmentCompatibilityTypeComparer Instance = new AssignmentCompatibilityTypeComparer();
-
-			public bool Equals(Type x, Type y)
-			{
-				return y.IsAssignableFrom(x);
-			}
-
-			int IEqualityComparer<Type>.GetHashCode(Type obj) => throw new NotSupportedException();
 		}
 	}
 }

--- a/src/Moq/InvocationShape.cs
+++ b/src/Moq/InvocationShape.cs
@@ -123,7 +123,7 @@ namespace Moq
 			}
 			else
 			{
-				if (!invocationMethod.HasSameParameterTypesAs(method))
+				if (!invocationMethod.GetParameterTypes().CompareTo(method.GetParameterTypes(), exact: true))
 				{
 					return false;
 				}

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -176,12 +176,16 @@ namespace Moq
 			}
 			else
 			{
-				var expectedParams = this.Method.GetParameters();
-				var actualParams = callback.GetMethodInfo().GetParameters();
-
-				if (!callback.HasCompatibleParameterList(expectedParams))
+				var expectedParamTypes = this.Method.GetParameterTypes();
+				if (!callback.CompareParameterTypesTo(expectedParamTypes))
 				{
-					ThrowParameterMismatch(expectedParams, actualParams);
+					var actualParams = callback.GetMethodInfo().GetParameters();
+					throw new ArgumentException(
+						string.Format(
+							CultureInfo.CurrentCulture,
+							Resources.InvalidCallbackParameterMismatch,
+							string.Join(",", expectedParamTypes.Select(p => p.Name).ToArray()),
+							string.Join(",", actualParams.Select(p => p.ParameterType.Name).ToArray())));
 				}
 
 				if (callback.GetMethodInfo().ReturnType != typeof(void))
@@ -190,16 +194,6 @@ namespace Moq
 				}
 
 				this.callbackResponse = (object[] args) => callback.InvokePreserveStack(args);
-			}
-
-			void ThrowParameterMismatch(ParameterInfo[] expected, ParameterInfo[] actual)
-			{
-				throw new ArgumentException(
-					string.Format(
-						CultureInfo.CurrentCulture,
-						Resources.InvalidCallbackParameterMismatch,
-						string.Join(",", expected.Select(p => p.ParameterType.Name).ToArray()),
-						string.Join(",", actual.Select(p => p.ParameterType.Name).ToArray())));
 			}
 		}
 

--- a/src/Moq/MethodCallReturn.cs
+++ b/src/Moq/MethodCallReturn.cs
@@ -188,7 +188,7 @@ namespace Moq
 			}
 			else if (this.valueDel != null)
 			{
-				invocation.Return(this.valueDel.HasCompatibleParameterList(new ParameterInfo[0])
+				invocation.Return(this.valueDel.CompareParameterTypesTo(Type.EmptyTypes)
 					? valueDel.InvokePreserveStack()                //we need this, for the user to be able to use parameterless methods
 					: valueDel.InvokePreserveStack(invocation.Arguments)); //will throw if parameters mismatch
 			}

--- a/src/Moq/ParameterTypes.cs
+++ b/src/Moq/ParameterTypes.cs
@@ -1,0 +1,74 @@
+//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//https://github.com/moq/moq4
+//All rights reserved.
+//
+//Redistribution and use in source and binary forms,
+//with or without modification, are permitted provided
+//that the following conditions are met:
+//
+//    * Redistributions of source code must retain the
+//    above copyright notice, this list of conditions and
+//    the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce
+//    the above copyright notice, this list of conditions
+//    and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
+//    names of its contributors may be used to endorse
+//    or promote products derived from this software
+//    without specific prior written permission.
+//
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+//SUCH DAMAGE.
+//
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Moq
+{
+	/// <summary>
+	///   Allocation-free adapter type for treating a `ParameterInfo[]` array like a `Type[]` array.
+	/// </summary>
+	internal readonly struct ParameterTypes : IReadOnlyList<Type>
+	{
+		private readonly ParameterInfo[] parameters;
+
+		public ParameterTypes(ParameterInfo[] parameters)
+		{
+			this.parameters = parameters;
+		}
+
+		public Type this[int index] => this.parameters[index].ParameterType;
+
+		public int Count => this.parameters.Length;
+
+		public IEnumerator<Type> GetEnumerator()
+		{
+			for (int i = 0, n = this.Count; i < n; ++i)
+			{
+				yield return this[i];
+			}
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
+	}
+}

--- a/src/Moq/Protected/ProtectedMock.cs
+++ b/src/Moq/Protected/ProtectedMock.cs
@@ -249,11 +249,11 @@ namespace Moq.Protected
 			return GetMethod(methodName, false, args);
 		}
 
-		private static MethodInfo GetMethod(string methodName, bool exactParameterMatch, params object[] args)
+		private static MethodInfo GetMethod(string methodName, bool exact, params object[] args)
 		{
 			var argTypes = ToArgTypes(args);
 			return typeof(T).GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
-				.SingleOrDefault(m => m.Name == methodName && m.HasCompatibleParameterTypes(argTypes, exactParameterMatch));
+				.SingleOrDefault(m => m.Name == methodName && m.GetParameterTypes().CompareTo(argTypes, exact));
 		}
 
 		private static Expression<Func<T, TResult>> GetMethodCall<TResult>(MethodInfo method, object[] args)


### PR DESCRIPTION
There are currently several different ways in the Moq code base for comparing ordered lists of (parameter) types:

* `Enumerable.SequenceEqual`
* `Enumerable.SequenceEqual` + `AssignmentCompatibilityTypeComparer`
* `Extensions.HasSameParameterTypesAs`
* `Extensions.HasCompatibleParameterTypes`
* `Extensions.HasCompatibleParameterList`

This refactoring replaces all of the above with three new composable building blocks:

* `ParameterTypes` &mdash; wrapper for `ParameterInfo[]` so it can be treated like `Type[]`
* `Extensions.GetParameterTypes` &mdash; gets a `MethodInfo`'s parameter types as a `ParameterTypes`
* `Extensions.CompareTo` &mdash; compares any pair of `Type[]` or `ParameterTypes` using either of two comparison modes: equality, or assignment-from-compatibility.

Care has been taken to keep them fast, and free of any heap allocations.