### PR TITLE
Support mocking of event subscription using SetupSet

### DIFF
--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -72,6 +72,11 @@ namespace Moq
 			return method.Name.StartsWith("remove_", StringComparison.Ordinal);
 		}
 
+		public static bool ProbablyEventAttachOrDetach(this MethodInfo method)
+		{
+			return method.IsSpecialName && (method.LooksLikeEventAttach() || method.LooksLikeEventDetach());
+		}
+
 		/// <summary>
 		/// Tests if a type is a delegate type (subclasses <see cref="Delegate" />).
 		/// </summary>

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -431,6 +431,8 @@ namespace Moq
 
 		#region Setup
 
+		internal bool HasEventSetup { get; private set; } = false;
+
 		[DebuggerStepThrough]
 		internal static VoidSetupPhrase<T> Setup<T>(Mock<T> mock, Expression<Action<T>> expression, Condition condition)
 			where T : class
@@ -612,7 +614,11 @@ namespace Moq
 				}
 
 				var setter = last.Invocation.Method;
-				if (!setter.IsPropertySetter())
+				if (setter.ProbablyEventAttachOrDetach())
+				{
+					mock.HasEventSetup = true;
+				}
+				else if (!setter.IsPropertySetter())
 				{
 					throw new ArgumentException(Resources.SetupNotSetter);
 				}

--- a/tests/Moq.Tests/MockedEventsFixture.cs
+++ b/tests/Moq.Tests/MockedEventsFixture.cs
@@ -595,6 +595,28 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public void SetupSetOfEventAttach()
+		{
+			var mock = new Mock<IWithEvent>();
+			int attachAndDetachCount = 0;
+			string message = null;
+			int? value = null;
+			CustomEvent attachedHandler = null;
+			CustomEvent detachedHandler = null;
+			CustomEvent handler = (m, v) => { message = m; value = v; };
+
+			mock.SetupSet(w => w.CustomEvent += It.IsAny<CustomEvent>()).Callback(new Action<CustomEvent>(handler_ => { ++attachAndDetachCount; attachedHandler = handler_; }));
+			mock.SetupSet(w => w.CustomEvent -= It.IsAny<CustomEvent>()).Callback(new Action<CustomEvent>(handler_ => { ++attachAndDetachCount; detachedHandler = handler_; }));
+
+			mock.Object.CustomEvent += handler;
+			mock.Object.CustomEvent -= handler;
+
+			Assert.Equal(2, attachAndDetachCount);
+			Assert.Equal(handler, attachedHandler);
+			Assert.Equal(handler, detachedHandler);
+		}
+
+		[Fact]
 		public void ShouldSuccessfullyAttachToEventForwaredToAProtectedEvent()
 		{
 			var mock = new Mock<FordawrdEventDoProtectedImplementation>();


### PR DESCRIPTION
I needed a functionality of mocking the add/remove methods of an vent and I wondered if this contribution is helpful for others.
There are two possible concerns: First, now mocking an event has two APIs. One - the old Raise method, and the other - by intercepting the add/remove methods. Second, for backward compatibility I needed to leave MockBehavior.Strict to ignore non explicitly mocked events (not only BW, it seems reasonable due to the classic API of the Raise method). In my opinion it still worth it.

If deciding to pull, I think that some unit tests still missing (I added only one to demonstrate the use). I'll be happy to hear what should be covered.