### PR TITLE
Reformat `License.txt` so GitHub recognizes it 

### DIFF
--- a/License.txt
+++ b/License.txt
@@ -1,39 +1,29 @@
-Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-http://www.moqthis.com/
+BSD 3-Clause License
+
+Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD
 All rights reserved.
 
-Redistribution and use in source and binary forms, 
-with or without modification, are permitted provided 
-that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-    * Redistributions of source code must retain the 
-    above copyright notice, this list of conditions and 
-    the following disclaimer.
-    
-    * Redistributions in binary form must reproduce 
-    the above copyright notice, this list of conditions 
-    and the following disclaimer in the documentation 
-    and/or other materials provided with the distribution.
-    
-    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-    names of its contributors may be used to endorse 
-    or promote products derived from this software 
-    without specific prior written permission.
+    * Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-SUCH DAMAGE.
+    * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
 
-[This is the BSD license, see
- http://opensource.org/licenses/BSD-3-Clause]
+    * Neither the names of the copyright holders nor the names of its
+    contributors may be used to endorse or promote products derived from this
+    software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/Moq/AsInterface.cs
+++ b/src/Moq/AsInterface.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Moq/AutoImplementedPropertyGetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertyGetterSetup.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Linq.Expressions;

--- a/src/Moq/AutoImplementedPropertySetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertySetterSetup.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Linq.Expressions;

--- a/src/Moq/Capture.cs
+++ b/src/Moq/Capture.cs
@@ -1,42 +1,5 @@
-//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Generic;

--- a/src/Moq/CaptureMatch.cs
+++ b/src/Moq/CaptureMatch.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Linq.Expressions;

--- a/src/Moq/Condition.cs
+++ b/src/Moq/Condition.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 

--- a/src/Moq/DefaultExpressionCompiler.cs
+++ b/src/Moq/DefaultExpressionCompiler.cs
@@ -1,42 +1,5 @@
-//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-//
-//Redistribution and use in source and binary forms,
-//with or without modification, are permitted provided
-//that the following conditions are met:
-//
-//    * Redistributions of source code must retain the
-//    above copyright notice, this list of conditions and
-//    the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce
-//    the above copyright notice, this list of conditions
-//    and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
-//    names of its contributors may be used to endorse
-//    or promote products derived from this software
-//    without specific prior written permission.
-//
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-//SUCH DAMAGE.
-//
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Linq.Expressions;

--- a/src/Moq/DefaultValue.cs
+++ b/src/Moq/DefaultValue.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System.ComponentModel;
 

--- a/src/Moq/DefaultValueProvider.cs
+++ b/src/Moq/DefaultValueProvider.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Diagnostics;

--- a/src/Moq/EmptyDefaultValueProvider.cs
+++ b/src/Moq/EmptyDefaultValueProvider.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections;

--- a/src/Moq/Evaluator.cs
+++ b/src/Moq/Evaluator.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Generic;

--- a/src/Moq/EventHandlerCollection.cs
+++ b/src/Moq/EventHandlerCollection.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Generic;

--- a/src/Moq/ExpressionComparer.cs
+++ b/src/Moq/ExpressionComparer.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Generic;

--- a/src/Moq/ExpressionCompiler.cs
+++ b/src/Moq/ExpressionCompiler.cs
@@ -1,42 +1,5 @@
-//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-//
-//Redistribution and use in source and binary forms,
-//with or without modification, are permitted provided
-//that the following conditions are met:
-//
-//    * Redistributions of source code must retain the
-//    above copyright notice, this list of conditions and
-//    the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce
-//    the above copyright notice, this list of conditions
-//    and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
-//    names of its contributors may be used to endorse
-//    or promote products derived from this software
-//    without specific prior written permission.
-//
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-//SUCH DAMAGE.
-//
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.ComponentModel;

--- a/src/Moq/ExpressionExtensions.cs
+++ b/src/Moq/ExpressionExtensions.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Generic;

--- a/src/Moq/ExpressionStringBuilder.cs
+++ b/src/Moq/ExpressionStringBuilder.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Generic;

--- a/src/Moq/FluentMockContext.cs
+++ b/src/Moq/FluentMockContext.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Generic;

--- a/src/Moq/Guard.cs
+++ b/src/Moq/Guard.cs
@@ -1,42 +1,5 @@
-//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Diagnostics;

--- a/src/Moq/IInvocation.cs
+++ b/src/Moq/IInvocation.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.Collections.Generic;
 using System.Reflection;
 
 namespace Moq

--- a/src/Moq/IInvocationList.cs
+++ b/src/Moq/IInvocationList.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-//
-//Redistribution and use in source and binary forms,
-//with or without modification, are permitted provided
-//that the following conditions are met:
-//
-//    * Redistributions of source code must retain the
-//    above copyright notice, this list of conditions and
-//    the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce
-//    the above copyright notice, this list of conditions
-//    and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
-//    names of its contributors may be used to endorse
-//    or promote products derived from this software
-//    without specific prior written permission.
-//
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-//SUCH DAMAGE.
-//
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System.Collections.Generic;
 

--- a/src/Moq/IMatcher.cs
+++ b/src/Moq/IMatcher.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 namespace Moq
 {

--- a/src/Moq/IMock.cs
+++ b/src/Moq/IMock.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
 using System.Diagnostics.CodeAnalysis;
 
 namespace Moq

--- a/src/Moq/IMocked.cs
+++ b/src/Moq/IMocked.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System.ComponentModel;
 

--- a/src/Moq/Interception/IInterceptor.cs
+++ b/src/Moq/Interception/IInterceptor.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 namespace Moq
 {

--- a/src/Moq/Interception/InterceptionAspect.cs
+++ b/src/Moq/Interception/InterceptionAspect.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 namespace Moq
 {

--- a/src/Moq/Interception/InterceptionAspects.cs
+++ b/src/Moq/Interception/InterceptionAspects.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Generic;

--- a/src/Moq/Interception/Mock.cs
+++ b/src/Moq/Interception/Mock.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 namespace Moq
 {

--- a/src/Moq/Invocation.cs
+++ b/src/Moq/Invocation.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System.Collections;
 using System.Collections.Generic;

--- a/src/Moq/InvocationCollection.cs
+++ b/src/Moq/InvocationCollection.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections;

--- a/src/Moq/InvocationShape.cs
+++ b/src/Moq/InvocationShape.cs
@@ -1,42 +1,5 @@
-//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-//
-//Redistribution and use in source and binary forms,
-//with or without modification, are permitted provided
-//that the following conditions are met:
-//
-//    * Redistributions of source code must retain the
-//    above copyright notice, this list of conditions and
-//    the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce
-//    the above copyright notice, this list of conditions
-//    and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
-//    names of its contributors may be used to endorse
-//    or promote products derived from this software
-//    without specific prior written permission.
-//
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-//SUCH DAMAGE.
-//
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Generic;

--- a/src/Moq/It.cs
+++ b/src/Moq/It.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Generic;

--- a/src/Moq/Language/Flow/ICallBaseResult.cs
+++ b/src/Moq/Language/Flow/ICallBaseResult.cs
@@ -1,42 +1,5 @@
-//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-//
-//Redistribution and use in source and binary forms,
-//with or without modification, are permitted provided
-//that the following conditions are met:
-//
-//    * Redistributions of source code must retain the
-//    above copyright notice, this list of conditions and
-//    the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce
-//    the above copyright notice, this list of conditions
-//    and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
-//    names of its contributors may be used to endorse
-//    or promote products derived from this software
-//    without specific prior written permission.
-//
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-//SUCH DAMAGE.
-//
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System.ComponentModel;
 

--- a/src/Moq/Language/Flow/ICallbackResult.cs
+++ b/src/Moq/Language/Flow/ICallbackResult.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System.ComponentModel;
 

--- a/src/Moq/Language/Flow/IReturnsResult.cs
+++ b/src/Moq/Language/Flow/IReturnsResult.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System.ComponentModel;
 

--- a/src/Moq/Language/Flow/IReturnsThrows.cs
+++ b/src/Moq/Language/Flow/IReturnsThrows.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System.ComponentModel;
 

--- a/src/Moq/Language/Flow/ISetup.cs
+++ b/src/Moq/Language/Flow/ISetup.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System.ComponentModel;
 

--- a/src/Moq/Language/Flow/IThrowsResult.cs
+++ b/src/Moq/Language/Flow/IThrowsResult.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System.ComponentModel;
 

--- a/src/Moq/Language/Flow/NonVoidSetupPhrase.cs
+++ b/src/Moq/Language/Flow/NonVoidSetupPhrase.cs
@@ -1,42 +1,5 @@
-//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-//
-//Redistribution and use in source and binary forms,
-//with or without modification, are permitted provided
-//that the following conditions are met:
-//
-//    * Redistributions of source code must retain the
-//    above copyright notice, this list of conditions and
-//    the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce
-//    the above copyright notice, this list of conditions
-//    and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
-//    names of its contributors may be used to endorse
-//    or promote products derived from this software
-//    without specific prior written permission.
-//
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-//SUCH DAMAGE.
-//
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 

--- a/src/Moq/Language/Flow/SetterSetupPhrase.cs
+++ b/src/Moq/Language/Flow/SetterSetupPhrase.cs
@@ -1,42 +1,5 @@
-//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-//
-//Redistribution and use in source and binary forms,
-//with or without modification, are permitted provided
-//that the following conditions are met:
-//
-//    * Redistributions of source code must retain the
-//    above copyright notice, this list of conditions and
-//    the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce
-//    the above copyright notice, this list of conditions
-//    and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
-//    names of its contributors may be used to endorse
-//    or promote products derived from this software
-//    without specific prior written permission.
-//
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-//SUCH DAMAGE.
-//
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 

--- a/src/Moq/Language/Flow/SetupPhrase.cs
+++ b/src/Moq/Language/Flow/SetupPhrase.cs
@@ -1,42 +1,5 @@
-//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-//
-//Redistribution and use in source and binary forms,
-//with or without modification, are permitted provided
-//that the following conditions are met:
-//
-//    * Redistributions of source code must retain the
-//    above copyright notice, this list of conditions and
-//    the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce
-//    the above copyright notice, this list of conditions
-//    and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
-//    names of its contributors may be used to endorse
-//    or promote products derived from this software
-//    without specific prior written permission.
-//
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-//SUCH DAMAGE.
-//
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Diagnostics;

--- a/src/Moq/Language/Flow/SetupSequencePhrase.cs
+++ b/src/Moq/Language/Flow/SetupSequencePhrase.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.ComponentModel;

--- a/src/Moq/Language/Flow/VoidSetupPhrase.cs
+++ b/src/Moq/Language/Flow/VoidSetupPhrase.cs
@@ -1,42 +1,5 @@
-//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-//
-//Redistribution and use in source and binary forms,
-//with or without modification, are permitted provided
-//that the following conditions are met:
-//
-//    * Redistributions of source code must retain the
-//    above copyright notice, this list of conditions and
-//    the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce
-//    the above copyright notice, this list of conditions
-//    and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
-//    names of its contributors may be used to endorse
-//    or promote products derived from this software
-//    without specific prior written permission.
-//
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-//SUCH DAMAGE.
-//
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 

--- a/src/Moq/Language/Flow/WhenPhrase.cs
+++ b/src/Moq/Language/Flow/WhenPhrase.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Linq.Expressions;

--- a/src/Moq/Language/ICallBase.cs
+++ b/src/Moq/Language/ICallBase.cs
@@ -1,42 +1,5 @@
-//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-//
-//Redistribution and use in source and binary forms,
-//with or without modification, are permitted provided
-//that the following conditions are met:
-//
-//    * Redistributions of source code must retain the
-//    above copyright notice, this list of conditions and
-//    the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce
-//    the above copyright notice, this list of conditions
-//    and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
-//    names of its contributors may be used to endorse
-//    or promote products derived from this software
-//    without specific prior written permission.
-//
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-//SUCH DAMAGE.
-//
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System.ComponentModel;
 

--- a/src/Moq/Language/ICallback.Generated.cs
+++ b/src/Moq/Language/ICallback.Generated.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.ComponentModel;

--- a/src/Moq/Language/ICallback.cs
+++ b/src/Moq/Language/ICallback.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.ComponentModel;

--- a/src/Moq/Language/ICallback.tt
+++ b/src/Moq/Language/ICallback.tt
@@ -1,46 +1,9 @@
-﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ template debug="false" hostspecific="false" language="C#" #>
 <#@ output extension=".Generated.cs" #>
 <#@ Assembly Name="System.Core" #>
 <#@ Import Namespace="System.Linq" #>
-//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.ComponentModel;

--- a/src/Moq/Language/ICallbackGetter.cs
+++ b/src/Moq/Language/ICallbackGetter.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.ComponentModel;

--- a/src/Moq/Language/ICallbackSetter.cs
+++ b/src/Moq/Language/ICallbackSetter.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.ComponentModel;

--- a/src/Moq/Language/IRaise.Generated.cs
+++ b/src/Moq/Language/IRaise.Generated.cs
@@ -1,42 +1,6 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
 using System;
 using System.ComponentModel;
 

--- a/src/Moq/Language/IRaise.cs
+++ b/src/Moq/Language/IRaise.cs
@@ -1,42 +1,6 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
 using System;
 using System.ComponentModel;
 

--- a/src/Moq/Language/IRaise.tt
+++ b/src/Moq/Language/IRaise.tt
@@ -1,46 +1,10 @@
-﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ template debug="false" hostspecific="false" language="C#" #>
 <#@ output extension=".Generated.cs" #>
 <#@ Assembly Name="System.Core" #>
 <#@ Import Namespace="System.Linq" #>
-//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
 using System;
 using System.ComponentModel;
 

--- a/src/Moq/Language/IReturns.Generated.cs
+++ b/src/Moq/Language/IReturns.Generated.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.ComponentModel;

--- a/src/Moq/Language/IReturns.cs
+++ b/src/Moq/Language/IReturns.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.ComponentModel;

--- a/src/Moq/Language/IReturns.tt
+++ b/src/Moq/Language/IReturns.tt
@@ -1,46 +1,9 @@
-﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ template debug="false" hostspecific="false" language="C#" #>
 <#@ output extension=".Generated.cs" #>
 <#@ Assembly Name="System.Core" #>
 <#@ Import Namespace="System.Linq" #>
-//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.ComponentModel;

--- a/src/Moq/Language/IReturnsGetter.cs
+++ b/src/Moq/Language/IReturnsGetter.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.ComponentModel;

--- a/src/Moq/Language/ISetupConditionResult.cs
+++ b/src/Moq/Language/ISetupConditionResult.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;

--- a/src/Moq/Language/ISetupSequentialAction.cs
+++ b/src/Moq/Language/ISetupSequentialAction.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.ComponentModel;

--- a/src/Moq/Language/ISetupSequentialResult.cs
+++ b/src/Moq/Language/ISetupSequentialResult.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 

--- a/src/Moq/Language/IThrows.cs
+++ b/src/Moq/Language/IThrows.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.ComponentModel;

--- a/src/Moq/Language/IVerifies.cs
+++ b/src/Moq/Language/IVerifies.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System.ComponentModel;
 

--- a/src/Moq/Linq/FluentMockVisitor.cs
+++ b/src/Moq/Linq/FluentMockVisitor.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Generic;

--- a/src/Moq/Linq/Mock.cs
+++ b/src/Moq/Linq/Mock.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Generic;

--- a/src/Moq/Linq/MockQuery.cs
+++ b/src/Moq/Linq/MockQuery.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections;

--- a/src/Moq/Linq/MockRepository.cs
+++ b/src/Moq/Linq/MockRepository.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Moq/Linq/MockSetupsBuilder.cs
+++ b/src/Moq/Linq/MockSetupsBuilder.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Globalization;

--- a/src/Moq/Linq/Mocks.cs
+++ b/src/Moq/Linq/Mocks.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Generic;

--- a/src/Moq/LookupOrFallbackDefaultValueProvider.cs
+++ b/src/Moq/LookupOrFallbackDefaultValueProvider.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections;

--- a/src/Moq/Match.cs
+++ b/src/Moq/Match.cs
@@ -1,42 +1,5 @@
-//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Diagnostics.CodeAnalysis;

--- a/src/Moq/MatchExpression.cs
+++ b/src/Moq/MatchExpression.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Linq.Expressions;

--- a/src/Moq/MatcherFactory.cs
+++ b/src/Moq/MatcherFactory.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Globalization;

--- a/src/Moq/Matchers/AnyMatcher.cs
+++ b/src/Moq/Matchers/AnyMatcher.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 namespace Moq.Matchers
 {

--- a/src/Moq/Matchers/ConstantMatcher.cs
+++ b/src/Moq/Matchers/ConstantMatcher.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System.Collections;
 using System.Linq;

--- a/src/Moq/Matchers/ExpressionMatcher.cs
+++ b/src/Moq/Matchers/ExpressionMatcher.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Linq.Expressions;

--- a/src/Moq/Matchers/LazyEvalMatcher.cs
+++ b/src/Moq/Matchers/LazyEvalMatcher.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Linq.Expressions;

--- a/src/Moq/Matchers/MatcherAttributeMatcher.cs
+++ b/src/Moq/Matchers/MatcherAttributeMatcher.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Generic;

--- a/src/Moq/Matchers/ParamArrayMatcher.cs
+++ b/src/Moq/Matchers/ParamArrayMatcher.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Linq;

--- a/src/Moq/Matchers/RefMatcher.cs
+++ b/src/Moq/Matchers/RefMatcher.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Linq.Expressions;

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Generic;

--- a/src/Moq/MethodCallReturn.cs
+++ b/src/Moq/MethodCallReturn.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Generic;

--- a/src/Moq/Mock.Generic.cs
+++ b/src/Moq/Mock.Generic.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Moq/MockBehavior.cs
+++ b/src/Moq/MockBehavior.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 namespace Moq
 {

--- a/src/Moq/MockDefaultValueProvider.cs
+++ b/src/Moq/MockDefaultValueProvider.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Diagnostics;

--- a/src/Moq/MockException.cs
+++ b/src/Moq/MockException.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Generic;

--- a/src/Moq/MockExceptionReason.cs
+++ b/src/Moq/MockExceptionReason.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-//
-//Redistribution and use in source and binary forms,
-//with or without modification, are permitted provided
-//that the following conditions are met:
-//
-//    * Redistributions of source code must retain the
-//    above copyright notice, this list of conditions and
-//    the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce
-//    the above copyright notice, this list of conditions
-//    and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
-//    names of its contributors may be used to endorse
-//    or promote products derived from this software
-//    without specific prior written permission.
-//
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-//SUCH DAMAGE.
-//
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 namespace Moq
 {

--- a/src/Moq/MockExtensions.cs
+++ b/src/Moq/MockExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System.ComponentModel;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.ComponentModel;
 
 namespace Moq
 {

--- a/src/Moq/MockRepository.cs
+++ b/src/Moq/MockRepository.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 namespace Moq
 {

--- a/src/Moq/MockSequence.cs
+++ b/src/Moq/MockSequence.cs
@@ -1,4 +1,7 @@
-﻿using System.ComponentModel;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.ComponentModel;
 
 using Moq.Language;
 using Moq.Language.Flow;

--- a/src/Moq/MockWithWrappedMockObject.cs
+++ b/src/Moq/MockWithWrappedMockObject.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System.Threading.Tasks;
 

--- a/src/Moq/Obsolete/IOccurrence.cs
+++ b/src/Moq/Obsolete/IOccurrence.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System.ComponentModel;
 using System;

--- a/src/Moq/Obsolete/MatcherAttribute.cs
+++ b/src/Moq/Obsolete/MatcherAttribute.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.ComponentModel;

--- a/src/Moq/Obsolete/Mock.Generic.Legacy.cs
+++ b/src/Moq/Obsolete/Mock.Generic.Legacy.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.ComponentModel;

--- a/src/Moq/Obsolete/Mock.Legacy.cs
+++ b/src/Moq/Obsolete/Mock.Legacy.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Linq.Expressions;

--- a/src/Moq/Obsolete/MockExtensions.cs
+++ b/src/Moq/Obsolete/MockExtensions.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-//
-//Redistribution and use in source and binary forms,
-//with or without modification, are permitted provided
-//that the following conditions are met:
-//
-//    * Redistributions of source code must retain the
-//    above copyright notice, this list of conditions and
-//    the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce
-//    the above copyright notice, this list of conditions
-//    and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
-//    names of its contributors may be used to endorse
-//    or promote products derived from this software
-//    without specific prior written permission.
-//
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-//SUCH DAMAGE.
-//
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.ComponentModel;

--- a/src/Moq/Obsolete/MockFactory.cs
+++ b/src/Moq/Obsolete/MockFactory.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Generic;

--- a/src/Moq/Obsolete/ObsoleteMockExtensions.cs
+++ b/src/Moq/Obsolete/ObsoleteMockExtensions.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.ComponentModel;

--- a/src/Moq/Obsolete/SequenceExtensions.cs
+++ b/src/Moq/Obsolete/SequenceExtensions.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.ComponentModel;

--- a/src/Moq/ParameterTypes.cs
+++ b/src/Moq/ParameterTypes.cs
@@ -1,42 +1,5 @@
-//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-//
-//Redistribution and use in source and binary forms,
-//with or without modification, are permitted provided
-//that the following conditions are met:
-//
-//    * Redistributions of source code must retain the
-//    above copyright notice, this list of conditions and
-//    the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce
-//    the above copyright notice, this list of conditions
-//    and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
-//    names of its contributors may be used to endorse
-//    or promote products derived from this software
-//    without specific prior written permission.
-//
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-//SUCH DAMAGE.
-//
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections;

--- a/src/Moq/PexProtector.cs
+++ b/src/Moq/PexProtector.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Diagnostics;

--- a/src/Moq/Protected/IProtectedAsMock.cs
+++ b/src/Moq/Protected/IProtectedAsMock.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.ComponentModel;

--- a/src/Moq/Protected/IProtectedMock.cs
+++ b/src/Moq/Protected/IProtectedMock.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;

--- a/src/Moq/Protected/ItExpr.cs
+++ b/src/Moq/Protected/ItExpr.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Diagnostics.CodeAnalysis;

--- a/src/Moq/Protected/ProtectedAsMock.cs
+++ b/src/Moq/Protected/ProtectedAsMock.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Diagnostics;

--- a/src/Moq/Protected/ProtectedExtension.cs
+++ b/src/Moq/Protected/ProtectedExtension.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System.ComponentModel;
 

--- a/src/Moq/Protected/ProtectedMock.cs
+++ b/src/Moq/Protected/ProtectedMock.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Generic;

--- a/src/Moq/ProxyFactories/CastleProxyFactory.cs
+++ b/src/Moq/ProxyFactories/CastleProxyFactory.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Generic;

--- a/src/Moq/ProxyFactories/InterfaceProxy.cs
+++ b/src/Moq/ProxyFactories/InterfaceProxy.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System.ComponentModel;
 using System.Diagnostics;

--- a/src/Moq/ProxyFactories/ProxyFactory.cs
+++ b/src/Moq/ProxyFactories/ProxyFactory.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Reflection;

--- a/src/Moq/Range.cs
+++ b/src/Moq/Range.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 namespace Moq
 {

--- a/src/Moq/ReturnsExtensions.Generated.cs
+++ b/src/Moq/ReturnsExtensions.Generated.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
 

--- a/src/Moq/ReturnsExtensions.cs
+++ b/src/Moq/ReturnsExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
 using Moq.Language;

--- a/src/Moq/ReturnsExtensions.tt
+++ b/src/Moq/ReturnsExtensions.tt
@@ -1,7 +1,10 @@
-﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ template debug="false" hostspecific="false" language="C#" #>
 <#@ output extension=".Generated.cs" #>
 <#@ Assembly Name="System.Core" #>
 <#@ Import Namespace="System.Linq" #>
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
 using System;
 using System.ComponentModel;
 using System.Threading.Tasks;

--- a/src/Moq/SequenceExtensions.cs
+++ b/src/Moq/SequenceExtensions.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.ComponentModel;

--- a/src/Moq/SequenceSetup.cs
+++ b/src/Moq/SequenceSetup.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -1,42 +1,5 @@
-//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-//
-//Redistribution and use in source and binary forms,
-//with or without modification, are permitted provided
-//that the following conditions are met:
-//
-//    * Redistributions of source code must retain the
-//    above copyright notice, this list of conditions and
-//    the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce
-//    the above copyright notice, this list of conditions
-//    and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
-//    names of its contributors may be used to endorse
-//    or promote products derived from this software
-//    without specific prior written permission.
-//
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-//SUCH DAMAGE.
-//
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System.Diagnostics;
 using System.Linq.Expressions;

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Generic;

--- a/src/Moq/SetupWithOutParameterSupport.cs
+++ b/src/Moq/SetupWithOutParameterSupport.cs
@@ -1,42 +1,5 @@
-//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-//
-//Redistribution and use in source and binary forms,
-//with or without modification, are permitted provided
-//that the following conditions are met:
-//
-//    * Redistributions of source code must retain the
-//    above copyright notice, this list of conditions and
-//    the following disclaimer.
-//
-//    * Redistributions in binary form must reproduce
-//    the above copyright notice, this list of conditions
-//    and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the
-//    names of its contributors may be used to endorse
-//    or promote products derived from this software
-//    without specific prior written permission.
-//
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-//SUCH DAMAGE.
-//
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections.Generic;

--- a/src/Moq/StringBuilderExtensions.cs
+++ b/src/Moq/StringBuilderExtensions.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Collections;

--- a/src/Moq/Switches.cs
+++ b/src/Moq/Switches.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 

--- a/src/Moq/Times.cs
+++ b/src/Moq/Times.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using System.Globalization;

--- a/tests/Moq.Tests.VisualBasic/IssueReports.vb
+++ b/tests/Moq.Tests.VisualBasic/IssueReports.vb
@@ -1,4 +1,7 @@
-﻿Imports Moq
+' Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+' All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+Imports Moq
 Imports Xunit
 
 

--- a/tests/Moq.Tests/AsInterfaceFixture.cs
+++ b/tests/Moq.Tests/AsInterfaceFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Diagnostics;
 using Xunit;
 

--- a/tests/Moq.Tests/CallBaseFixture.cs
+++ b/tests/Moq.Tests/CallBaseFixture.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
 using Xunit;
 
 namespace Moq.Tests

--- a/tests/Moq.Tests/CallbackDelegateValidationFixture.cs
+++ b/tests/Moq.Tests/CallbackDelegateValidationFixture.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/tests/Moq.Tests/CallbacksFixture.cs
+++ b/tests/Moq.Tests/CallbacksFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using Xunit;
 
 namespace Moq.Tests

--- a/tests/Moq.Tests/CaptureFixture.cs
+++ b/tests/Moq.Tests/CaptureFixture.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.Collections.Generic;
 using Xunit;
 
 namespace Moq.Tests

--- a/tests/Moq.Tests/CaptureMatchFixture.cs
+++ b/tests/Moq.Tests/CaptureMatchFixture.cs
@@ -1,4 +1,7 @@
-﻿using Xunit;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using Xunit;
 
 namespace Moq.Tests
 {

--- a/tests/Moq.Tests/ConditionalSetupFixture.cs
+++ b/tests/Moq.Tests/ConditionalSetupFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using Xunit;
 
 namespace Moq.Tests

--- a/tests/Moq.Tests/CustomDefaultValueProviderFixture.cs
+++ b/tests/Moq.Tests/CustomDefaultValueProviderFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using Xunit;
 
 namespace Moq.Tests

--- a/tests/Moq.Tests/CustomMatcherFixture.cs
+++ b/tests/Moq.Tests/CustomMatcherFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using Xunit;
 
 namespace Moq.Tests

--- a/tests/Moq.Tests/DefaultValueProviderFixture.cs
+++ b/tests/Moq.Tests/DefaultValueProviderFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Reflection;
 
 using Xunit;

--- a/tests/Moq.Tests/Demo.cs
+++ b/tests/Moq.Tests/Demo.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using Xunit;
 
 namespace Moq.Tests

--- a/tests/Moq.Tests/EmptyDefaultValueProviderFixture.cs
+++ b/tests/Moq.Tests/EmptyDefaultValueProviderFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/tests/Moq.Tests/ExpressionExtensionsFixture.cs
+++ b/tests/Moq.Tests/ExpressionExtensionsFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;

--- a/tests/Moq.Tests/ExtensibilityFixture.cs
+++ b/tests/Moq.Tests/ExtensibilityFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;

--- a/tests/Moq.Tests/ExtensionsFixture.cs
+++ b/tests/Moq.Tests/ExtensionsFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/tests/Moq.Tests/GeneratedReturnsExtensionsFixture.cs
+++ b/tests/Moq.Tests/GeneratedReturnsExtensionsFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;

--- a/tests/Moq.Tests/InvocationsFixture.cs
+++ b/tests/Moq.Tests/InvocationsFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using Xunit;
 
 namespace Moq.Tests

--- a/tests/Moq.Tests/Linq/MockRepositoryQuerying.cs
+++ b/tests/Moq.Tests/Linq/MockRepositoryQuerying.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/tests/Moq.Tests/Linq/QueryableMocksFixture.cs
+++ b/tests/Moq.Tests/Linq/QueryableMocksFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Linq;
 using Xunit;
 using System.Collections.Generic;

--- a/tests/Moq.Tests/Linq/SupportedQuerying.cs
+++ b/tests/Moq.Tests/Linq/SupportedQuerying.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/tests/Moq.Tests/Linq/UnsupportedQuerying.cs
+++ b/tests/Moq.Tests/Linq/UnsupportedQuerying.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/tests/Moq.Tests/LookupOrFallbackDefaultValueProviderFixture.cs
+++ b/tests/Moq.Tests/LookupOrFallbackDefaultValueProviderFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;

--- a/tests/Moq.Tests/MatcherAttributeFixture.cs
+++ b/tests/Moq.Tests/MatcherAttributeFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using Xunit;
 
 namespace Moq.Tests

--- a/tests/Moq.Tests/Matchers/AnyMatcherFixture.cs
+++ b/tests/Moq.Tests/Matchers/AnyMatcherFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Linq.Expressions;
 using Xunit;
 

--- a/tests/Moq.Tests/MatchersFixture.cs
+++ b/tests/Moq.Tests/MatchersFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text.RegularExpressions;

--- a/tests/Moq.Tests/MockBehaviorFixture.cs
+++ b/tests/Moq.Tests/MockBehaviorFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;

--- a/tests/Moq.Tests/MockDefaultValueProviderFixture.cs
+++ b/tests/Moq.Tests/MockDefaultValueProviderFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/tests/Moq.Tests/MockFixture.cs
+++ b/tests/Moq.Tests/MockFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 #if NETCORE

--- a/tests/Moq.Tests/MockRepositoryFixture.cs
+++ b/tests/Moq.Tests/MockRepositoryFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Linq.Expressions;
 using Xunit;
 

--- a/tests/Moq.Tests/MockSequenceFixture.cs
+++ b/tests/Moq.Tests/MockSequenceFixture.cs
@@ -1,4 +1,7 @@
-﻿using Xunit;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using Xunit;
 
 namespace Moq.Tests
 {

--- a/tests/Moq.Tests/MockedDelegatesFixture.cs
+++ b/tests/Moq.Tests/MockedDelegatesFixture.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
 using System;
 using System.ComponentModel;
 using Xunit;

--- a/tests/Moq.Tests/MockedEventsFixture.cs
+++ b/tests/Moq.Tests/MockedEventsFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;

--- a/tests/Moq.Tests/MockedFixture.cs
+++ b/tests/Moq.Tests/MockedFixture.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
 using System;
 using Xunit;
 

--- a/tests/Moq.Tests/OccurrenceFixture.cs
+++ b/tests/Moq.Tests/OccurrenceFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using Xunit;
 
 namespace Moq.Tests

--- a/tests/Moq.Tests/OutRefFixture.cs
+++ b/tests/Moq.Tests/OutRefFixture.cs
@@ -1,4 +1,7 @@
-﻿using Xunit;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using Xunit;
 using System;
 
 namespace Moq.Tests

--- a/tests/Moq.Tests/PropertiesFixture.cs
+++ b/tests/Moq.Tests/PropertiesFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/tests/Moq.Tests/ProtectedAsMockFixture.cs
+++ b/tests/Moq.Tests/ProtectedAsMockFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Collections.Generic;
 
 using Moq.Protected;

--- a/tests/Moq.Tests/ProtectedMockFixture.cs
+++ b/tests/Moq.Tests/ProtectedMockFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using Moq.Protected;
 using Xunit;
 using System.Linq.Expressions;

--- a/tests/Moq.Tests/RecursiveMocksFixture.cs
+++ b/tests/Moq.Tests/RecursiveMocksFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using Xunit;
 
 namespace Moq.Tests

--- a/tests/Moq.Tests/Regressions/FluentMockIssues.cs
+++ b/tests/Moq.Tests/Regressions/FluentMockIssues.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 #if FEATURE_SERIALIZATION
 using System.Runtime.Serialization;
 #endif

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/Moq.Tests/Regressions/StreamFixture.cs
+++ b/tests/Moq.Tests/Regressions/StreamFixture.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.Diagnostics;
 using System.IO;
 using Xunit;
 

--- a/tests/Moq.Tests/ReturnsDelegateValidationFixture.cs
+++ b/tests/Moq.Tests/ReturnsDelegateValidationFixture.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/tests/Moq.Tests/ReturnsExtensionsFixture.cs
+++ b/tests/Moq.Tests/ReturnsExtensionsFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using Xunit;

--- a/tests/Moq.Tests/ReturnsFixture.cs
+++ b/tests/Moq.Tests/ReturnsFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 
 using Xunit;
 using System.Collections.Generic;

--- a/tests/Moq.Tests/ReturnsValidationFixture.cs
+++ b/tests/Moq.Tests/ReturnsValidationFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Reflection;
 
 using Moq.Language.Flow;

--- a/tests/Moq.Tests/SequenceExtensionsFixture.cs
+++ b/tests/Moq.Tests/SequenceExtensionsFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using System.Threading.Tasks;
 using Xunit;
 

--- a/tests/Moq.Tests/SequentialActionExtensionsFixture.cs
+++ b/tests/Moq.Tests/SequentialActionExtensionsFixture.cs
@@ -1,42 +1,5 @@
-﻿//Copyright (c) 2007. Clarius Consulting, Manas Technology Solutions, InSTEDD
-//https://github.com/moq/moq4
-//All rights reserved.
-
-//Redistribution and use in source and binary forms, 
-//with or without modification, are permitted provided 
-//that the following conditions are met:
-
-//    * Redistributions of source code must retain the 
-//    above copyright notice, this list of conditions and 
-//    the following disclaimer.
-
-//    * Redistributions in binary form must reproduce 
-//    the above copyright notice, this list of conditions 
-//    and the following disclaimer in the documentation 
-//    and/or other materials provided with the distribution.
-
-//    * Neither the name of Clarius Consulting, Manas Technology Solutions or InSTEDD nor the 
-//    names of its contributors may be used to endorse 
-//    or promote products derived from this software 
-//    without specific prior written permission.
-
-//THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
-//CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
-//INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
-//MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-//DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
-//CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
-//SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-//SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-//INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-//WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
-//NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-//OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF 
-//SUCH DAMAGE.
-
-//[This is the BSD license, see
-// http://www.opensource.org/licenses/bsd-license.php]
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
 using Xunit;

--- a/tests/Moq.Tests/StringExtensions.cs
+++ b/tests/Moq.Tests/StringExtensions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/tests/Moq.Tests/StubExtensionsFixture.cs
+++ b/tests/Moq.Tests/StubExtensionsFixture.cs
@@ -1,4 +1,7 @@
-﻿using System.Diagnostics;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.Diagnostics;
 using Xunit;
 
 namespace Moq.Tests

--- a/tests/Moq.Tests/TimesFixture.cs
+++ b/tests/Moq.Tests/TimesFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using Xunit;
 
 namespace Moq.Tests

--- a/tests/Moq.Tests/VerifyFixture.cs
+++ b/tests/Moq.Tests/VerifyFixture.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
 using Moq;
 using Xunit;
 


### PR DESCRIPTION
This follows up on #683.

* The `License.txt` is reformatted so that GitHub recognizes the license as BSD 3-Clause. This reformatting consists mostly of line break changes.

* All source code files are updated to include a two-line copyright notice referring to `License.txt`. Much shorter than the current 39-line texts.

* While we're changing the first line of every source code file, let's take the opportunity to normalize UTF-8 BOMs at the same time. (That is, remove them everywhere).

Closes #669.

/cc @kzu, @retslig