### PR TITLE
Make internal `Mock` methods non-generic

### DIFF
--- a/src/Moq/Language/Flow/WhenPhrase.cs
+++ b/src/Moq/Language/Flow/WhenPhrase.cs
@@ -35,12 +35,14 @@ namespace Moq.Language.Flow
 
 		public ISetupSetter<T, TProperty> SetupSet<TProperty>(Action<T> setterExpression)
 		{
-			return Mock.SetupSet<T, TProperty>(mock, setterExpression, this.condition);
+			var setup = Mock.SetupSet(mock, setterExpression, this.condition);
+			return new SetterSetupPhrase<T, TProperty>(setup);
 		}
 
 		public ISetup<T> SetupSet(Action<T> setterExpression)
 		{
-			return Mock.SetupSet<T>(mock, setterExpression, this.condition);
+			var setup = Mock.SetupSet(mock, setterExpression, this.condition);
+			return new VoidSetupPhrase<T>(setup);
 		}
 	}
 }

--- a/src/Moq/Language/Flow/WhenPhrase.cs
+++ b/src/Moq/Language/Flow/WhenPhrase.cs
@@ -20,17 +20,20 @@ namespace Moq.Language.Flow
 
 		public ISetup<T> Setup(Expression<Action<T>> expression)
 		{
-			return Mock.Setup<T>(mock, expression, this.condition);
+			var setup = Mock.SetupVoid(mock, expression, this.condition);
+			return new VoidSetupPhrase<T>(setup);
 		}
 
 		public ISetup<T, TResult> Setup<TResult>(Expression<Func<T, TResult>> expression)
 		{
-			return Mock.Setup<T, TResult>(mock, expression, this.condition);
+			var setup = Mock.SetupNonVoid(mock, expression, this.condition);
+			return new NonVoidSetupPhrase<T, TResult>(setup);
 		}
 
 		public ISetupGetter<T, TProperty> SetupGet<TProperty>(Expression<Func<T, TProperty>> expression)
 		{
-			return Mock.SetupGet<T, TProperty>(mock, expression, this.condition);
+			var setup = Mock.SetupGet(mock, expression, this.condition);
+			return new NonVoidSetupPhrase<T, TProperty>(setup);
 		}
 
 		public ISetupSetter<T, TProperty> SetupSet<TProperty>(Action<T> setterExpression)

