### PR TITLE
Add VerifyNoOtherCalls to MockFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 * `ExpressionCompiler`: An extensibility point for setting up alternate LINQ expression tree compilation strategies (@stakx, #647)
 * `setup.CallBase()` for `void` methods (@stakx, #664)
+* `VerifyNoOtherCalls` for `MockRepository` (@BlythMeister, #682)
 
 #### Changed
 

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -415,7 +415,7 @@ namespace Moq
 				var remainingUnverifiedInvocations = unverifiedInvocations.Where(i => i != null);
 				if (remainingUnverifiedInvocations.Any())
 				{
-					throw MockException.UnverifiedInvocations(remainingUnverifiedInvocations);
+					throw MockException.UnverifiedInvocations(mock, remainingUnverifiedInvocations);
 				}
 			}
 

--- a/src/Moq/MockException.cs
+++ b/src/Moq/MockException.cs
@@ -193,14 +193,29 @@ namespace Moq
 		/// <summary>
 		///   Returns the exception to be thrown when <see cref="Mock.VerifyNoOtherCalls(Mock)"/> finds invocations that have not been verified.
 		/// </summary>
-		internal static MockException UnverifiedInvocations(IEnumerable<Invocation> invocations)
+		internal static MockException UnverifiedInvocations(Mock mock, IEnumerable<Invocation> invocations)
 		{
 			return new MockException(
 				MockExceptionReason.UnverifiedInvocations,
 				string.Format(
 					CultureInfo.CurrentCulture,
 					Resources.UnverifiedInvocations,
-					string.Join(Environment.NewLine, invocations)));
+					mock.ToString(),
+					invocations.Aggregate(new StringBuilder(), (builder, setup) => builder.AppendLine(setup.ToString())).ToString()));
+		}
+
+		/// <summary>
+		///   Returns the exception to be thrown when <see cref="MockFactory.VerifyNoOtherCalls()"/> finds invocations that have not been verified.
+		/// </summary>
+		public static Exception UnverifiedInvocations(List<MockException> errors)
+		{
+			Debug.Assert(errors.All(e => e.Reason == MockExceptionReason.UnverifiedInvocations));
+
+			return new MockException(
+				MockExceptionReason.UnverifiedInvocations,
+				string.Join(
+					Environment.NewLine,
+					errors.Select(error => error.Message)));
 		}
 
 		private MockExceptionReason reason;

--- a/src/Moq/Obsolete/MockFactory.cs
+++ b/src/Moq/Obsolete/MockFactory.cs
@@ -363,8 +363,35 @@ namespace Moq
 		}
 
 		/// <summary>
-		/// Invokes <paramref name="verifyAction"/> for each mock 
-		/// in <see cref="Mocks"/>, and accumulates the resulting 
+		/// Calls <see cref="Mock{T}.VerifyNoOtherCalls()"/> on all mocks created by this factory.
+		/// </summary>
+		/// <seealso cref="Mock{T}.VerifyNoOtherCalls()"/>
+		/// <exception cref="MockException">One or more mocks had invocations that were not verified.</exception>
+		public void VerifyNoOtherCalls()
+		{
+			var errors = new List<MockException>();
+
+			foreach (var mock in mocks)
+			{
+				try
+				{
+					Mock.VerifyNoOtherCalls(mock);
+				}
+				catch (MockException error) when (error.Reason == MockExceptionReason.UnverifiedInvocations)
+				{
+					errors.Add(error);
+				}
+			}
+
+			if (errors.Count > 0)
+			{
+				throw MockException.UnverifiedInvocations(errors);
+			}
+		}
+
+		/// <summary>
+		/// Invokes <paramref name="verifyAction"/> for each mock
+		/// in <see cref="Mocks"/>, and accumulates the resulting
 		/// verification exceptions that might be
 		/// thrown from the action.
 		/// </summary>

--- a/src/Moq/Properties/Resources.resx
+++ b/src/Moq/Properties/Resources.resx
@@ -345,7 +345,7 @@ Expected invocation on the mock once, but was {4} times: {1}</value>
 		<value>Invalid callback. Setup on method with {0} parameter(s) cannot invoke callback with different number of parameters ({1}).</value>
 	</data>
 	<data name="UnverifiedInvocations" xml:space="preserve">
-		<value>The following invocations were not verified:
-{0}</value>
+		<value>The following invocations on mock '{0}' were not verified:
+{1}</value>
 	</data>
 </root>


### PR DESCRIPTION
Enables single call to verify no other calls on all mocks generated by the factory

Based on the discussion with @stakx in #675 it appeared that i was not using the framework correctly.
The reason i chose to do it this was way the inability to perform a `VerifyNoOtherCalls` on all mocks generated from a single factory.

This new method means you can create many mocks from a single factory, verify each expectation in turn and then at the end call `Factory.VerifyNoOtherCalls` to ensure that only the items you have verified occurred for every mock generated in a given test.

Current rather nasty workaround

```
    public class MyMockRepository : MockRepository
    {
        public MyMockRepository(MockBehavior defaultBehavior) : base(defaultBehavior)
        {
        }

        public virtual void VerifyNoOtherCalls()
        {
            VerifyMocks(m =>
            {
                dynamic objectAsType = Convert.ChangeType(m, m.GetType());
                objectAsType.VerifyNoOtherCalls();
            });
        }
    }
```