### PR TITLE
Add tests for Moq compatibility with F# events

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ end_of_line = CRLF
 indent_style = tab
 indent_size = 4
 
-[*.{sln,proj,csproj,vbproj,props,targets,xml,xdoc,resx,config,nuspec}]
+[*.{sln,proj,csproj,fsproj,vbproj,props,targets,xml,xdoc,resx,config,nuspec}]
 indent_style = tab
 indent_size = 2
 

--- a/Moq.sln
+++ b/Moq.sln
@@ -18,6 +18,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moq.Tests", "tests\Moq.Test
 EndProject
 Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "Moq.Tests.VisualBasic", "tests\Moq.Tests.VisualBasic\Moq.Tests.VisualBasic.vbproj", "{840A8B2E-3D4B-4521-A61A-0291562CDC8B}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Moq.Tests.FSharpTypes", "tests\Moq.Tests.FSharpTypes\Moq.Tests.FSharpTypes.fsproj", "{2D9EE4E0-8433-4F9C-A330-C4D74B956E0B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -50,6 +52,14 @@ Global
 		{840A8B2E-3D4B-4521-A61A-0291562CDC8B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{840A8B2E-3D4B-4521-A61A-0291562CDC8B}.Release|x86.ActiveCfg = Release|Any CPU
 		{840A8B2E-3D4B-4521-A61A-0291562CDC8B}.Release|x86.Build.0 = Release|Any CPU
+		{2D9EE4E0-8433-4F9C-A330-C4D74B956E0B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2D9EE4E0-8433-4F9C-A330-C4D74B956E0B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2D9EE4E0-8433-4F9C-A330-C4D74B956E0B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2D9EE4E0-8433-4F9C-A330-C4D74B956E0B}.Debug|x86.Build.0 = Debug|Any CPU
+		{2D9EE4E0-8433-4F9C-A330-C4D74B956E0B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2D9EE4E0-8433-4F9C-A330-C4D74B956E0B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2D9EE4E0-8433-4F9C-A330-C4D74B956E0B}.Release|x86.ActiveCfg = Release|Any CPU
+		{2D9EE4E0-8433-4F9C-A330-C4D74B956E0B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -62,6 +62,20 @@ namespace Moq
 			return method.Name.StartsWith("set_", StringComparison.Ordinal);
 		}
 
+		// NOTE: The following two methods used to first check whether `method.IsSpecialName` was set
+		// as a quick guard against non-event accessor methods. This was removed in commit 44070a90
+		// to "increase compatibility with F# and COM". More specifically:
+		//
+		//  1. COM does not really have events. Some COM interop assemblies define events, but do not
+		//     mark those with the IL `specialname` flag. See:
+		//      - https://code.google.com/archive/p/moq/issues/226
+		//     - the `Microsoft.Office.Interop.Word.ApplicationEvents4_Event` interface in Office PIA
+		//
+		//  2. F# does not mark abstract events' accessors with the IL `specialname` flag. See:
+		//      - https://github.com/Microsoft/visualfsharp/issues/5834
+		//      - https://code.google.com/archive/p/moq/issues/238
+		//      - the unit tests in `FSharpCompatibilityFixture`
+
 		public static bool LooksLikeEventAttach(this MethodInfo method)
 		{
 			return method.Name.StartsWith("add_", StringComparison.Ordinal);

--- a/tests/Moq.Tests.FSharpTypes/HasAbstractActionEvent.fs
+++ b/tests/Moq.Tests.FSharpTypes/HasAbstractActionEvent.fs
@@ -1,0 +1,11 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+namespace Moq.Tests.FSharpTypes
+
+open System;
+
+[<AbstractClass>]
+type HasAbstractActionEvent =
+    [<CLIEvent>]
+    abstract member Event: IDelegateEvent<Action>

--- a/tests/Moq.Tests.FSharpTypes/HasAbstractEventHandlerEvent.fs
+++ b/tests/Moq.Tests.FSharpTypes/HasAbstractEventHandlerEvent.fs
@@ -1,0 +1,11 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+namespace Moq.Tests.FSharpTypes
+
+open System;
+
+[<AbstractClass>]
+type HasAbstractEventHandlerEvent =
+    [<CLIEvent>]
+    abstract member Event: IEvent<EventHandler, EventArgs>

--- a/tests/Moq.Tests.FSharpTypes/HasActionEvent.fs
+++ b/tests/Moq.Tests.FSharpTypes/HasActionEvent.fs
@@ -1,0 +1,12 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+namespace Moq.Tests.FSharpTypes
+
+open System;
+
+type HasActionEvent() =
+    let event = new DelegateEvent<Action>();
+
+    [<CLIEvent>]
+    member this.Event = event.Publish

--- a/tests/Moq.Tests.FSharpTypes/IHasActionEvent.fs
+++ b/tests/Moq.Tests.FSharpTypes/IHasActionEvent.fs
@@ -1,0 +1,10 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+namespace Moq.Tests.FSharpTypes
+
+open System;
+
+type IHasActionEvent =
+    [<CLIEvent>]
+    abstract member Event: IDelegateEvent<Action>

--- a/tests/Moq.Tests.FSharpTypes/IHasEventHandlerEvent.fs
+++ b/tests/Moq.Tests.FSharpTypes/IHasEventHandlerEvent.fs
@@ -1,0 +1,10 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+namespace Moq.Tests.FSharpTypes
+
+open System;
+
+type IHasEventHandlerEvent =
+    [<CLIEvent>]
+    abstract member Event: IEvent<EventHandler, EventArgs>

--- a/tests/Moq.Tests.FSharpTypes/Moq.Tests.FSharpTypes.fsproj
+++ b/tests/Moq.Tests.FSharpTypes/Moq.Tests.FSharpTypes.fsproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<Import Project="$(BuildDirectory)AssemblyInfo.props" />
+	<Import Project="$(BuildDirectory)SignAssembly.props" />
+
+	<PropertyGroup>
+		<TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+		<DebugSymbols>True</DebugSymbols>
+		<DebugType>full</DebugType>
+		<IsPackable>False</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Compile Include="HasAbstractActionEvent.fs" />
+		<Compile Include="HasAbstractEventHandlerEvent.fs" />
+		<Compile Include="HasActionEvent.fs" />
+		<Compile Include="IHasActionEvent.fs" />
+		<Compile Include="IHasEventHandlerEvent.fs" />
+	</ItemGroup>
+
+	<Target Name="Test" DependsOnTargets="Build" />
+
+</Project>

--- a/tests/Moq.Tests/FSharpCompatibilityFixture.cs
+++ b/tests/Moq.Tests/FSharpCompatibilityFixture.cs
@@ -1,0 +1,81 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using Moq.Tests.FSharpTypes;
+
+using Xunit;
+
+namespace Moq.Tests
+{
+	public class FSharpCompatibilityFixture
+	{
+		public static IEnumerable<object[]> AbstractFSharpEvents
+		{
+			get
+			{
+				yield return new object[] { typeof(HasAbstractActionEvent).GetEvent(nameof(HasAbstractActionEvent.Event)) };
+				yield return new object[] { typeof(HasAbstractEventHandlerEvent).GetEvent(nameof(HasAbstractEventHandlerEvent.Event)) };
+				yield return new object[] { typeof(IHasActionEvent).GetEvent(nameof(IHasActionEvent.Event)) };
+				yield return new object[] { typeof(IHasEventHandlerEvent).GetEvent(nameof(IHasEventHandlerEvent.Event)) };
+			}
+		}
+
+		public static IEnumerable<object[]> NonAbstractFSharpEvents
+		{
+			get
+			{
+				yield return new object[] { typeof(HasActionEvent).GetEvent(nameof(HasActionEvent.Event)) };
+			}
+		}
+
+		[Theory(Skip = "See https://github.com/Microsoft/visualfsharp/issues/5834.")]
+		[MemberData(nameof(AbstractFSharpEvents))]
+		public void Abstract_FSharp_event_has_accessors_marked_as_specialname(EventInfo @event)
+		{
+			Assert.All(@event.GetAccessors(), accessor => Assert.True(accessor.IsAbstract));
+			Assert.All(@event.GetAccessors(), accessor => Assert.True(accessor.IsSpecialName, "Accessor not marked as `specialname`."));
+		}
+
+		[Theory]
+		[MemberData(nameof(NonAbstractFSharpEvents))]
+		public void Non_abstract_FSharp_event_has_accessors_marked_as_specialname(EventInfo @event)
+		{
+			Assert.All(@event.GetAccessors(), accessor => Assert.False(accessor.IsAbstract));
+			Assert.All(@event.GetAccessors(), accessor => Assert.True(accessor.IsSpecialName, "Accessor not marked as `specialname`."));
+		}
+
+		[Fact]
+		public void Can_subscribe_to_and_raise_abstract_FSharp_event()
+		{
+			var mock = new Mock<IHasEventHandlerEvent>();
+			var eventRaiseCount = 0;
+			EventHandler handler = (sender, e) => ++eventRaiseCount;
+
+			mock.Object.Event += handler;
+			mock.Raise(x => x.Event += null, EventArgs.Empty);
+
+			Assert.Equal(1, eventRaiseCount);
+		}
+
+		[Fact]
+		public void Can_unsubscribe_from_FSharp_event()
+		{
+			var mock = new Mock<IHasEventHandlerEvent>();
+			var eventRaiseCount = 0;
+			EventHandler handler = (sender, e) => ++eventRaiseCount;
+
+			mock.Object.Event += handler;
+			mock.Raise(x => x.Event += null, EventArgs.Empty);
+
+			mock.Object.Event -= handler;
+			mock.Raise(x => x.Event += null, EventArgs.Empty);
+
+			Assert.Equal(1, eventRaiseCount);
+		}
+	}
+}

--- a/tests/Moq.Tests/Moq.Tests.csproj
+++ b/tests/Moq.Tests/Moq.Tests.csproj
@@ -25,6 +25,7 @@
 		<PackageReference Include="Castle.Core" Version="4.3.1" />
 		<PackageReference Include="System.ValueTuple" Version="4.4.0" />
 		<ProjectReference Include="..\..\src\Moq\Moq.csproj" />
+		<ProjectReference Include="..\Moq.Tests.FSharpTypes\Moq.Tests.FSharpTypes.fsproj" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
 		<PackageReference Include="EntityFramework" Version="6.2.0" />

--- a/tests/Moq.Tests/ReflectionExtensions.cs
+++ b/tests/Moq.Tests/ReflectionExtensions.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Moq.Tests
+{
+	public static class ReflectionExtensions
+	{
+		public static IEnumerable<MethodInfo> GetAccessors(this EventInfo @event, bool nonPublic = false)
+		{
+			yield return @event.GetAddMethod(nonPublic);
+			yield return @event.GetRemoveMethod(nonPublic);
+		}
+	}
+}


### PR DESCRIPTION
There are two old Google Code issues which were resolved with commit 44070a90, however no documentation or unit tests were ever added for these issues:

 * **Moq fails to mock events defined in F#:**  
   https://code.google.com/archive/p/moq/issues/238

 * **Can't raise events on mocked Interop interfaces:**  
   https://code.google.com/archive/p/moq/issues/226

This commit adds unit tests for the first of these two issues by adding an F# test project to the solution, which allows us to define F# types for use in unit tests.

Some of these tests are skipped on purpose; see https://github.com/Microsoft/visualfsharp/issues/5834.