--- a/src/Moq/Mock.Generic.cs
+++ b/src/Moq/Mock.Generic.cs
@@ -306,21 +306,24 @@ namespace Moq
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public ISetup<T> Setup(Expression<Action<T>> expression)
 		{
-			return Mock.Setup<T>(this, expression, null);
+			var setup = Mock.SetupVoid(this, expression, null);
+			return new VoidSetupPhrase<T>(setup);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Setup{TResult}"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public ISetup<T, TResult> Setup<TResult>(Expression<Func<T, TResult>> expression)
 		{
-			return Mock.Setup(this, expression, null);
+			var setup = Mock.SetupNonVoid(this, expression, null);
+			return new NonVoidSetupPhrase<T, TResult>(setup);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupGet"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public ISetupGetter<T, TProperty> SetupGet<TProperty>(Expression<Func<T, TProperty>> expression)
 		{
-			return Mock.SetupGet(this, expression, null);
+			var setup = Mock.SetupGet(this, expression, null);
+			return new NonVoidSetupPhrase<T, TProperty>(setup);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupSet{TProperty}"]/*'/>

--- a/src/Moq/Mock.Generic.cs
+++ b/src/Moq/Mock.Generic.cs
@@ -372,7 +372,7 @@ namespace Moq
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By Design")]
 		public ISetupSequentialResult<TResult> SetupSequence<TResult>(Expression<Func<T, TResult>> expression)
 		{
-			var setup = Mock.SetupNonVoidSequence(this, expression);
+			var setup = Mock.SetupSequence(this, expression);
 			return new SetupSequencePhrase<TResult>(setup);
 		}
 
@@ -382,7 +382,7 @@ namespace Moq
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By Design")]
 		public ISetupSequentialAction SetupSequence(Expression<Action<T>> expression)
 		{
-			var setup = Mock.SetupVoidSequence(this, expression);
+			var setup = Mock.SetupSequence(this, expression);
 			return new SetupSequencePhrase(setup);
 		}
 

--- a/src/Moq/Mock.Generic.cs
+++ b/src/Moq/Mock.Generic.cs
@@ -517,7 +517,7 @@ namespace Moq
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifySet(expression)"]/*'/>
 		public void VerifySet(Action<T> setterExpression)
 		{
-			Mock.VerifySet<T>(this, setterExpression, Times.AtLeastOnce(), null);
+			Mock.VerifySet(this, setterExpression, Times.AtLeastOnce(), null);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifySet(expression,times)"]/*'/>

--- a/src/Moq/Mock.Generic.cs
+++ b/src/Moq/Mock.Generic.cs
@@ -325,13 +325,15 @@ namespace Moq
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupSet{TProperty}"]/*'/>
 		public ISetupSetter<T, TProperty> SetupSet<TProperty>(Action<T> setterExpression)
 		{
-			return Mock.SetupSet<T, TProperty>(this, setterExpression, null);
+			var setup = Mock.SetupSet(this, setterExpression, null);
+			return new SetterSetupPhrase<T, TProperty>(setup);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupSet"]/*'/>
 		public ISetup<T> SetupSet(Action<T> setterExpression)
 		{
-			return Mock.SetupSet<T>(this, setterExpression, null);
+			var setup = Mock.SetupSet(this, setterExpression, null);
+			return new VoidSetupPhrase<T>(setup);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupProperty(property)"]/*'/>

--- a/src/Moq/Mock.Generic.cs
+++ b/src/Moq/Mock.Generic.cs
@@ -20,6 +20,7 @@ using Microsoft.CSharp;
 using Moq.Language;
 using Moq.Language.Flow;
 using Moq.Properties;
+using Moq.Protected;
 
 namespace Moq
 {
@@ -351,7 +352,7 @@ namespace Moq
 		{
 			TProperty value = initialValue;
 			this.SetupGet(property).Returns(() => value);
-			SetupSet<T, TProperty>(this, property).Callback(p => value = p);
+			SetupSet(this, property, ItExpr.IsAny<TProperty>()).SetCallbackResponse(new Action<TProperty>(p => value = p));
 			return this;
 		}
 

--- a/src/Moq/Mock.Generic.cs
+++ b/src/Moq/Mock.Generic.cs
@@ -372,7 +372,8 @@ namespace Moq
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By Design")]
 		public ISetupSequentialResult<TResult> SetupSequence<TResult>(Expression<Func<T, TResult>> expression)
 		{
-			return Mock.SetupSequence<TResult>(this, expression);
+			var setup = Mock.SetupNonVoidSequence(this, expression);
+			return new SetupSequencePhrase<TResult>(setup);
 		}
 
 		/// <summary>
@@ -381,7 +382,8 @@ namespace Moq
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By Design")]
 		public ISetupSequentialAction SetupSequence(Expression<Action<T>> expression)
 		{
-			return Mock.SetupSequence(this, expression);
+			var setup = Mock.SetupVoidSequence(this, expression);
+			return new SetupSequencePhrase(setup);
 		}
 
 #endregion

--- a/src/Moq/Mock.Generic.cs
+++ b/src/Moq/Mock.Generic.cs
@@ -402,14 +402,14 @@ namespace Moq
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify(Expression<Action<T>> expression)
 		{
-			Mock.Verify(this, expression, Times.AtLeastOnce(), null);
+			Mock.VerifyVoid(this, expression, Times.AtLeastOnce(), null);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify(Expression<Action<T>> expression, Times times)
 		{
-			Mock.Verify(this, expression, times, null);
+			Mock.VerifyVoid(this, expression, times, null);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times)"]/*'/>
@@ -423,56 +423,56 @@ namespace Moq
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify(Expression<Action<T>> expression, string failMessage)
 		{
-			Mock.Verify(this, expression, Times.AtLeastOnce(), failMessage);
+			Mock.VerifyVoid(this, expression, Times.AtLeastOnce(), failMessage);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times,failMessage)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify(Expression<Action<T>> expression, Times times, string failMessage)
 		{
-			Mock.Verify(this, expression, times, failMessage);
+			Mock.VerifyVoid(this, expression, times, failMessage);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times,failMessage)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify(Expression<Action<T>> expression, Func<Times> times, string failMessage)
 		{
-			Verify(this, expression, times(), failMessage);
+			VerifyVoid(this, expression, times(), failMessage);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify<TResult>(Expression<Func<T, TResult>> expression)
 		{
-			Mock.Verify(this, expression, Times.AtLeastOnce(), null);
+			Mock.VerifyNonVoid(this, expression, Times.AtLeastOnce(), null);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,times)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify<TResult>(Expression<Func<T, TResult>> expression, Times times)
 		{
-			Mock.Verify(this, expression, times, null);
+			Mock.VerifyNonVoid(this, expression, times, null);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,times)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify<TResult>(Expression<Func<T, TResult>> expression, Func<Times> times)
 		{
-			Verify(this, expression, times(), null);
+			VerifyNonVoid(this, expression, times(), null);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,failMessage)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify<TResult>(Expression<Func<T, TResult>> expression, string failMessage)
 		{
-			Mock.Verify(this, expression, Times.AtLeastOnce(), failMessage);
+			Mock.VerifyNonVoid(this, expression, Times.AtLeastOnce(), failMessage);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,times,failMessage)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify<TResult>(Expression<Func<T, TResult>> expression, Times times, string failMessage)
 		{
-			Mock.Verify(this, expression, times, failMessage);
+			Mock.VerifyNonVoid(this, expression, times, failMessage);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyGet(expression)"]/*'/>

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -521,10 +521,7 @@ namespace Moq
 			return setup;
 		}
 
-		internal static SetterSetupPhrase<T, TProperty> SetupSet<T, TProperty>(
-			Mock<T> mock,
-			Expression<Func<T, TProperty>> expression)
-			where T : class
+		internal static MethodCall SetupSet(Mock mock, LambdaExpression expression, Expression valueExpression)
 		{
 			var prop = expression.ToPropertyInfo();
 			Guard.CanWrite(prop);
@@ -533,12 +530,12 @@ namespace Moq
 			ThrowIfSetupExpressionInvolvesUnsupportedMember(expression, propSet);
 			ThrowIfSetupMethodNotVisibleToProxyFactory(propSet);
 
-			var setup = new MethodCall(mock, null, expression, propSet, new[] { ItExpr.IsAny<TProperty>() });
+			var setup = new MethodCall(mock, null, expression, propSet, new[] { valueExpression });
 			var targetMock = GetTargetMock(((MemberExpression)expression.Body).Expression, mock);
 
 			targetMock.Setups.Add(setup);
 
-			return new SetterSetupPhrase<T, TProperty>(setup);
+			return setup;
 		}
 
 		private static (Mock, LambdaExpression, MethodInfo, Expression[]) SetupSetImpl(Mock mock, Delegate setterExpression)

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -566,14 +566,11 @@ namespace Moq
 			return new SetterSetupPhrase<T, TProperty>(setup);
 		}
 
-		private static (Mock, LambdaExpression, MethodInfo, Expression[]) SetupSetImpl<T>(
-			Mock<T> mock,
-			Action<T> setterExpression)
-			where T : class
+		private static (Mock, LambdaExpression, MethodInfo, Expression[]) SetupSetImpl(Mock mock, Delegate setterExpression)
 		{
 			using (var context = new FluentMockContext())
 			{
-				setterExpression(mock.Object);
+				setterExpression.DynamicInvoke(mock.Object);
 
 				var last = context.LastInvocation;
 				if (last == null)

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -508,42 +508,17 @@ namespace Moq
 		}
 
 		[DebuggerStepThrough]
-		internal static SetterSetupPhrase<T, TProperty> SetupSet<T, TProperty>(
-			Mock<T> mock,
-			Action<T> setterExpression,
-			Condition condition)
-			where T : class
-		{
-			return PexProtector.Invoke(SetupSetPexProtected<T, TProperty>, mock, setterExpression, condition);
-		}
-
-		private static SetterSetupPhrase<T, TProperty> SetupSetPexProtected<T, TProperty>(
-			Mock<T> mock,
-			Action<T> setterExpression,
-			Condition condition)
-			where T : class
-		{
-			var (m, expr, method, value) = SetupSetImpl(mock, setterExpression);
-			Debug.Assert(value.Length == 1);
-			var setup = new MethodCall(m, condition, expr, method, value);
-			m.Setups.Add(setup);
-			return new SetterSetupPhrase<T, TProperty>(setup);
-		}
-
-		[DebuggerStepThrough]
-		internal static VoidSetupPhrase<T> SetupSet<T>(Mock<T> mock, Action<T> setterExpression, Condition condition)
-			where T : class
+		internal static MethodCall SetupSet(Mock mock, Delegate setterExpression, Condition condition)
 		{
 			return PexProtector.Invoke(SetupSetPexProtected, mock, setterExpression, condition);
 		}
 
-		private static VoidSetupPhrase<T> SetupSetPexProtected<T>(Mock<T> mock, Action<T> setterExpression, Condition condition)
-			where T : class
+		private static MethodCall SetupSetPexProtected(Mock mock, Delegate setterExpression, Condition condition)
 		{
-			var (m, expr, method, values) = SetupSetImpl(mock, setterExpression);
-			var setup = new MethodCall(m, condition, expr, method, values);
+			var (m, expr, method, value) = SetupSetImpl(mock, setterExpression);
+			var setup = new MethodCall(m, condition, expr, method, value);
 			m.Setups.Add(setup);
-			return new VoidSetupPhrase<T>(setup);
+			return setup;
 		}
 
 		internal static SetterSetupPhrase<T, TProperty> SetupSet<T, TProperty>(

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -597,7 +597,7 @@ namespace Moq
 			return Expression.Convert(Expression.Constant(value), type);
 		}
 
-		internal static SetupSequencePhrase<TResult> SetupSequence<TResult>(Mock mock, LambdaExpression expression)
+		internal static SequenceSetup SetupNonVoidSequence(Mock mock, LambdaExpression expression)
 		{
 			if (expression.IsProperty())
 			{
@@ -611,7 +611,7 @@ namespace Moq
 				var setup = new SequenceSetup(expression, propGet, new Expression[0]);
 				var targetMock = GetTargetMock(((MemberExpression)expression.Body).Expression, mock);
 				targetMock.Setups.Add(setup);
-				return new SetupSequencePhrase<TResult>(setup);
+				return setup;
 			}
 			else
 			{
@@ -619,17 +619,17 @@ namespace Moq
 				var setup = new SequenceSetup(expression, method, args);
 				var targetMock = GetTargetMock(obj, mock);
 				targetMock.Setups.Add(setup);
-				return new SetupSequencePhrase<TResult>(setup);
+				return setup;
 			}
 		}
 
-		internal static SetupSequencePhrase SetupSequence(Mock mock, LambdaExpression expression)
+		internal static SequenceSetup SetupVoidSequence(Mock mock, LambdaExpression expression)
 		{
 			var (obj, method, args) = expression.GetCallInfo(mock);
 			var setup = new SequenceSetup(expression, method, args);
 			var targetMock = GetTargetMock(obj, mock);
 			targetMock.Setups.Add(setup);
-			return new SetupSequencePhrase(setup);
+			return setup;
 		}
 
 		[DebuggerStepThrough]

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -319,12 +319,7 @@ namespace Moq
 			VerifyCalls(GetTargetMock(((MemberExpression)expression.Body).Expression, mock), expectation, expression, times, failMessage);
 		}
 
-		internal static void VerifySet<T>(
-			Mock<T> mock,
-			Action<T> setterExpression,
-			Times times,
-			string failMessage)
-			where T : class
+		internal static void VerifySet(Mock mock, Delegate setterExpression, Times times, string failMessage)
 		{
 			var (targetMock, expression, method, value) = SetupSetImpl(mock, setterExpression);
 			var expectation = new InvocationShape(method, value);

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -411,14 +411,12 @@ namespace Moq
 		#region Setup
 
 		[DebuggerStepThrough]
-		internal static VoidSetupPhrase<T> Setup<T>(Mock<T> mock, Expression<Action<T>> expression, Condition condition)
-			where T : class
+		internal static MethodCall SetupVoid(Mock mock, LambdaExpression expression, Condition condition)
 		{
-			return PexProtector.Invoke(SetupPexProtected, mock, expression, condition);
+			return PexProtector.Invoke(SetupVoidPexProtected, mock, expression, condition);
 		}
 
-		private static VoidSetupPhrase<T> SetupPexProtected<T>(Mock<T> mock, Expression<Action<T>> expression, Condition condition)
-			where T : class
+		private static MethodCall SetupVoidPexProtected(Mock mock, LambdaExpression expression, Condition condition)
 		{
 			var (obj, method, args) = expression.GetCallInfo(mock);
 
@@ -429,24 +427,16 @@ namespace Moq
 			var targetMock = GetTargetMock(obj, mock);
 			targetMock.Setups.Add(setup);
 
-			return new VoidSetupPhrase<T>(setup);
+			return setup;
 		}
 
 		[DebuggerStepThrough]
-		internal static NonVoidSetupPhrase<T, TResult> Setup<T, TResult>(
-			Mock<T> mock,
-			Expression<Func<T, TResult>> expression,
-			Condition condition)
-			where T : class
+		internal static MethodCallReturn SetupNonVoid(Mock mock, LambdaExpression expression, Condition condition)
 		{
-			return PexProtector.Invoke(SetupPexProtected, mock, expression, condition);
+			return PexProtector.Invoke(SetupNonVoidPexProtected, mock, expression, condition);
 		}
 
-		private static NonVoidSetupPhrase<T, TResult> SetupPexProtected<T, TResult>(
-			Mock<T> mock,
-			Expression<Func<T, TResult>> expression,
-			Condition condition)
-			where T : class
+		private static MethodCallReturn SetupNonVoidPexProtected(Mock mock, LambdaExpression expression, Condition condition)
 		{
 			if (expression.IsProperty())
 			{
@@ -462,29 +452,21 @@ namespace Moq
 			var targetMock = GetTargetMock(obj, mock);
 			targetMock.Setups.Add(setup);
 
-			return new NonVoidSetupPhrase<T, TResult>(setup);
+			return setup;
 		}
 
 		[DebuggerStepThrough]
-		internal static NonVoidSetupPhrase<T, TProperty> SetupGet<T, TProperty>(
-			Mock<T> mock,
-			Expression<Func<T, TProperty>> expression,
-			Condition condition)
-			where T : class
+		internal static MethodCallReturn SetupGet(Mock mock, LambdaExpression expression, Condition condition)
 		{
 			return PexProtector.Invoke(SetupGetPexProtected, mock, expression, condition);
 		}
 
-		private static NonVoidSetupPhrase<T, TProperty> SetupGetPexProtected<T, TProperty>(
-			Mock<T> mock,
-			Expression<Func<T, TProperty>> expression,
-			Condition condition)
-			where T : class
+		private static MethodCallReturn SetupGetPexProtected(Mock mock, LambdaExpression expression, Condition condition)
 		{
 			if (expression.IsPropertyIndexer())
 			{
 				// Treat indexers as regular method invocations.
-				return Setup<T, TProperty>(mock, expression, condition);
+				return SetupNonVoid(mock, expression, condition);
 			}
 
 			var prop = expression.ToPropertyInfo();
@@ -499,7 +481,7 @@ namespace Moq
 			var targetMock = GetTargetMock(((MemberExpression)expression.Body).Expression, mock);
 			targetMock.Setups.Add(setup);
 
-			return new NonVoidSetupPhrase<T, TProperty>(setup);
+			return setup;
 		}
 
 		[DebuggerStepThrough]

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -266,12 +266,7 @@ namespace Moq
 			return true;
 		}
 
-		internal static void Verify<T>(
-			Mock<T> mock,
-			Expression<Action<T>> expression,
-			Times times,
-			string failMessage)
-			where T : class
+		internal static void VerifyVoid(Mock mock, LambdaExpression expression, Times times, string failMessage)
 		{
 			Guard.NotNull(times, nameof(times));
 
@@ -282,18 +277,13 @@ namespace Moq
 			VerifyCalls(GetTargetMock(obj, mock), expectation, expression, times, failMessage);
 		}
 
-		internal static void Verify<T, TResult>(
-			Mock<T> mock,
-			Expression<Func<T, TResult>> expression,
-			Times times,
-			string failMessage)
-			where T : class
+		internal static void VerifyNonVoid(Mock mock, LambdaExpression expression, Times times, string failMessage)
 		{
 			Guard.NotNull(times, nameof(times));
 
 			if (expression.IsProperty())
 			{
-				VerifyGet<T, TResult>(mock, expression, times, failMessage);
+				VerifyGet(mock, expression, times, failMessage);
 			}
 			else
 			{
@@ -305,12 +295,7 @@ namespace Moq
 			}
 		}
 
-		internal static void VerifyGet<T, TProperty>(
-			Mock<T> mock,
-			Expression<Func<T, TProperty>> expression,
-			Times times,
-			string failMessage)
-			where T : class
+		internal static void VerifyGet(Mock mock, LambdaExpression expression, Times times, string failMessage)
 		{
 			var method = expression.ToPropertyInfo().GetGetMethod(true);
 			ThrowIfVerifyExpressionInvolvesUnsupportedMember(expression, method);

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -597,7 +597,7 @@ namespace Moq
 			return Expression.Convert(Expression.Constant(value), type);
 		}
 
-		internal static SequenceSetup SetupNonVoidSequence(Mock mock, LambdaExpression expression)
+		internal static SequenceSetup SetupSequence(Mock mock, LambdaExpression expression)
 		{
 			if (expression.IsProperty())
 			{
@@ -621,15 +621,6 @@ namespace Moq
 				targetMock.Setups.Add(setup);
 				return setup;
 			}
-		}
-
-		internal static SequenceSetup SetupVoidSequence(Mock mock, LambdaExpression expression)
-		{
-			var (obj, method, args) = expression.GetCallInfo(mock);
-			var setup = new SequenceSetup(expression, method, args);
-			var targetMock = GetTargetMock(obj, mock);
-			targetMock.Setups.Add(setup);
-			return setup;
 		}
 
 		[DebuggerStepThrough]

--- a/src/Moq/Obsolete/Mock.Generic.Legacy.cs
+++ b/src/Moq/Obsolete/Mock.Generic.Legacy.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Linq.Expressions;
 
 using Moq.Language.Flow;
+using Moq.Protected;
 
 namespace Moq
 {
@@ -54,7 +55,8 @@ namespace Moq
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public ISetupSetter<T, TProperty> ExpectSet<TProperty>(Expression<Func<T, TProperty>> expression)
 		{
-			return Mock.SetupSet(this, expression);
+			var setup = Mock.SetupSet(this, expression, ItExpr.IsAny<TProperty>());
+			return new SetterSetupPhrase<T, TProperty>(setup);
 		}
 
 		/// <summary>

--- a/src/Moq/Obsolete/Mock.Legacy.cs
+++ b/src/Moq/Obsolete/Mock.Legacy.cs
@@ -12,12 +12,7 @@ namespace Moq
 	public partial class Mock
 	{
 		[Obsolete]
-		internal static void VerifySet<T, TProperty>(
-			Mock mock,
-			Expression<Func<T, TProperty>> expression,
-			Times times,
-			string failMessage)
-			where T : class
+		internal static void VerifySet(Mock mock, LambdaExpression expression, Times times, string failMessage)
 		{
 			var method = expression.ToPropertyInfo().SetMethod;
 			ThrowIfVerifyExpressionInvolvesUnsupportedMember(expression, method);

--- a/src/Moq/Obsolete/ObsoleteMockExtensions.cs
+++ b/src/Moq/Obsolete/ObsoleteMockExtensions.cs
@@ -4,7 +4,9 @@
 using System;
 using System.ComponentModel;
 using System.Linq.Expressions;
+
 using Moq.Language.Flow;
+using Moq.Protected;
 
 namespace Moq
 {
@@ -43,7 +45,8 @@ namespace Moq
 		public static ISetupSetter<T, TProperty> SetupSet<T, TProperty>(this Mock<T> mock, Expression<Func<T, TProperty>> expression)
 			where T : class
 		{
-			return Mock.SetupSet<T, TProperty>(mock, expression);
+			var setup = Mock.SetupSet(mock, expression, ItExpr.IsAny<TProperty>());
+			return new SetterSetupPhrase<T, TProperty>(setup);
 		}
 
 		/// <summary>

--- a/src/Moq/Protected/ProtectedAsMock.cs
+++ b/src/Moq/Protected/ProtectedAsMock.cs
@@ -113,7 +113,8 @@ namespace Moq.Protected
 				throw new ArgumentException(ex.Message, nameof(expression));
 			}
 
-			return Mock.SetupSequence<TResult>(this.mock, rewrittenExpression);
+			var setup = Mock.SetupNonVoidSequence(this.mock, rewrittenExpression);
+			return new SetupSequencePhrase<TResult>(setup);
 		}
 
 		public ISetupSequentialAction SetupSequence(Expression<Action<TAnalog>> expression)
@@ -130,7 +131,8 @@ namespace Moq.Protected
 				throw new ArgumentException(ex.Message, nameof(expression));
 			}
 
-			return Mock.SetupSequence(this.mock, rewrittenExpression);
+			var setup = Mock.SetupVoidSequence(this.mock, rewrittenExpression);
+			return new SetupSequencePhrase(setup);
 		}
 
 		public void Verify(Expression<Action<TAnalog>> expression, Times? times = null, string failMessage = null)

--- a/src/Moq/Protected/ProtectedAsMock.cs
+++ b/src/Moq/Protected/ProtectedAsMock.cs
@@ -147,7 +147,7 @@ namespace Moq.Protected
 				throw new ArgumentException(ex.Message, nameof(expression));
 			}
 
-			Mock.Verify(this.mock, rewrittenExpression, times ?? Times.AtLeastOnce(), failMessage);
+			Mock.VerifyVoid(this.mock, rewrittenExpression, times ?? Times.AtLeastOnce(), failMessage);
 		}
 
 		public void Verify<TResult>(Expression<Func<TAnalog, TResult>> expression, Times? times = null, string failMessage = null)
@@ -164,7 +164,7 @@ namespace Moq.Protected
 				throw new ArgumentException(ex.Message, nameof(expression));
 			}
 
-			Mock.Verify(this.mock, rewrittenExpression, times ?? Times.AtLeastOnce(), failMessage);
+			Mock.VerifyNonVoid(this.mock, rewrittenExpression, times ?? Times.AtLeastOnce(), failMessage);
 		}
 
 		public void VerifyGet<TProperty>(Expression<Func<TAnalog, TProperty>> expression, Times? times = null, string failMessage = null)

--- a/src/Moq/Protected/ProtectedAsMock.cs
+++ b/src/Moq/Protected/ProtectedAsMock.cs
@@ -113,7 +113,7 @@ namespace Moq.Protected
 				throw new ArgumentException(ex.Message, nameof(expression));
 			}
 
-			var setup = Mock.SetupNonVoidSequence(this.mock, rewrittenExpression);
+			var setup = Mock.SetupSequence(this.mock, rewrittenExpression);
 			return new SetupSequencePhrase<TResult>(setup);
 		}
 
@@ -131,7 +131,7 @@ namespace Moq.Protected
 				throw new ArgumentException(ex.Message, nameof(expression));
 			}
 
-			var setup = Mock.SetupVoidSequence(this.mock, rewrittenExpression);
+			var setup = Mock.SetupSequence(this.mock, rewrittenExpression);
 			return new SetupSequencePhrase(setup);
 		}
 

--- a/src/Moq/Protected/ProtectedAsMock.cs
+++ b/src/Moq/Protected/ProtectedAsMock.cs
@@ -42,7 +42,8 @@ namespace Moq.Protected
 				throw new ArgumentException(ex.Message, nameof(expression));
 			}
 
