### PR TITLE
`Verify` exception should include complete call expression for delegate mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * More precise `out` parameter detection for mocking COM interfaces with `[in,out]` parameters (@koutinho, #645)
 * Prevent false 'Different number of parameters' error with `Returns` callback methods that have been compiled from `Expression`s (@stakx, #654)
 * `Verify` exception should report configured setups for delegate mocks (@stakx, #679)
+* `Verify` exception should include complete call expression for delegate mocks (@stakx, #680)
 
 
 ## 4.9.0 (2018-07-13)

--- a/src/Moq/ExpressionStringBuilder.cs
+++ b/src/Moq/ExpressionStringBuilder.cs
@@ -480,7 +480,10 @@ namespace Moq
 
 		private void ToStringInvocation(InvocationExpression iv)
 		{
+			ToString(iv.Expression);
+			builder.Append('(');
 			ToStringExpressionList(iv.Arguments);
+			builder.Append(')');
 			return;
 		}
 

--- a/tests/Moq.Tests/VerifyFixture.cs
+++ b/tests/Moq.Tests/VerifyFixture.cs
@@ -1397,7 +1397,41 @@ namespace Moq.Tests
 			var ex = Record.Exception(() => mock.Verify(m => m(), Times.Once()));
 
 			Assert.Contains("Configured setups:", ex.Message);
-			Assert.Contains("Action m =>", ex.Message);
+			Assert.Contains("Action m => m()", ex.Message);
+		}
+
+		[Fact]
+		public void Verification_error_message_contains_setup_for_delegate_mock_with_parameters()
+		{
+			var mock = new Mock<Action<int, int>>();
+			mock.Setup(m => m(1, It.IsAny<int>()));
+
+			var ex = Record.Exception(() => mock.Verify(m => m(1, 2), Times.Once()));
+
+			Assert.Contains("Configured setups:", ex.Message);
+			Assert.Contains("Action<Int32, Int32> m => m(1, It.IsAny<Int32>())", ex.Message);
+		}
+
+		[Fact]
+		public void Verification_error_message_contains_complete_call_expression_for_delegate_mock()
+		{
+			var mock = new Mock<Action>();
+			mock.Setup(m => m());
+
+			var ex = Record.Exception(() => mock.Verify(m => m(), Times.Once()));
+
+			Assert.Contains("but was 0 times: m => m()", ex.Message);
+		}
+
+		[Fact]
+		public void Verification_error_message_contains_complete_call_expression_for_delegate_mock_with_parameters()
+		{
+			var mock = new Mock<Action<int, int>>();
+			mock.Setup(m => m(1, It.IsAny<int>()));
+
+			var ex = Record.Exception(() => mock.Verify(m => m(1, 2), Times.Once()));
+
+			Assert.Contains("but was 0 times: m => m(1, 2)", ex.Message);
 		}
 
 		public interface IBar


### PR DESCRIPTION
Fixes #678.