### PR TITLE
`Verify` exception should report configured setups for delegate mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 * More precise `out` parameter detection for mocking COM interfaces with `[in,out]` parameters (@koutinho, #645)
 * Prevent false 'Different number of parameters' error with `Returns` callback methods that have been compiled from `Expression`s (@stakx, #654)
+* `Verify` exception should report configured setups for delegate mocks (@stakx, #679)
 
 
 ## 4.9.0 (2018-07-13)

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -439,7 +439,17 @@ namespace Moq
 			var matchingInvocationCount = matchingInvocations.Length;
 			if (!times.Verify(matchingInvocationCount))
 			{
-				var setups = targetMock.Setups.ToArrayLive(oc => AreSameMethod(oc.Expression, expression));
+				Setup[] setups;
+				if (targetMock.IsDelegateMock)
+				{
+					// For delegate mocks, there's no need to compare methods as for regular mocks (below)
+					// since there's only one single method, so include all setups unconditionally.
+					setups = targetMock.Setups.ToArrayLive(s => true);
+				}
+				else
+				{
+					setups = targetMock.Setups.ToArrayLive(oc => AreSameMethod(oc.Expression, expression));
+				}
 				throw MockException.NoMatchingCalls(failMessage, setups, allInvocations, expression, times, matchingInvocationCount);
 			}
 			else

--- a/tests/Moq.Tests/VerifyFixture.cs
+++ b/tests/Moq.Tests/VerifyFixture.cs
@@ -1388,6 +1388,18 @@ namespace Moq.Tests
 			mock.VerifyNoOtherCalls();
 		}
 
+		[Fact]
+		public void Verification_error_message_contains_setup_for_delegate_mock()
+		{
+			var mock = new Mock<Action>();
+			mock.Setup(m => m());
+
+			var ex = Record.Exception(() => mock.Verify(m => m(), Times.Once()));
+
+			Assert.Contains("Configured setups:", ex.Message);
+			Assert.Contains("Action m =>", ex.Message);
+		}
+
 		public interface IBar
 		{
 			int? Value { get; set; }


### PR DESCRIPTION
This fixes #677.