-			return Mock.Setup(this.mock, rewrittenExpression, null);
+			var setup = Mock.SetupVoid(this.mock, rewrittenExpression, null);
+			return new VoidSetupPhrase<T>(setup);
 		}
 
 		public ISetup<T, TResult> Setup<TResult>(Expression<Func<TAnalog, TResult>> expression)
@@ -59,7 +60,8 @@ namespace Moq.Protected
 				throw new ArgumentException(ex.Message, nameof(expression));
 			}
 
-			return Mock.Setup(this.mock, rewrittenExpression, null);
+			var setup = Mock.SetupNonVoid(this.mock, rewrittenExpression, null);
+			return new NonVoidSetupPhrase<T, TResult>(setup);
 		}
 
 		public ISetupGetter<T, TProperty> SetupGet<TProperty>(Expression<Func<TAnalog, TProperty>> expression)
@@ -76,7 +78,8 @@ namespace Moq.Protected
 				throw new ArgumentException(ex.Message, nameof(expression));
 			}
 
-			return Mock.SetupGet(this.mock, rewrittenExpression, null);
+			var setup = Mock.SetupGet(this.mock, rewrittenExpression, null);
+			return new NonVoidSetupPhrase<T, TProperty>(setup);
 		}
 
 		public Mock<T> SetupProperty<TProperty>(Expression<Func<TAnalog, TProperty>> expression, TProperty initialValue = default(TProperty))

