### PR TITLE
Drop `System.ValueTuple` NuGet dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * `NullReferenceException` when using `SetupSet` on indexers with multiple parameters (@idigra, #694)
 * `CallBase` should not be allowed for delegate mocks (@tehmantra, #706)
 
+#### Changed
+
+* Dropped the dependency on the `System.ValueTuple` NuGet package, at no functional cost (i.e. value tuples are still supported just fine) (@stakx, #721)
+
 
 ## 4.10.0 (2018-09-08)
 

--- a/src/Moq/ExpressionExtensions.cs
+++ b/src/Moq/ExpressionExtensions.cs
@@ -141,7 +141,7 @@ namespace Moq
 		/// around either a <see cref="MethodCallExpression" /> (for a normal method call)
 		/// or a <see cref="InvocationExpression" /> (for a delegate invocation).
 		/// </summary>
-		internal static (Expression Object, MethodInfo Method, IReadOnlyList<Expression> Arguments) GetCallInfo(this LambdaExpression expression, Mock mock)
+		internal static CallInfo GetCallInfo(this LambdaExpression expression, Mock mock)
 		{
 			Guard.NotNull(expression, nameof(expression));
 
@@ -155,18 +155,39 @@ namespace Moq
 				// delegate interface proxy, so we need to map instead to the
 				// method on that interface, which is the property we've just tested for.
 				_ = ProxyFactory.Instance.GetDelegateProxyInterface(mock.TargetType, out var delegateInterfaceMethod);
-				return (Object: invocation.Expression, Method: delegateInterfaceMethod, Arguments: invocation.Arguments);
+				return new CallInfo(invocation.Expression, delegateInterfaceMethod, invocation.Arguments);
 			}
 
 			if (expression.Body is MethodCallExpression methodCall)
 			{
-				return (Object: methodCall.Object, Method: methodCall.Method, Arguments: methodCall.Arguments);
+				return new CallInfo(methodCall.Object, methodCall.Method, methodCall.Arguments);
 			}
 
 			throw new ArgumentException(string.Format(
 				CultureInfo.CurrentCulture,
 				Resources.SetupNotMethod,
 				expression.ToStringFixed()));
+		}
+	}
+
+	internal readonly struct CallInfo
+	{
+		private readonly Expression expression;
+		private readonly MethodInfo method;
+		private readonly IReadOnlyList<Expression> arguments;
+
+		public CallInfo(Expression expression, MethodInfo method, IReadOnlyList<Expression> arguments)
+		{
+			this.expression = expression;
+			this.method = method;
+			this.arguments = arguments;
+		}
+
+		public void Deconstruct(out Expression expression, out MethodInfo method, out IReadOnlyList<Expression> arguments)
+		{
+			expression = this.expression;
+			method = this.method;
+			arguments = this.arguments;
 		}
 	}
 }

--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -137,7 +137,7 @@ namespace Moq
 			return false;
 		}
 
-		public static (EventInfo Event, Mock Target) GetEventWithTarget<TMock>(this Action<TMock> eventExpression, TMock mock)
+		public static EventWithTarget GetEventWithTarget<TMock>(this Action<TMock> eventExpression, TMock mock)
 			where TMock : class
 		{
 			Guard.NotNull(eventExpression, nameof(eventExpression));
@@ -169,7 +169,7 @@ namespace Moq
 					addRemove));
 			}
 
-			return (ev, target);
+			return new EventWithTarget(ev, target);
 		}
 
 		public static IEnumerable<MethodInfo> GetMethods(this Type type, string name)
@@ -305,6 +305,24 @@ namespace Moq
 					properties.Add(property);
 				}
 			}
+		}
+	}
+
+	internal readonly struct EventWithTarget
+	{
+		private readonly EventInfo @event;
+		private readonly Mock target;
+
+		public EventWithTarget(EventInfo @event, Mock target)
+		{
+			this.@event = @event;
+			this.target = target;
+		}
+
+		public void Deconstruct(out EventInfo @event, out Mock target)
+		{
+			@event = this.@event;
+			target = this.target;
 		}
 	}
 }

