### PR TITLE
Remove or deprecate unsupported verbs after post-`Returns` callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * `Verify` exception should report configured setups for delegate mocks (@stakx, #679)
 * `Verify` exception should include complete call expression for delegate mocks (@stakx, #680)
 
+#### Obsoleted
+
+* For non-`void` methods, the setup sequence `Returns`/`CallBase` &rarr; `Callback` &rarr; `Throws` has been deprecated because a method cannot return a value and throw an exception at the same time (@stakx, #686)
+
 
 ## 4.9.0 (2018-07-13)
 

--- a/src/Moq/Language/Flow/ICallbackAfterResult.cs
+++ b/src/Moq/Language/Flow/ICallbackAfterResult.cs
@@ -1,0 +1,66 @@
+//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//https://github.com/moq/moq4
+//All rights reserved.
+
+//Redistribution and use in source and binary forms,
+//with or without modification, are permitted provided
+//that the following conditions are met:
+
+//    * Redistributions of source code must retain the
+//    above copyright notice, this list of conditions and
+//    the following disclaimer.
+
+//    * Redistributions in binary form must reproduce
+//    the above copyright notice, this list of conditions
+//    and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
+//    names of its contributors may be used to endorse
+//    or promote products derived from this software
+//    without specific prior written permission.
+
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+//SUCH DAMAGE.
+
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System;
+using System.ComponentModel;
+
+namespace Moq.Language.Flow
+{
+	/// <summary>
+	/// Implements the fluent API.
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public interface ICallbackAfterResult : IOccurrence, IVerifies, IFluentInterface
+	{
+		/// <summary>
+		/// This member has been deprecated.
+		/// </summary>
+		[Obsolete("A method cannot be set up to return a value and throw an exception at the same time.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		IThrowsResult Throws(Exception exception);
+
+		/// <summary>
+		/// This member has been deprecated.
+		/// </summary>
+		[Obsolete("A method cannot be set up to return a value and throw an exception at the same time.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		IThrowsResult Throws<TException>() where TException : Exception, new();
+	}
+}

--- a/src/Moq/Language/Flow/IReturnsResult.cs
+++ b/src/Moq/Language/Flow/IReturnsResult.cs
@@ -46,7 +46,7 @@ namespace Moq.Language.Flow
 	/// Implements the fluent API.
 	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
-	public interface IReturnsResult<TMock> : ICallback, IOccurrence, IRaise<TMock>, IVerifies, IFluentInterface
+	public interface IReturnsResult<TMock> : ICallbackAfter, IOccurrence, IRaise<TMock>, IVerifies, IFluentInterface
 	{
 	}
 }

--- a/src/Moq/Language/Flow/NonVoidSetupPhrase.cs
+++ b/src/Moq/Language/Flow/NonVoidSetupPhrase.cs
@@ -42,13 +42,25 @@ using System;
 
 namespace Moq.Language.Flow
 {
-	internal class NonVoidSetupPhrase<T, TResult> : SetupPhrase<MethodCallReturn>, ISetup<T, TResult>, ISetupGetter<T, TResult>, IReturnsResult<T> where T : class
+	internal class NonVoidSetupPhrase<T, TResult> : SetupPhrase<MethodCallReturn>, ISetup<T, TResult>, ISetupGetter<T, TResult>, IReturnsResult<T>, ICallbackAfterResult where T : class
 	{
 		public NonVoidSetupPhrase(MethodCallReturn setup) : base(setup)
 		{
 		}
 
+		ICallbackAfterResult ICallbackAfter.Callback(Delegate callback)
+		{
+			this.Setup.SetCallbackResponse(callback);
+			return this;
+		}
+
 		public new IReturnsThrows<T, TResult> Callback(Delegate callback)
+		{
+			this.Setup.SetCallbackResponse(callback);
+			return this;
+		}
+
+		ICallbackAfterResult ICallbackAfter.Callback(Action callback)
 		{
 			this.Setup.SetCallbackResponse(callback);
 			return this;
@@ -66,7 +78,19 @@ namespace Moq.Language.Flow
 			return this;
 		}
 
+		ICallbackAfterResult ICallbackAfter.Callback<T1>(Action<T1> callback)
+		{
+			this.Setup.SetCallbackResponse(callback);
+			return this;
+		}
+
 		public new IReturnsThrows<T, TResult> Callback<T1>(Action<T1> callback)
+		{
+			this.Setup.SetCallbackResponse(callback);
+			return this;
+		}
+
+		ICallbackAfterResult ICallbackAfter.Callback<T1, T2>(Action<T1, T2> callback)
 		{
 			this.Setup.SetCallbackResponse(callback);
 			return this;
@@ -78,7 +102,19 @@ namespace Moq.Language.Flow
 			return this;
 		}
 
+		ICallbackAfterResult ICallbackAfter.Callback<T1, T2, T3>(Action<T1, T2, T3> callback)
+		{
+			this.Setup.SetCallbackResponse(callback);
+			return this;
+		}
+
 		public new IReturnsThrows<T, TResult> Callback<T1, T2, T3>(Action<T1, T2, T3> callback)
+		{
+			this.Setup.SetCallbackResponse(callback);
+			return this;
+		}
+
+		ICallbackAfterResult ICallbackAfter.Callback<T1, T2, T3, T4>(Action<T1, T2, T3, T4> callback)
 		{
 			this.Setup.SetCallbackResponse(callback);
 			return this;
@@ -90,7 +126,19 @@ namespace Moq.Language.Flow
 			return this;
 		}
 
+		ICallbackAfterResult ICallbackAfter.Callback<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> callback)
+		{
+			this.Setup.SetCallbackResponse(callback);
+			return this;
+		}
+
 		public new IReturnsThrows<T, TResult> Callback<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> callback)
+		{
+			this.Setup.SetCallbackResponse(callback);
+			return this;
+		}
+
+		ICallbackAfterResult ICallbackAfter.Callback<T1, T2, T3, T4, T5, T6>(Action<T1, T2, T3, T4, T5, T6> callback)
 		{
 			this.Setup.SetCallbackResponse(callback);
 			return this;
@@ -102,7 +150,19 @@ namespace Moq.Language.Flow
 			return this;
 		}
 
+		ICallbackAfterResult ICallbackAfter.Callback<T1, T2, T3, T4, T5, T6, T7>(Action<T1, T2, T3, T4, T5, T6, T7> callback)
+		{
+			this.Setup.SetCallbackResponse(callback);
+			return this;
+		}
+
 		public new IReturnsThrows<T, TResult> Callback<T1, T2, T3, T4, T5, T6, T7>(Action<T1, T2, T3, T4, T5, T6, T7> callback)
+		{
+			this.Setup.SetCallbackResponse(callback);
+			return this;
+		}
+
+		ICallbackAfterResult ICallbackAfter.Callback<T1, T2, T3, T4, T5, T6, T7, T8>(Action<T1, T2, T3, T4, T5, T6, T7, T8> callback)
 		{
 			this.Setup.SetCallbackResponse(callback);
 			return this;
@@ -114,7 +174,19 @@ namespace Moq.Language.Flow
 			return this;
 		}
 
+		ICallbackAfterResult ICallbackAfter.Callback<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> callback)
+		{
+			this.Setup.SetCallbackResponse(callback);
+			return this;
+		}
+
 		public new IReturnsThrows<T, TResult> Callback<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> callback)
+		{
+			this.Setup.SetCallbackResponse(callback);
+			return this;
+		}
+
+		ICallbackAfterResult ICallbackAfter.Callback<T1, T2, T3, T4, T5, T6, T7, T8, T9,  T10>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> callback)
 		{
 			this.Setup.SetCallbackResponse(callback);
 			return this;
@@ -126,7 +198,19 @@ namespace Moq.Language.Flow
 			return this;
 		}
 
+		ICallbackAfterResult ICallbackAfter.Callback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> callback)
+		{
+			this.Setup.SetCallbackResponse(callback);
+			return this;
+		}
+
 		public new IReturnsThrows<T, TResult> Callback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> callback)
+		{
+			this.Setup.SetCallbackResponse(callback);
+			return this;
+		}
+
+		ICallbackAfterResult ICallbackAfter.Callback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> callback)
 		{
 			this.Setup.SetCallbackResponse(callback);
 			return this;
@@ -138,7 +222,19 @@ namespace Moq.Language.Flow
 			return this;
 		}
 