--- a/src/Moq/Protected/ProtectedMock.cs
+++ b/src/Moq/Protected/ProtectedMock.cs
@@ -91,7 +91,8 @@ namespace Moq.Protected
 			ThrowIfPublicSetter(property, typeof(T).Name);
 			Guard.CanWrite(property);
 
-			return Mock.SetupSet<T, TProperty>(mock, GetSetterExpression(property, ItExpr.IsAny<TProperty>()), null);
+			var setup = Mock.SetupSet(mock, GetSetterExpression(property, ItExpr.IsAny<TProperty>()), null);
+			return new SetterSetupPhrase<T, TProperty>(setup);
 		}
 
 		public ISetupSequentialAction SetupSequence(string methodOrPropertyName, params object[] args)

--- a/src/Moq/Protected/ProtectedMock.cs
+++ b/src/Moq/Protected/ProtectedMock.cs
@@ -112,7 +112,7 @@ namespace Moq.Protected
 			ThrowIfMemberMissing(methodOrPropertyName, method);
 			ThrowIfPublicMethod(method, typeof(T).Name);
 
-			var setup = Mock.SetupVoidSequence(mock, GetMethodCall(method, args));
+			var setup = Mock.SetupSequence(mock, GetMethodCall(method, args));
 			return new SetupSequencePhrase(setup);
 		}
 
