### PR TITLE
Make multi-line comparisons in tests ignorant of CRLF/LF

### DIFF
--- a/tests/Moq.Tests/MockRepositoryFixture.cs
+++ b/tests/Moq.Tests/MockRepositoryFixture.cs
@@ -97,14 +97,13 @@ namespace Moq.Tests
 
 			var ex = Record.Exception(() => repository.VerifyNoOtherCalls());
 
-			var expectedErrorMessage = $"The following invocations on mock \'{fooMock}\' were not verified:{Environment.NewLine}" +
-									   $"IFoo.Do(){Environment.NewLine}" +
-									   Environment.NewLine +
-									   $"The following invocations on mock \'{barMock}\' were not verified:{Environment.NewLine}" +
-									   $"IBar.Redo(){Environment.NewLine}";
-
 			Assert.NotNull(ex);
-			Assert.Equal(expectedErrorMessage, ex.Message);
+			Assert.True(ex.Message.ContainsConsecutiveLines(
+				$"The following invocations on mock \'{fooMock}\' were not verified:",
+				$"IFoo.Do()",
+				$"",
+				$"The following invocations on mock \'{barMock}\' were not verified:",
+				$"IBar.Redo()"));
 		}
 
 		[Fact]
@@ -140,14 +139,13 @@ namespace Moq.Tests
 
 			var ex = Record.Exception(() => repository.VerifyAll());
 
-			var expectedErrorMessage = $"The following setups on mock \'{foo}\' were not matched:{Environment.NewLine}" +
-									   $"IFoo f => f.Do(){Environment.NewLine}" +
-									   Environment.NewLine +
-									   $"The following setups on mock \'{bar}\' were not matched:{Environment.NewLine}" +
-									   $"IBar b => b.Redo(){Environment.NewLine}";
-
 			Assert.NotNull(ex);
-			Assert.Equal(expectedErrorMessage, ex.Message);
+			Assert.True(ex.Message.ContainsConsecutiveLines(
+				$"The following setups on mock \'{foo}\' were not matched:",
+				$"IFoo f => f.Do()",
+				$"",
+				$"The following setups on mock \'{bar}\' were not matched:",
+				$"IBar b => b.Redo()"));
 		}
 
 		[Fact]

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2980,11 +2980,10 @@ namespace Moq.Tests.Regressions
 				mock.Object.Execute(5);
 
 				var e = Assert.Throws<MockException>(() => mock.Verify(m => m.Execute(0)));
-				Assert.Contains(
-					Environment.NewLine + "Configured setups: " +
-					Environment.NewLine + "IFoo m => m.Execute(1)" +
-					Environment.NewLine + "IFoo m => m.Execute(It.IsInRange<Int32>(2, 20, Range.Exclusive))",
-					e.Message);
+				Assert.True(e.Message.ContainsConsecutiveLines(
+					"Configured setups: ",
+					"IFoo m => m.Execute(1)",
+					"IFoo m => m.Execute(It.IsInRange<Int32>(2, 20, Range.Exclusive))"));
 			}
 
 			[Fact]
@@ -2997,10 +2996,9 @@ namespace Moq.Tests.Regressions
 				mock.Object.Execute(1, 10);
 
 				var e = Assert.Throws<MockException>(() => mock.Verify(m => m.Execute<int>(1, 1)));
-				Assert.Contains(
-					Environment.NewLine + "Configured setups: " +
-					Environment.NewLine + "IFoo m => m.Execute<Int32>(1, 10)",
-					e.Message);
+				Assert.True(e.Message.ContainsConsecutiveLines(
+					"Configured setups: ",
+					"IFoo m => m.Execute<Int32>(1, 10)"));
 			}
 
 			[Fact]
@@ -3009,9 +3007,7 @@ namespace Moq.Tests.Regressions
 				var mock = new Mock<IFoo>();
 
 				var e = Assert.Throws<MockException>(() => mock.Verify(m => m.Execute(1)));
-				Assert.Contains(
-					Environment.NewLine + "No setups configured.",
-					e.Message);
+				Assert.Contains("No setups configured.", e.Message);
 
 			}
 

--- a/tests/Moq.Tests/StringExtensions.cs
+++ b/tests/Moq.Tests/StringExtensions.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Moq.Tests
+{
+	public static class StringExtensions
+	{
+		public static bool ContainsConsecutiveLines(this string str, params string[] lines)
+		{
+			var haystack = str.Replace("\r\n", "\n");
+			var needle = string.Join("\n", lines);
+			return haystack.Contains(needle);
+		}
+	}
+}