+		ICallbackAfterResult ICallbackAfter.Callback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> callback)
+		{
+			this.Setup.SetCallbackResponse(callback);
+			return this;
+		}
+
 		public new IReturnsThrows<T, TResult> Callback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> callback)
+		{
+			this.Setup.SetCallbackResponse(callback);
+			return this;
+		}
+
+		ICallbackAfterResult ICallbackAfter.Callback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> callback)
 		{
 			this.Setup.SetCallbackResponse(callback);
 			return this;
@@ -150,7 +246,19 @@ namespace Moq.Language.Flow
 			return this;
 		}
 
+		ICallbackAfterResult ICallbackAfter.Callback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> callback)
+		{
+			this.Setup.SetCallbackResponse(callback);
+			return this;
+		}
+
 		public new IReturnsThrows<T, TResult> Callback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> callback)
+		{
+			this.Setup.SetCallbackResponse(callback);
+			return this;
+		}
+
+		ICallbackAfterResult ICallbackAfter.Callback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> callback)
 		{
 			this.Setup.SetCallbackResponse(callback);
 			return this;

--- a/src/Moq/Language/ICallbackAfter.Generated.cs
+++ b/src/Moq/Language/ICallbackAfter.Generated.cs
@@ -1,0 +1,273 @@
+//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//https://github.com/moq/moq4
+//All rights reserved.
+
+//Redistribution and use in source and binary forms,
+//with or without modification, are permitted provided
+//that the following conditions are met:
+
+//    * Redistributions of source code must retain the
+//    above copyright notice, this list of conditions and
+//    the following disclaimer.
+
+//    * Redistributions in binary form must reproduce
+//    the above copyright notice, this list of conditions
+//    and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
+//    names of its contributors may be used to endorse
+//    or promote products derived from this software
+//    without specific prior written permission.
+
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+//SUCH DAMAGE.
+
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System;
+using Moq.Language.Flow;
+
+namespace Moq.Language
+{
+	partial interface ICallbackAfter
+	{
+		/// <summary>
+		/// Specifies a callback that receives the original arguments, to be invoked after a method's return value has been determined.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <param name="action">The callback method to invoke.</param>
+		new ICallbackAfterResult Callback<T1, T2>(Action<T1, T2> action);
+
+		/// <summary>
+		/// Specifies a callback that receives the original arguments, to be invoked after a method's return value has been determined.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <param name="action">The callback method to invoke.</param>
+		new ICallbackAfterResult Callback<T1, T2, T3>(Action<T1, T2, T3> action);
+
+		/// <summary>
+		/// Specifies a callback that receives the original arguments, to be invoked after a method's return value has been determined.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <param name="action">The callback method to invoke.</param>
+		new ICallbackAfterResult Callback<T1, T2, T3, T4>(Action<T1, T2, T3, T4> action);
+
+		/// <summary>
+		/// Specifies a callback that receives the original arguments, to be invoked after a method's return value has been determined.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <param name="action">The callback method to invoke.</param>
+		new ICallbackAfterResult Callback<T1, T2, T3, T4, T5>(Action<T1, T2, T3, T4, T5> action);
+
+		/// <summary>
+		/// Specifies a callback that receives the original arguments, to be invoked after a method's return value has been determined.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="T6">The type of the sixth argument of the invoked method.</typeparam>
+		/// <param name="action">The callback method to invoke.</param>
+		new ICallbackAfterResult Callback<T1, T2, T3, T4, T5, T6>(Action<T1, T2, T3, T4, T5, T6> action);
+
+		/// <summary>
+		/// Specifies a callback that receives the original arguments, to be invoked after a method's return value has been determined.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="T6">The type of the sixth argument of the invoked method.</typeparam>
+		/// <typeparam name="T7">The type of the seventh argument of the invoked method.</typeparam>
+		/// <param name="action">The callback method to invoke.</param>
+		new ICallbackAfterResult Callback<T1, T2, T3, T4, T5, T6, T7>(Action<T1, T2, T3, T4, T5, T6, T7> action);
+
+		/// <summary>
+		/// Specifies a callback that receives the original arguments, to be invoked after a method's return value has been determined.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="T6">The type of the sixth argument of the invoked method.</typeparam>
+		/// <typeparam name="T7">The type of the seventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T8">The type of the eighth argument of the invoked method.</typeparam>
+		/// <param name="action">The callback method to invoke.</param>
+		new ICallbackAfterResult Callback<T1, T2, T3, T4, T5, T6, T7, T8>(Action<T1, T2, T3, T4, T5, T6, T7, T8> action);
+
+		/// <summary>
+		/// Specifies a callback that receives the original arguments, to be invoked after a method's return value has been determined.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="T6">The type of the sixth argument of the invoked method.</typeparam>
+		/// <typeparam name="T7">The type of the seventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T8">The type of the eighth argument of the invoked method.</typeparam>
+		/// <typeparam name="T9">The type of the ninth argument of the invoked method.</typeparam>
+		/// <param name="action">The callback method to invoke.</param>
+		new ICallbackAfterResult Callback<T1, T2, T3, T4, T5, T6, T7, T8, T9>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9> action);
+
+		/// <summary>
+		/// Specifies a callback that receives the original arguments, to be invoked after a method's return value has been determined.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="T6">The type of the sixth argument of the invoked method.</typeparam>
+		/// <typeparam name="T7">The type of the seventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T8">The type of the eighth argument of the invoked method.</typeparam>
+		/// <typeparam name="T9">The type of the ninth argument of the invoked method.</typeparam>
+		/// <typeparam name="T10">The type of the tenth argument of the invoked method.</typeparam>
+		/// <param name="action">The callback method to invoke.</param>
+		new ICallbackAfterResult Callback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> action);
+
+		/// <summary>
+		/// Specifies a callback that receives the original arguments, to be invoked after a method's return value has been determined.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="T6">The type of the sixth argument of the invoked method.</typeparam>
+		/// <typeparam name="T7">The type of the seventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T8">The type of the eighth argument of the invoked method.</typeparam>
+		/// <typeparam name="T9">The type of the ninth argument of the invoked method.</typeparam>
+		/// <typeparam name="T10">The type of the tenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh argument of the invoked method.</typeparam>
+		/// <param name="action">The callback method to invoke.</param>
+		new ICallbackAfterResult Callback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> action);
+
+		/// <summary>
+		/// Specifies a callback that receives the original arguments, to be invoked after a method's return value has been determined.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="T6">The type of the sixth argument of the invoked method.</typeparam>
+		/// <typeparam name="T7">The type of the seventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T8">The type of the eighth argument of the invoked method.</typeparam>
+		/// <typeparam name="T9">The type of the ninth argument of the invoked method.</typeparam>
+		/// <typeparam name="T10">The type of the tenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T12">The type of the twelfth argument of the invoked method.</typeparam>
+		/// <param name="action">The callback method to invoke.</param>
+		new ICallbackAfterResult Callback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> action);
+
+		/// <summary>
+		/// Specifies a callback that receives the original arguments, to be invoked after a method's return value has been determined.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="T6">The type of the sixth argument of the invoked method.</typeparam>
+		/// <typeparam name="T7">The type of the seventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T8">The type of the eighth argument of the invoked method.</typeparam>
+		/// <typeparam name="T9">The type of the ninth argument of the invoked method.</typeparam>
+		/// <typeparam name="T10">The type of the tenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T12">The type of the twelfth argument of the invoked method.</typeparam>
+		/// <typeparam name="T13">The type of the thirteenth argument of the invoked method.</typeparam>
+		/// <param name="action">The callback method to invoke.</param>
+		new ICallbackAfterResult Callback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> action);
+
+		/// <summary>
+		/// Specifies a callback that receives the original arguments, to be invoked after a method's return value has been determined.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="T6">The type of the sixth argument of the invoked method.</typeparam>
+		/// <typeparam name="T7">The type of the seventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T8">The type of the eighth argument of the invoked method.</typeparam>
+		/// <typeparam name="T9">The type of the ninth argument of the invoked method.</typeparam>
+		/// <typeparam name="T10">The type of the tenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T12">The type of the twelfth argument of the invoked method.</typeparam>
+		/// <typeparam name="T13">The type of the thirteenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T14">The type of the fourteenth argument of the invoked method.</typeparam>
+		/// <param name="action">The callback method to invoke.</param>
+		new ICallbackAfterResult Callback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> action);
+
+		/// <summary>
+		/// Specifies a callback that receives the original arguments, to be invoked after a method's return value has been determined.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="T6">The type of the sixth argument of the invoked method.</typeparam>
+		/// <typeparam name="T7">The type of the seventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T8">The type of the eighth argument of the invoked method.</typeparam>
+		/// <typeparam name="T9">The type of the ninth argument of the invoked method.</typeparam>
+		/// <typeparam name="T10">The type of the tenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T12">The type of the twelfth argument of the invoked method.</typeparam>
+		/// <typeparam name="T13">The type of the thirteenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T14">The type of the fourteenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T15">The type of the fifteenth argument of the invoked method.</typeparam>
+		/// <param name="action">The callback method to invoke.</param>
+		new ICallbackAfterResult Callback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> action);
+
+		/// <summary>
+		/// Specifies a callback that receives the original arguments, to be invoked after a method's return value has been determined.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="T6">The type of the sixth argument of the invoked method.</typeparam>
+		/// <typeparam name="T7">The type of the seventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T8">The type of the eighth argument of the invoked method.</typeparam>
+		/// <typeparam name="T9">The type of the ninth argument of the invoked method.</typeparam>
+		/// <typeparam name="T10">The type of the tenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T12">The type of the twelfth argument of the invoked method.</typeparam>
+		/// <typeparam name="T13">The type of the thirteenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T14">The type of the fourteenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T15">The type of the fifteenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T16">The type of the sixteenth argument of the invoked method.</typeparam>
+		/// <param name="action">The callback method to invoke.</param>
+		new ICallbackAfterResult Callback<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(Action<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16> action);
+	}
+}