@@ -130,7 +130,7 @@ namespace Moq.Protected
 			{
 				ThrowIfPublicGetter(property, typeof(T).Name);
 				// TODO should consider property indexers
-				var getterSetup = Mock.SetupNonVoidSequence(mock, GetMemberAccess<TResult>(property));
+				var getterSetup = Mock.SetupSequence(mock, GetMemberAccess<TResult>(property));
 				return new SetupSequencePhrase<TResult>(getterSetup);
 			}
 
@@ -139,7 +139,7 @@ namespace Moq.Protected
 			ThrowIfVoidMethod(method);
 			ThrowIfPublicMethod(method, typeof(T).Name);
 
-			var setup = Mock.SetupNonVoidSequence(mock, GetMethodCall<TResult>(method, args));
+			var setup = Mock.SetupSequence(mock, GetMethodCall<TResult>(method, args));
 			return new SetupSequencePhrase<TResult>(setup);
 		}
 

--- a/src/Moq/Protected/ProtectedMock.cs
+++ b/src/Moq/Protected/ProtectedMock.cs
@@ -152,7 +152,7 @@ namespace Moq.Protected
 			ThrowIfMemberMissing(methodName, method);
 			ThrowIfPublicMethod(method, typeof(T).Name);
 
-			Mock.Verify(mock, GetMethodCall(method, args), times, null);
+			Mock.VerifyVoid(mock, GetMethodCall(method, args), times, null);
 		}
 
 		public void Verify<TResult>(string methodName, Times times, object[] args)
