### PR TITLE
Support indexer with multiple arguments

### DIFF
--- a/src/Moq/Mock.Generic.cs
+++ b/src/Moq/Mock.Generic.cs
@@ -344,12 +344,6 @@ namespace Moq
 			return Mock.SetupSet<T>(this, setterExpression, null);
 		}
 
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupIndexerSet"]/*'/>
-		public ISetup<T> SetupSetMethod<T1, T2, TProperty>(Expression<Action<Action<T1, T2, TProperty>>> setter)
-		{
-			return Mock.SetupSetMethod<T, TProperty>(this, new Type[] { typeof(T1), typeof(T2) }, setter);
-		}
-
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupProperty(property)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		[SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Property", Justification = "This sets properties, so it's appropriate.")]

--- a/src/Moq/Mock.Generic.cs
+++ b/src/Moq/Mock.Generic.cs
@@ -344,6 +344,12 @@ namespace Moq
 			return Mock.SetupSet<T>(this, setterExpression, null);
 		}
 
+		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupIndexerSet"]/*'/>
+		public ISetup<T> SetupSetMethod<T1, T2, TProperty>(Expression<Action<Action<T1, T2, TProperty>>> setter)
+		{
+			return Mock.SetupSetMethod<T, TProperty>(this, new Type[] { typeof(T1), typeof(T2) }, setter);
+		}
+
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupProperty(property)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		[SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Property", Justification = "This sets properties, so it's appropriate.")]

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -682,28 +682,6 @@ namespace Moq
 			}
 		}
 
-		internal static ISetup<T> SetupSetMethod<T, TProperty>(
-			Mock<T> mock,
-			Type[] argumentTypes,
-			LambdaExpression setter)
-			where T : class
-		{
-			Expression actionParameter = setter.Parameters.Single();
-			if (!(setter.Body is InvocationExpression call) || call.Expression != actionParameter)
-			{
-				throw new InvalidOperationException("Expected only call to the indexer method given in the lambda parameter");
-			}
-
-			PropertyInfo indexer = typeof(T).GetProperty("Item", typeof(TProperty), argumentTypes);
-			MethodInfo setterMethod = indexer.GetSetMethod();
-			ParameterExpression instanceLambdaArg = Expression.Parameter(typeof(T), "inst");
-			Expression<Action<T>> callSetter = Expression.Lambda<Action<T>>(
-				Expression.Call(instanceLambdaArg, setterMethod, call.Arguments),
-				instanceLambdaArg);
-
-			return Setup(mock, callSetter, condition: null);
-		}
-
 		private static Expression GetValueExpression(object value, Type type)
 		{
 			if (value != null && value.GetType() == type)

--- a/tests/Moq.Tests/CallbacksFixture.cs
+++ b/tests/Moq.Tests/CallbacksFixture.cs
@@ -474,6 +474,105 @@ namespace Moq.Tests
 			Assert.Equal("input", value);
 		}
 