--- a/src/Moq/LookupOrFallbackDefaultValueProvider.cs
+++ b/src/Moq/LookupOrFallbackDefaultValueProvider.cs
@@ -32,26 +32,26 @@ namespace Moq
 	[EditorBrowsable(EditorBrowsableState.Advanced)]
 	public abstract class LookupOrFallbackDefaultValueProvider : DefaultValueProvider
 	{
-		private Dictionary<Type, Func<Type, Mock, object>> factories;
+		private Dictionary<object, Func<Type, Mock, object>> factories;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="LookupOrFallbackDefaultValueProvider"/> class.
 		/// </summary>
 		protected LookupOrFallbackDefaultValueProvider()
 		{
-			this.factories = new Dictionary<Type, Func<Type, Mock, object>>()
+			this.factories = new Dictionary<object, Func<Type, Mock, object>>()
 			{
 				[typeof(Task)] = CreateTask,
 				[typeof(Task<>)] = CreateTaskOf,
 				[typeof(ValueTask<>)] = CreateValueTaskOf,
-				[typeof(ValueTuple<>)] = CreateValueTupleOf,
-				[typeof(ValueTuple<,>)] = CreateValueTupleOf,
-				[typeof(ValueTuple<,,>)] = CreateValueTupleOf,
-				[typeof(ValueTuple<,,,>)] = CreateValueTupleOf,
-				[typeof(ValueTuple<,,,,>)] = CreateValueTupleOf,
-				[typeof(ValueTuple<,,,,,>)] = CreateValueTupleOf,
-				[typeof(ValueTuple<,,,,,,>)] = CreateValueTupleOf,
-				[typeof(ValueTuple<,,,,,,,>)] = CreateValueTupleOf,
+				["System.ValueTuple`1"] = CreateValueTupleOf,
+				["System.ValueTuple`2"] = CreateValueTupleOf,
+				["System.ValueTuple`3"] = CreateValueTupleOf,
+				["System.ValueTuple`4"] = CreateValueTupleOf,
+				["System.ValueTuple`5"] = CreateValueTupleOf,
+				["System.ValueTuple`6"] = CreateValueTupleOf,
+				["System.ValueTuple`7"] = CreateValueTupleOf,
+				["System.ValueTuple`8"] = CreateValueTupleOf,
 			};
 		}
 
@@ -122,7 +122,9 @@ namespace Moq
 			               : type.IsArray ? typeof(Array)
 			               : type;
 
-			return this.factories.TryGetValue(handlerKey, out Func<Type, Mock, object> factory) ? factory.Invoke(type, mock)
+			Func<Type, Mock, object> factory;
+			return this.factories.TryGetValue(handlerKey         , out factory) ? factory.Invoke(type, mock)
+			     : this.factories.TryGetValue(handlerKey.FullName, out factory) ? factory.Invoke(type, mock)
 			     : this.GetFallbackDefaultValue(type, mock);
 		}
 

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -500,7 +500,7 @@ namespace Moq
 			return setup;
 		}
 
-		private static (Mock, LambdaExpression, MethodInfo, Expression[]) SetupSetImpl(Mock mock, Delegate setterExpression)
+		private static SetupSetImplResult SetupSetImpl(Mock mock, Delegate setterExpression)
 		{
 			using (var context = new FluentMockContext())
 			{
@@ -546,7 +546,7 @@ namespace Moq
 						Expression.Call(x, last.Invocation.Method, values),
 						x);
 
-					return (last.Mock, lambda, last.Invocation.Method, values);
+					return new SetupSetImplResult(last.Mock, lambda, last.Invocation.Method, values);
 				}
 				else
 				{
@@ -581,7 +581,7 @@ namespace Moq
 						Expression.Call(x, last.Invocation.Method, values),
 						x);
 
-					return (last.Mock, lambda, last.Invocation.Method, matchers);
+					return new SetupSetImplResult(last.Mock, lambda, last.Invocation.Method, matchers);
 				}
 			}
 		}
@@ -948,5 +948,29 @@ namespace Moq
 		}
 
 		#endregion
+
+		private readonly struct SetupSetImplResult
+		{
+			private readonly Mock mock;
+			private readonly LambdaExpression lambda;
+			private readonly MethodInfo method;
+			private readonly Expression[] arguments;
+
+			public SetupSetImplResult(Mock mock, LambdaExpression lambda, MethodInfo method, Expression[] arguments)
+			{
+				this.mock = mock;
+				this.lambda = lambda;
+				this.method = method;
+				this.arguments = arguments;
+			}
+
+			public void Deconstruct(out Mock mock, out LambdaExpression lambda, out MethodInfo method, out Expression[] arguments)
+			{
+				mock = this.mock;
+				lambda = this.lambda;
+				method = this.method;
+				arguments = this.arguments;
+			}
+		}
 	}
 }