@@ -172,7 +172,7 @@ namespace Moq.Protected
 			ThrowIfMemberMissing(methodName, method);
 			ThrowIfPublicMethod(method, typeof(T).Name);
 
-			Mock.Verify(mock, GetMethodCall<TResult>(method, args), times, null);
+			Mock.VerifyNonVoid(mock, GetMethodCall<TResult>(method, args), times, null);
 		}
 
 		// TODO should receive args to support indexers

--- a/src/Moq/Protected/ProtectedMock.cs
+++ b/src/Moq/Protected/ProtectedMock.cs
@@ -112,7 +112,8 @@ namespace Moq.Protected
 			ThrowIfMemberMissing(methodOrPropertyName, method);
 			ThrowIfPublicMethod(method, typeof(T).Name);
 
-			return Mock.SetupSequence(mock, GetMethodCall(method, args));
+			var setup = Mock.SetupVoidSequence(mock, GetMethodCall(method, args));
+			return new SetupSequencePhrase(setup);
 		}
 
 		public ISetupSequentialResult<TResult> SetupSequence<TResult>(string methodOrPropertyName, params object[] args)
@@ -129,7 +130,8 @@ namespace Moq.Protected
 			{
 				ThrowIfPublicGetter(property, typeof(T).Name);
 				// TODO should consider property indexers
-				return Mock.SetupSequence<TResult>(mock, GetMemberAccess<TResult>(property));
+				var getterSetup = Mock.SetupNonVoidSequence(mock, GetMemberAccess<TResult>(property));
+				return new SetupSequencePhrase<TResult>(getterSetup);
 			}
 
 			var method = GetMethod(methodOrPropertyName, exactParameterMatch, args);