+		[Fact]
+		public void CallbackWithIndexerGetter()
+		{
+			int x = default(int);
+
+			var mock = new Mock<IFoo>();
+			mock.Setup(f => f[It.IsAny<int>()])
+				.Callback(new Action<int>(x_ => x = x_))
+				.Returns(32);
+
+			int result = mock.Object[17];
+			Assert.Equal(17, x);
+			Assert.Equal(32, result);
+		}
+
+		[Fact]
+		public void CallbackWithIndexerSetter()
+		{
+			int x = default(int);
+			int result = default(int);
+
+			var mock = new Mock<IFoo>();
+			mock.SetupSet(f => f[10] = It.IsAny<int>())
+				.Callback(new Action<int, int>((x_, result_) =>
+				{
+					x = x_;
+					result = result_;
+				}));
+
+			mock.Object[10] = 5;
+			Assert.Equal(10, x);
+			Assert.Equal(5, result);
+		}
+
+		[Fact]
+		public void CallbackWithMultipleArgumentIndexerGetter()
+		{
+			int x = default(int);
+			int y = default(int);
+
+			var mock = new Mock<IFoo>();
+			mock.Setup(f => f[It.IsAny<int>(), It.IsAny<int>()])
+				.Callback(new Action<int, int>((x_, y_) =>
+				{
+					x = x_;
+					y = y_;
+				}))
+				.Returns(14);
+
+			int result = mock.Object[20, 22];
+			Assert.Equal(20, x);
+			Assert.Equal(22, y);
+			Assert.Equal(14, result);
+		}
+
+		[Fact]
+		public void CallbackWithMultipleArgumentIndexerSetterWithoutAny()
+		{
+			int x = default(int);
+			int y = default(int);
+			int result = default(int);
+
+			var mock = new Mock<IFoo>();
+			mock.SetupSet(f => f[3, 13] = It.IsAny<int>())
+				.Callback(new Action<int, int, int>((x_, y_, result_) =>
+				{
+					x = x_;
+					y = y_;
+					result = result_;
+				}));
+
+			mock.Object[3, 13] = 2;
+			Assert.Equal(3, x);
+			Assert.Equal(13, y);
+			Assert.Equal(2, result);
+		}
+
+		[Fact]
+		public void CallbackWithMultipleArgumentIndexerSetterWithAny()
+		{
+			int x = default(int);
+			int y = default(int);
+			int result = default(int);
+
+			var mock = new Mock<IFoo>();
+			mock.SetupSetMethod<int, int, int>(setter => setter(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()))
+				.Callback(new Action<int, int, int>((x_, y_, result_) =>
+				{
+					x = x_;
+					y = y_;
+					result = result_;
+				}));
+
+			mock.Object[3, 13] = 2;
+			Assert.Equal(3, x);
+			Assert.Equal(13, y);
+			Assert.Equal(2, result);
+		}
+
 		public interface IInterface
 		{
 			void Method(Derived b);
@@ -490,7 +589,7 @@ namespace Moq.Tests
 		private void TraceMe(Base b)
 		{
 		}
-		
+
 		public interface IFoo
 		{
 			void Submit();
@@ -515,6 +614,10 @@ namespace Moq.Tests
 			string Execute(ref string arg1, string arg2);
 
 			int Value { get; set; }
+
+			int this[int x] { get; set; }
+
+			int this[int x, int y] { get; set; }
 		}
 
 		public delegate void ExecuteRHandler(ref string arg1);

--- a/tests/Moq.Tests/CallbacksFixture.cs
+++ b/tests/Moq.Tests/CallbacksFixture.cs
@@ -475,21 +475,6 @@ namespace Moq.Tests
 		}
 
 		[Fact]
-		public void CallbackWithIndexerGetter()
-		{
-			int x = default(int);
-
-			var mock = new Mock<IFoo>();
-			mock.Setup(f => f[It.IsAny<int>()])
-				.Callback(new Action<int>(x_ => x = x_))
-				.Returns(32);
-
-			int result = mock.Object[17];
-			Assert.Equal(17, x);
-			Assert.Equal(32, result);
-		}
-
-		[Fact]
 		public void CallbackWithIndexerSetter()
 		{
 			int x = default(int);
@@ -509,27 +494,6 @@ namespace Moq.Tests
 		}
 
 		[Fact]
-		public void CallbackWithMultipleArgumentIndexerGetter()
-		{
-			int x = default(int);
-			int y = default(int);
-
-			var mock = new Mock<IFoo>();
-			mock.Setup(f => f[It.IsAny<int>(), It.IsAny<int>()])
-				.Callback(new Action<int, int>((x_, y_) =>
-				{
-					x = x_;
-					y = y_;
-				}))
-				.Returns(14);
-
-			int result = mock.Object[20, 22];
-			Assert.Equal(20, x);
-			Assert.Equal(22, y);
-			Assert.Equal(14, result);
-		}
-
-		[Fact]
 		public void CallbackWithMultipleArgumentIndexerSetterWithoutAny()
 		{
 			int x = default(int);
@@ -538,28 +502,6 @@ namespace Moq.Tests
 
 			var mock = new Mock<IFoo>();
 			mock.SetupSet(f => f[3, 13] = It.IsAny<int>())
-				.Callback(new Action<int, int, int>((x_, y_, result_) =>
-				{
-					x = x_;
-					y = y_;
-					result = result_;
-				}));
-
-			mock.Object[3, 13] = 2;
-			Assert.Equal(3, x);
-			Assert.Equal(13, y);
-			Assert.Equal(2, result);
-		}
-
-		[Fact]
-		public void CallbackWithMultipleArgumentIndexerSetterWithAny()
-		{
-			int x = default(int);
-			int y = default(int);
-			int result = default(int);
-
-			var mock = new Mock<IFoo>();
-			mock.SetupSetMethod<int, int, int>(setter => setter(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()))
 				.Callback(new Action<int, int, int>((x_, y_, result_) =>
 				{
 					x = x_;
@@ -589,7 +531,7 @@ namespace Moq.Tests
 		private void TraceMe(Base b)
 		{
 		}
-
+		
 		public interface IFoo
 		{
 			void Submit();


### PR DESCRIPTION
This PR contains support in multiple arguments.

1. Fix null reference exception in case of multiple arguments indexer.
2. Proposal for new API method SetupSetMethod which allows using It.IsAny for the indexer arguments (can be used also for properties, although existing API already covers properties). This is only in proposal level, should be enhanced (documentation, overloading for any count of indexer arguments, exceptions on illegal input).