--- a/tests/Moq.Tests/VerifyFixture.cs
+++ b/tests/Moq.Tests/VerifyFixture.cs
@@ -837,14 +837,12 @@ namespace Moq.Tests
 
 			var mex = Assert.Throws<MockException>(() => mock.Verify(f => f.Execute("pong")));
 
-			Assert.Contains(
-				Environment.NewLine +
-				"Performed invocations: " + Environment.NewLine +
-				"IFoo.Execute(\"ping\")" + Environment.NewLine +
-				"IFoo.Echo(42)" + Environment.NewLine +
-				"IFoo.Submit()" + Environment.NewLine +
-				"IFoo.Save([1, 2, \"hello\"])",
-				mex.Message);
+			Assert.True(mex.Message.ContainsConsecutiveLines(
+				"Performed invocations: ",
+				"IFoo.Execute(\"ping\")",
+				"IFoo.Echo(42)",
+				"IFoo.Submit()",
+				"IFoo.Save([1, 2, \"hello\"])"));
 		}
 
 		[Fact]
@@ -875,7 +873,7 @@ namespace Moq.Tests
 
 			MockException mex = Assert.Throws<MockException>(() => mock.Verify(f => f.Execute("pong")));
 
-			Assert.Contains(Environment.NewLine + "No invocations performed.", mex.Message);
+			Assert.Contains("No invocations performed.", mex.Message);
 		}
 
 		[Fact]
@@ -885,7 +883,7 @@ namespace Moq.Tests
 
 			MockException mex = Assert.Throws<MockException>(() => mock.Verify(f => f.Execute("pong")));
 
-			Assert.Contains(Environment.NewLine + "No setups configured.", mex.Message);
+			Assert.Contains("No setups configured.", mex.Message);
 		}
 
 		[Fact]
@@ -905,10 +903,9 @@ namespace Moq.Tests
 			var mock = new Mock<IArrays>();
 			mock.Object.Method(strings);
 			var mex = Assert.Throws<MockException>(() => mock.Verify(_ => _.Method(null)));
-			Assert.Contains(
-				@"Performed invocations: " + Environment.NewLine +
-				@"IArrays.Method([""1"", null, ""3""])",
-				mex.Message);
+			Assert.True(mex.Message.ContainsConsecutiveLines(
+				@"Performed invocations: ",
+				@"IArrays.Method([""1"", null, ""3""])"));
 		}
 
 		[Fact]
@@ -918,10 +915,9 @@ namespace Moq.Tests
 			var mock = new Mock<IArrays>();
 			mock.Object.Method(strings);
 			var mex = Assert.Throws<MockException>(() => mock.Verify(_ => _.Method(null)));
-			Assert.Contains(
-				@"Performed invocations: " + Environment.NewLine +
-				@"IArrays.Method([""1"", null, ""3"", ""4"", ""5"", ""6"", ""7"", ""8"", ""9"", ""10""])",
-				mex.Message);
+			Assert.True(mex.Message.ContainsConsecutiveLines(
+				@"Performed invocations: ",
+				@"IArrays.Method([""1"", null, ""3"", ""4"", ""5"", ""6"", ""7"", ""8"", ""9"", ""10""])"));
 		}
 
 		[Fact]
@@ -931,10 +927,9 @@ namespace Moq.Tests
 			var mock = new Mock<IArrays>();
 			mock.Object.Method(strings);
 			var mex = Assert.Throws<MockException>(() => mock.Verify(_ => _.Method(null)));
-			Assert.Contains(
-				@"Performed invocations: " + Environment.NewLine +
-				@"IArrays.Method([""1"", null, ""3"", ""4"", ""5"", ""6"", ""7"", ""8"", ""9"", ""10"", ...])",
-				mex.Message);
+			Assert.True(mex.Message.ContainsConsecutiveLines(
+				@"Performed invocations: ",
+				@"IArrays.Method([""1"", null, ""3"", ""4"", ""5"", ""6"", ""7"", ""8"", ""9"", ""10"", ...])"));
 		}
 
 		[Fact]


### PR DESCRIPTION
This removes all mentions of `"\r\n"`, `"\n"`, or `Environment.NewLine` from individual tests. A new helper method is used wherever multi-line string comparisons need to be performed.