@@ -137,7 +139,8 @@ namespace Moq.Protected
 			ThrowIfVoidMethod(method);
 			ThrowIfPublicMethod(method, typeof(T).Name);
 
-			return Mock.SetupSequence<TResult>(mock, GetMethodCall<TResult>(method, args));
+			var setup = Mock.SetupNonVoidSequence(mock, GetMethodCall<TResult>(method, args));
+			return new SetupSequencePhrase<TResult>(setup);
 		}
 
 		#endregion

--- a/src/Moq/Protected/ProtectedMock.cs
+++ b/src/Moq/Protected/ProtectedMock.cs
@@ -40,7 +40,8 @@ namespace Moq.Protected
 			ThrowIfMemberMissing(methodName, method);
 			ThrowIfPublicMethod(method, typeof(T).Name);
 
-			return Mock.Setup(mock, GetMethodCall(method, args), null);
+			var setup = Mock.SetupVoid(mock, GetMethodCall(method, args), null);
+			return new VoidSetupPhrase<T>(setup);
 		}
 
 		public ISetup<T, TResult> Setup<TResult>(string methodName, params object[] args)
@@ -59,7 +60,8 @@ namespace Moq.Protected
 			{
 				ThrowIfPublicGetter(property, typeof(T).Name);
 				// TODO should consider property indexers
-				return Mock.SetupGet(mock, GetMemberAccess<TResult>(property), null);
+				var getterSetup = Mock.SetupGet(mock, GetMemberAccess<TResult>(property), null);
+				return new NonVoidSetupPhrase<T, TResult>(getterSetup);
 			}
 
 			var method = GetMethod(methodName, exactParameterMatch, args);