--- a/src/Moq/Language/ICallbackAfter.cs
+++ b/src/Moq/Language/ICallbackAfter.cs
@@ -1,0 +1,75 @@
+//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//https://github.com/moq/moq4
+//All rights reserved.
+
+//Redistribution and use in source and binary forms,
+//with or without modification, are permitted provided
+//that the following conditions are met:
+
+//    * Redistributions of source code must retain the
+//    above copyright notice, this list of conditions and
+//    the following disclaimer.
+
+//    * Redistributions in binary form must reproduce
+//    the above copyright notice, this list of conditions
+//    and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
+//    names of its contributors may be used to endorse
+//    or promote products derived from this software
+//    without specific prior written permission.
+
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+//SUCH DAMAGE.
+
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System;
+using System.ComponentModel;
+
+using Moq.Language.Flow;
+
+namespace Moq.Language
+{
+	/// <summary>
+	/// Defines the <c>Callback</c> verb (and overloads) after a preceding <c>Returns</c> or <c>CallBase</c>.
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public partial interface ICallbackAfter : ICallback
+	{
+		/// <summary>
+		/// Specifies a callback of any delegate type to invoke after a method's return value has been determined.
+		/// This overload specifically allows you to define callbacks for methods with by-ref parameters.
+		/// By-ref parameters can be assigned to.
+		/// </summary>
+		/// <param name="callback">The callback method to invoke. Must have return type <c>void</c> (C#) or be a <c>Sub</c> (VB.NET).</param>
+		new ICallbackAfterResult Callback(Delegate callback);
+
+		/// <summary>
+		/// Specifies a callback to invoke after a method's return value has been determined.
+		/// </summary>
+		/// <param name="action">The callback method to invoke.</param>
+		new ICallbackAfterResult Callback(Action action);
+
+		/// <summary>
+		/// Specifies a callback to invoke after a method's return value has been determined.
+		/// </summary>
+		/// <typeparam name="T">The argument type of the invoked method.</typeparam>
+		/// <param name="action">The callback method to invoke.</param>
+		new ICallbackAfterResult Callback<T>(Action<T> action);
+	}
+}