--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -39,7 +39,6 @@
 		<PackageReference Include="Castle.Core" Version="4.3.1" />
 		<PackageReference Include="IFluentInterface" Version="2.1.0" />
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.3.0" />
-		<PackageReference Include="System.ValueTuple" Version="4.4.0" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
 		<Reference Include="System" />

--- a/src/Moq/Moq.nuspec
+++ b/src/Moq/Moq.nuspec
@@ -16,7 +16,6 @@
 			<group targetFramework=".NETFramework4.5">
 				<dependency id="Castle.Core" version="4.3.1" />
 				<dependency id="System.Threading.Tasks.Extensions" version="4.3.0" />
-				<dependency id="System.ValueTuple" version="4.4.0" />
 			</group>
 			<group targetFramework=".NETStandard1.3">
 				<dependency id="NETStandard.Library" version="1.6.1" />
@@ -25,7 +24,6 @@
 				<dependency id="System.Reflection.TypeExtensions" version="4.3.0" />
 				<dependency id="Castle.Core" version="4.3.1" />
 				<dependency id="System.Threading.Tasks.Extensions" version="4.3.0" />
-				<dependency id="System.ValueTuple" version="4.4.0" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/src/Moq/SequenceSetup.cs
+++ b/src/Moq/SequenceSetup.cs
@@ -15,38 +15,38 @@ namespace Moq
 	internal sealed class SequenceSetup : SetupWithOutParameterSupport
 	{
 		// contains the responses set up with the `CallBase`, `Pass`, `Returns`, and `Throws` verbs
-		private ConcurrentQueue<(ResponseKind, object)> responses;
+		private ConcurrentQueue<Response> responses;
 		private bool invoked;
 
 		public SequenceSetup(LambdaExpression originalExpression, MethodInfo method, IReadOnlyList<Expression> arguments)
 			: base(method, arguments, originalExpression)
 		{
-			this.responses = new ConcurrentQueue<(ResponseKind, object)>();
+			this.responses = new ConcurrentQueue<Response>();
 		}
 
 		public void AddCallBase()
 		{
-			this.responses.Enqueue((ResponseKind.CallBase, (object)null));
+			this.responses.Enqueue(new Response(ResponseKind.CallBase, null));
 		}
 
 		public void AddPass()
 		{
-			this.responses.Enqueue((ResponseKind.Pass, (object)null));
+			this.responses.Enqueue(new Response(ResponseKind.Pass, null));
 		}
 
 		public void AddReturns(object value)
 		{
-			this.responses.Enqueue((ResponseKind.Returns, value));
+			this.responses.Enqueue(new Response(ResponseKind.Returns, value));
 		}
 
 		public void AddReturns(Func<object> valueFunction)
 		{
-			this.responses.Enqueue((ResponseKind.InvokeFunc, valueFunction));
+			this.responses.Enqueue(new Response(ResponseKind.InvokeFunc, valueFunction));
 		}
 
 		public void AddThrows(Exception exception)
 		{
-			this.responses.Enqueue((ResponseKind.Throws, (object)exception));
+			this.responses.Enqueue(new Response(ResponseKind.Throws, exception));
 		}
 
 		public override void Execute(Invocation invocation)
@@ -98,6 +98,24 @@ namespace Moq
 		public override bool TryVerifyAll()
 		{
 			return this.invoked;
+		}
+
+		private readonly struct Response
+		{
+			private readonly ResponseKind kind;
+			private readonly object arg;
+
+			public Response(ResponseKind kind, object arg)
+			{
+				this.kind = kind;
+				this.arg = arg;
+			}
+
+			public void Deconstruct(out ResponseKind kind, out object arg)
+			{
+				kind = this.kind;
+				arg = this.arg;
+			}
 		}
 
 		private enum ResponseKind


### PR DESCRIPTION
People are still experiencing assembly versioning problems on the .NET Framework because of the NuGet packages `System.Threading.Tasks.Extensions` and `System.ValueTuple` referenced by Moq. (See e.g. the recent #719.)

It is fairly trivial to get rid of the latter dependency... so let's get rid of it! (It means we can no longer use tuple syntax everywhere in Moq's code base, but as we haven't made excessive use of it so far, that's perhaps a small price to pay.)