@@ -67,7 +69,8 @@ namespace Moq.Protected
 			ThrowIfVoidMethod(method);
 			ThrowIfPublicMethod(method, typeof(T).Name);
 
-			return Mock.Setup(mock, GetMethodCall<TResult>(method, args), null);
+			var setup = Mock.SetupNonVoid(mock, GetMethodCall<TResult>(method, args), null);
+			return new NonVoidSetupPhrase<T, TResult>(setup);
 		}
 
 		public ISetupGetter<T, TProperty> SetupGet<TProperty>(string propertyName)
@@ -79,7 +82,8 @@ namespace Moq.Protected
 			ThrowIfPublicGetter(property, typeof(T).Name);
 			Guard.CanRead(property);
 
-			return Mock.SetupGet(mock, GetMemberAccess<TProperty>(property), null);
+			var setup = Mock.SetupGet(mock, GetMemberAccess<TProperty>(property), null);
+			return new NonVoidSetupPhrase<T, TProperty>(setup);
 		}
 
 		public ISetupSetter<T, TProperty> SetupSet<TProperty>(string propertyName, object value)

--- a/src/Moq/SequenceSetup.cs
+++ b/src/Moq/SequenceSetup.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 namespace Moq
 {
 	/// <summary>
-	///   Programmable setup used by <see cref="Mock.SetupVoidSequence(Mock, LambdaExpression)"/> and <see cref="Mock.SetupNonVoidSequence(Mock, LambdaExpression)"/>.
+	///   Programmable setup used by <see cref="Mock.SetupSequence(Mock, LambdaExpression)"/>.
 	/// </summary>
 	internal sealed class SequenceSetup : SetupWithOutParameterSupport
 	{

--- a/src/Moq/SequenceSetup.cs
+++ b/src/Moq/SequenceSetup.cs
@@ -10,7 +10,7 @@ using System.Reflection;
 namespace Moq
 {
 	/// <summary>
-	///   Programmable setup used by <see cref="Mock.SetupSequence(Mock, LambdaExpression)"/> and <see cref="Mock.SetupSequence{TResult}(Mock, LambdaExpression)"/>.
+	///   Programmable setup used by <see cref="Mock.SetupVoidSequence(Mock, LambdaExpression)"/> and <see cref="Mock.SetupNonVoidSequence(Mock, LambdaExpression)"/>.
 	/// </summary>
 	internal sealed class SequenceSetup : SetupWithOutParameterSupport
 	{


### PR DESCRIPTION
This is a continuation of #663. Internal worker methods in the `Mock` class are made non-generic. The idea here is to restrict the use of generics exclusively to those places where they are useful: in the methods making up the public API. Underneath that layer, Moq should use generics as little as possible in order to avoid needless code duplication, and to make reflection easier.