--- a/src/Moq/Language/ICallbackAfter.tt
+++ b/src/Moq/Language/ICallbackAfter.tt
@@ -1,0 +1,75 @@
+<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ output extension=".Generated.cs" #>
+<#@ Assembly Name="System.Core" #>
+<#@ Import Namespace="System.Linq" #>
+//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
+//https://github.com/moq/moq4
+//All rights reserved.
+
+//Redistribution and use in source and binary forms,
+//with or without modification, are permitted provided
+//that the following conditions are met:
+
+//    * Redistributions of source code must retain the
+//    above copyright notice, this list of conditions and
+//    the following disclaimer.
+
+//    * Redistributions in binary form must reproduce
+//    the above copyright notice, this list of conditions
+//    and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+
+//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
+//    names of its contributors may be used to endorse
+//    or promote products derived from this software
+//    without specific prior written permission.
+
+//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+//SUCH DAMAGE.
+
+//[This is the BSD license, see
+// http://www.opensource.org/licenses/bsd-license.php]
+
+using System;
+using Moq.Language.Flow;
+
+namespace Moq.Language
+{
+	partial interface ICallbackAfter
+	{<#
+for (var typeCount = 2; typeCount <= GenericTypeMax; typeCount++)
+{
+	var typeList = GetGenericList(typeCount, GenericTypeFormat);
+#>
+
+		/// <summary>
+		/// Specifies a callback that receives the original arguments, to be invoked after a method's return value has been determined.
+		/// </summary>
+<#
+	for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++)
+	{
+#>
+		/// <typeparam name="T<#= typeIndex #>">The type of the <#=  ConvertToOrdinal(typeIndex) #> argument of the invoked method.</typeparam>
+<#
+	}
+#>
+		/// <param name="action">The callback method to invoke.</param>
+		new ICallbackAfterResult Callback<<#= typeList #>>(Action<<#= typeList #>> action);
+<#
+}
+#>
+	}
+}
+<#@ Include File="..\Includes\GenericTypeParameters.tt" #>

--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -78,6 +78,16 @@
 			<DependentUpon>ICallback.tt</DependentUpon>
 		</Compile>
 
+		<None Update="Language\ICallbackAfter.tt">
+			<Generator>TextTemplatingFileGenerator</Generator>
+			<LastGenOutput>ICallbackAfter.Generated.cs</LastGenOutput>
+		</None>
+		<Compile Update="Language\ICallbackAfter.Generated.cs">
+			<AutoGen>True</AutoGen>
+			<DesignTime>True</DesignTime>
+			<DependentUpon>ICallbackAfter.tt</DependentUpon>
+		</Compile>
+
 		<None Update="Language\IRaise.tt">
 			<Generator>TextTemplatingFileGenerator</Generator>
 			<LastGenOutput>IRaise.Generated.cs</LastGenOutput>

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2007,6 +2007,219 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 665-667
+
+		public class Issues665to667
+		{
+			[Fact]
+			public void Callback_Returns_Callback_invokes_first_callback()
+			{
+				bool firstCallbackInvoked = false;
+
+				var mock = new Mock<Foo>();
+				mock.Setup(m => m.ToString())
+					.Callback(() => firstCallbackInvoked = true)
+					.Returns(() => default(string))
+					.Callback(() => { });
+
+				mock.Object.ToString();
+
+				Assert.True(firstCallbackInvoked);
+			}
+
+			[Fact]
+			public void Callback_Returns_Callback_sets_return_value()
+			{
+				var mock = new Mock<Foo>();
+				mock.Setup(m => m.ToString())
+					.Callback(() => { })
+					.Returns(() => "some string")
+					.Callback(() => { });
+
+				var returnValue = mock.Object.ToString();
+
+				Assert.Equal("some string", returnValue);
+			}
+
+			[Fact]
+			public void Callback_Returns_Callback_invokes_second_callback()
+			{
+				bool secondCallbackInvoked = false;
+
+				var mock = new Mock<Foo>();
+				mock.Setup(m => m.ToString())
+					.Callback(() => { })
+					.Returns(() => default(string))
+					.Callback(() => secondCallbackInvoked = true);
+
+				mock.Object.ToString();
+
+				Assert.True(secondCallbackInvoked);
+			}
+
+			[Fact]
+			public void Callback_CallBase_Callback_invokes_first_callback()
+			{
+				bool firstCallbackInvoked = false;
+
+				var mock = new Mock<Foo>();
+				mock.Setup(m => m.ToString())
+					.Callback(() => firstCallbackInvoked = true)
+					.CallBase()
+					.Callback(() => { });
+
+				mock.Object.ToString();
+
+				Assert.True(firstCallbackInvoked);
+			}
+
+			[Fact]
+			public void Callback_CallBase_Callback_sets_return_value()
+			{
+				var mock = new Mock<Foo>();
+				mock.Setup(m => m.ToString())
+					.Callback(() => { })
+					.CallBase()
+					.Callback(() => { });
+
+				var returnValue = mock.Object.ToString();
+
+				Assert.Equal("original", returnValue);
+			}
+
+			[Fact]
+			public void Callback_CallBase_Callback_invokes_second_callback()
+			{
+				bool secondCallbackInvoked = false;
+
+				var mock = new Mock<Foo>();
+				mock.Setup(m => m.ToString())
+					.Callback(() => { })
+					.CallBase()
+					.Callback(() => secondCallbackInvoked = true);
+
+				mock.Object.ToString();
+
+				Assert.True(secondCallbackInvoked);
+			}
+
+			[Fact]
+			public void Callback_Returns_Callback_Throws_invokes_first_callback()
+			{
+				bool firstCallbackInvoked = false;
+
+				var mock = new Mock<Foo>();
+				mock.Setup(m => m.ToString())
+					.Callback(() => firstCallbackInvoked = true)
+					.Returns(() => default(string))
+					.Callback(() => { })
+					.Throws<Exception>();
+
+				Assert.Throws<Exception>(() => mock.Object.ToString());
+
+				Assert.True(firstCallbackInvoked);
+			}
+
+			[Fact]
+			public void Callback_Returns_Callback_Throws_throws()
+			{
+				var mock = new Mock<Foo>();
+				mock.Setup(m => m.ToString())
+					.Callback(() => { })
+					.Returns(() => "some string")
+					.Callback(() => { })
+					.Throws<Exception>();
+
+				Assert.Throws<Exception>(() => mock.Object.ToString());
+			}
+
+			[Fact]
+			public void Callback_Returns_Callback_Throws_invokes_second_callback()
+			{
+				bool secondCallbackInvoked = false;
+
+				var mock = new Mock<Foo>();
+				mock.Setup(m => m.ToString())
+					.Callback(() => { })
+					.Returns(() => default(string))
+					.Callback(() => secondCallbackInvoked = true)
+					.Throws<Exception>();
+
+				Assert.Throws<Exception>(() => mock.Object.ToString());
+
+				Assert.True(secondCallbackInvoked);
+			}
+
+			[Fact]
+			public void Callback_CallBase_Callback_Throws_invokes_first_callback_and_throws()
+			{
+				bool firstCallbackInvoked = false;
+
+				var mock = new Mock<Foo>();
+				mock.Setup(m => m.ToString())
+					.Callback(() => firstCallbackInvoked = true)
+					.CallBase()
+					.Callback(() => { })
+					.Throws<Exception>();
+
+				Assert.Throws<Exception>(() => mock.Object.ToString());
+
+				Assert.True(firstCallbackInvoked);
+			}
+
+			[Fact]
+			public void Callback_CallBase_Callback_Throws_throws()
+			{
+				var mock = new Mock<Foo>();
+				mock.Setup(m => m.ToString())
+					.Callback(() => { })
+					.CallBase()
+					.Callback(() => { })
+					.Throws<Exception>();
+
+				Assert.Throws<Exception>(() => mock.Object.ToString());
+			}
+
+			[Fact]
+			public void Callback_CallBase_Callback_Throws_invokes_second_callback_and_throws()
+			{
+				bool secondCallbackInvoked = false;
+
+				var mock = new Mock<Foo>();
+				mock.Setup(m => m.ToString())
+					.Callback(() => { })
+					.CallBase()
+					.Callback(() => secondCallbackInvoked = true)
+					.Throws<Exception>();
+
+				Assert.Throws<Exception>(() => mock.Object.ToString());
+
+				Assert.True(secondCallbackInvoked);
+			}
+
+			[Fact]
+			public void Callback_Returns_Callback_CallBase_is_illogical_but_possible()
+			{
+				var mock = new Mock<Foo>();
+				mock.Setup(m => m.ToString())
+					.Callback(() => { })
+					.Returns(() => "changed")
+					.Callback(() => { })
+					.CallBase();
+
+				var returnValue = mock.Object.ToString();
+
+				Assert.Equal("original", returnValue);
+			}
+
+			public class Foo
+			{
+				public override string ToString() => "original";
+			}
+		}
+
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2103,6 +2103,7 @@ namespace Moq.Tests.Regressions
 				Assert.True(secondCallbackInvoked);
 			}
 
+#pragma warning disable 0618
 			[Fact]
 			public void Callback_Returns_Callback_Throws_invokes_first_callback()
 			{
@@ -2133,7 +2134,7 @@ namespace Moq.Tests.Regressions
 				Assert.Throws<Exception>(() => mock.Object.ToString());
 			}
 
-			[Fact]
+			[Fact(Skip = "Fails due to a bug which hasn't been fixed yet, because this use case has been deprecated.")]
 			public void Callback_Returns_Callback_Throws_invokes_second_callback()
 			{
 				bool secondCallbackInvoked = false;
@@ -2180,7 +2181,7 @@ namespace Moq.Tests.Regressions
 				Assert.Throws<Exception>(() => mock.Object.ToString());
 			}
 
-			[Fact]
+			[Fact(Skip = "Fails due to a bug which hasn't been fixed yet, because this use case has been deprecated.")]
 			public void Callback_CallBase_Callback_Throws_invokes_second_callback_and_throws()
 			{
 				bool secondCallbackInvoked = false;
@@ -2196,21 +2197,7 @@ namespace Moq.Tests.Regressions
 
 				Assert.True(secondCallbackInvoked);
 			}
-
-			[Fact]
-			public void Callback_Returns_Callback_CallBase_is_illogical_but_possible()
-			{
-				var mock = new Mock<Foo>();
-				mock.Setup(m => m.ToString())
-					.Callback(() => { })
-					.Returns(() => "changed")
-					.Callback(() => { })
-					.CallBase();
-
-				var returnValue = mock.Object.ToString();
-
-				Assert.Equal("original", returnValue);
-			}
+#pragma warning restore 0618
 
 			public class Foo
 			{


### PR DESCRIPTION
This closes #668 (most of it, anyway).