### PR TITLE
Enable `FluentMockContext` to record >1 matcher per invocation

### DIFF
--- a/src/Moq/AmbientObserver.cs
+++ b/src/Moq/AmbientObserver.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Moq
 {
@@ -32,6 +33,13 @@ namespace Moq
 		[ThreadStatic]
 		private static AmbientObserver current;
 
+		public static AmbientObserver Activate()
+		{
+			Debug.Assert(current == null);
+
+			return current = new AmbientObserver();
+		}
+
 		public static bool IsActive(out AmbientObserver observer)
 		{
 			var current = AmbientObserver.current;
@@ -42,9 +50,8 @@ namespace Moq
 
 		private List<Observation> observations;
 
-		public AmbientObserver()
+		private AmbientObserver()
 		{
-			current = this;
 		}
 
 		public void Dispose()
@@ -93,7 +100,7 @@ namespace Moq
 		/// <param name="mock">The <see cref="Mock"/> on which an invocation was observed.</param>
 		/// <param name="invocation">The observed <see cref="Invocation"/>.</param>
 		/// <param name="matches">The <see cref="Match"/>es that were observed just before the invocation.</param>
-		public bool LastObservationWasMockInvocation(out Mock mock, out Invocation invocation, out Matches matches)
+		public bool LastIsInvocation(out Mock mock, out Invocation invocation, out Matches matches)
 		{
 			if (this.observations != null)
 			{
@@ -128,7 +135,7 @@ namespace Moq
 		///   If <see langword="true"/>, details about that matcher are provided via the <see langword="out"/> parameter.
 		/// </summary>
 		/// <param name="match">The observed <see cref="Match"/> matcher.</param>
-		public bool LastObservationWasMatcher(out Match match)
+		public bool LastIsMatch(out Match match)
 		{
 			if (this.observations != null && this.observations[this.observations.Count - 1] is MatchObservation matchRecord)
 			{

--- a/src/Moq/ExpressionExtensions.cs
+++ b/src/Moq/ExpressionExtensions.cs
@@ -119,7 +119,7 @@ namespace Moq
 					using (var context = new FluentMockContext())
 					{
 						Expression.Lambda<Action>(expression).CompileUsingExpressionCompiler().Invoke();
-						return context.LastMatch == null;
+						return !context.LastObservationWasMatcher(out _);
 					}
 
 				default:

--- a/src/Moq/ExpressionExtensions.cs
+++ b/src/Moq/ExpressionExtensions.cs
@@ -116,10 +116,10 @@ namespace Moq
 				case ExpressionType.Call:
 				case ExpressionType.MemberAccess:
 					// Evaluate everything but matchers:
-					using (var context = new FluentMockContext())
+					using (var observer = new AmbientObserver())
 					{
 						Expression.Lambda<Action>(expression).CompileUsingExpressionCompiler().Invoke();
-						return !context.LastObservationWasMatcher(out _);
+						return !observer.LastObservationWasMatcher(out _);
 					}
 
 				default:

--- a/src/Moq/ExpressionExtensions.cs
+++ b/src/Moq/ExpressionExtensions.cs
@@ -28,6 +28,15 @@ namespace Moq
 			return ExpressionCompiler.Instance.Compile(expression);
 		}
 
+		public static bool IsMatch(this Expression expression, out Match match)
+		{
+			using (var observer = AmbientObserver.Activate())
+			{
+				Expression.Lambda<Action>(expression).CompileUsingExpressionCompiler().Invoke();
+				return observer.LastIsMatch(out match);
+			}
+		}
+
 		/// <summary>
 		/// Converts the body of the lambda expression into the <see cref="PropertyInfo"/> referenced by it.
 		/// </summary>
@@ -115,12 +124,7 @@ namespace Moq
 
 				case ExpressionType.Call:
 				case ExpressionType.MemberAccess:
-					// Evaluate everything but matchers:
-					using (var observer = new AmbientObserver())
-					{
-						Expression.Lambda<Action>(expression).CompileUsingExpressionCompiler().Invoke();
-						return !observer.LastObservationWasMatcher(out _);
-					}
+					return !expression.IsMatch(out _);
 
 				default:
 					return true;

--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -145,11 +145,11 @@ namespace Moq
 			MethodBase addRemove;
 			Mock target;
 
-			using (var context = new FluentMockContext())
+			using (var observer = new AmbientObserver())
 			{
 				eventExpression(mock);
 
-				if (!context.LastObservationWasMockInvocation(out target, out var lastInvocation, out _))
+				if (!observer.LastObservationWasMockInvocation(out target, out var lastInvocation, out _))
 				{
 					throw new ArgumentException(Resources.ExpressionIsNotEventAttachOrDetachOrIsNotVirtual);
 				}

--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -149,13 +149,12 @@ namespace Moq
 			{
 				eventExpression(mock);
 
-				if (context.LastInvocation == null)
+				if (!context.LastObservationWasMockInvocation(out target, out var lastInvocation, out _))
 				{
 					throw new ArgumentException(Resources.ExpressionIsNotEventAttachOrDetachOrIsNotVirtual);
 				}
 
-				addRemove = context.LastInvocation.Invocation.Method;
-				target = context.LastInvocation.Mock;
+				addRemove = lastInvocation.Method;
 			}
 
 			var ev = addRemove.DeclaringType.GetEvent(

--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -145,16 +145,16 @@ namespace Moq
 			MethodBase addRemove;
 			Mock target;
 
-			using (var observer = new AmbientObserver())
+			using (var observer = AmbientObserver.Activate())
 			{
 				eventExpression(mock);
 
-				if (!observer.LastObservationWasMockInvocation(out target, out var lastInvocation, out _))
+				if (!observer.LastIsInvocation(out target, out var invocation, out _))
 				{
 					throw new ArgumentException(Resources.ExpressionIsNotEventAttachOrDetachOrIsNotVirtual);
 				}
 
-				addRemove = lastInvocation.Method;
+				addRemove = invocation.Method;
 			}
 
 			var ev = addRemove.DeclaringType.GetEvent(

--- a/src/Moq/FluentMockContext.cs
+++ b/src/Moq/FluentMockContext.cs
@@ -15,8 +15,6 @@ namespace Moq
 		[ThreadStatic]
 		private static FluentMockContext current;
 
-		private List<MockInvocation> invocations = new List<MockInvocation>();
-
 		/// <summary>
 		/// Having an active fluent mock context means that the invocation 
 		/// is being performed in "trial" mode, just to gather the 
@@ -31,58 +29,168 @@ namespace Moq
 			return current != null;
 		}
 
+		private List<Observation> observations;
+
 		public FluentMockContext()
 		{
 			current = this;
 		}
 
-		public void Add(Mock mock, Invocation invocation)
-		{
-			invocations.Add(new MockInvocation(mock, invocation, LastMatch));
-		}
-
-		public MockInvocation LastInvocation
-		{
-			get { return invocations.LastOrDefault(); }
-		}
-
-		public Match LastMatch { get; set; }
-
 		public void Dispose()
 		{
-			invocations.Reverse();
-			foreach (var invocation in invocations)
+			if (this.observations != null)
 			{
-				invocation.Dispose();
+				for (var i = this.observations.Count - 1; i >= 0; --i)
+				{
+					this.observations[i].Dispose();
+				}
 			}
 
 			current = null;
 		}
 
-		internal class MockInvocation : IDisposable
+		/// <summary>
+		///   Adds the specified mock invocation as an observation.
+		/// </summary>
+		public void OnInvocation(Mock mock, Invocation invocation)
 		{
+			if (this.observations == null)
+			{
+				this.observations = new List<Observation>();
+			}
+
+			observations.Add(new InvocationObservation(mock, invocation));
+		}
+
+		/// <summary>
+		///   Adds the specified <see cref="Match"/> as an observation.
+		/// </summary>
+		public void OnMatch(Match match)
+		{
+			if (this.observations == null)
+			{
+				this.observations = new List<Observation>();
+			}
+
+			this.observations.Add(new MatchObservation(match));
+		}
+
+		/// <summary>
+		///   Checks whether the last observed thing was a mock invocation.
+		///   If <see langword="true"/>, details about that mock invocation are provided via the <see langword="out"/> parameters.
+		/// </summary>
+		/// <param name="mock">The <see cref="Mock"/> on which an invocation was observed.</param>
+		/// <param name="invocation">The observed <see cref="Invocation"/>.</param>
+		/// <param name="matches">The <see cref="Match"/>es that were observed just before the invocation.</param>
+		public bool LastObservationWasMockInvocation(out Mock mock, out Invocation invocation, out Matches matches)
+		{
+			if (this.observations != null)
+			{
+				var lastIndex = this.observations.Count - 1;
+
+				if (this.observations[lastIndex] is InvocationObservation invocationRecord)
+				{
+					// Determine the first index of all recorded matches that immediately precede
+					// the last invocation; up to the previous recorded invocation or the beginning
+					// of the recording (whichever comes first):
+					int offset = lastIndex;
+					while (offset > 0 && this.observations[offset - 1] is MatchObservation)
+					{
+						--offset;
+					}
+
+					mock = invocationRecord.Mock;
+					invocation = invocationRecord.Invocation;
+					matches = new Matches(this, offset, lastIndex - offset);
+					return true;
+				}
+			}
+
+			mock = default;
+			invocation = default;
+			matches = default;
+			return false;
+		}
+
+		/// <summary>
+		///   Checks whether the last thing observed was a <see cref="Match"/> matcher.
+		///   If <see langword="true"/>, details about that matcher are provided via the <see langword="out"/> parameter.
+		/// </summary>
+		/// <param name="match">The observed <see cref="Match"/> matcher.</param>
+		public bool LastObservationWasMatcher(out Match match)
+		{
+			if (this.observations != null && this.observations[this.observations.Count - 1] is MatchObservation matchRecord)
+			{
+				match = matchRecord.Match;
+				return true;
+			}
+
+			match = default;
+			return false;
+		}
+
+		/// <summary>
+		///   Allocation-free pseudo-collection (think `ReadOnlySpan&lt;Match&gt;`)
+		///   used to access all <see cref="Match"/>es associated with a recorded invocation.
+		/// </summary>
+		public readonly struct Matches
+		{
+			private readonly FluentMockContext context;
+			private readonly int offset;
+			private readonly int count;
+
+			public Matches(FluentMockContext context, int offset, int count)
+			{
+				this.context = context;
+				this.offset = offset;
+				this.count = count;
+			}
+
+			public int Count => this.count;
+
+			public Match this[int index] => ((MatchObservation)this.context.observations[this.offset + index]).Match;
+		}
+
+		private abstract class Observation : IDisposable
+		{
+			protected Observation()
+			{
+			}
+
+			public virtual void Dispose()
+			{
+			}
+		}
+
+		private sealed class InvocationObservation : Observation
+		{
+			public readonly Mock Mock;
+			public readonly Invocation Invocation;
+
 			private DefaultValueProvider defaultValueProvider;
 
-			public MockInvocation(Mock mock, Invocation invocation, Match matcher)
+			public InvocationObservation(Mock mock, Invocation invocation)
 			{
 				this.Mock = mock;
 				this.Invocation = invocation;
-				this.Match = matcher;
-				this.defaultValueProvider = mock.DefaultValueProvider;
 
-				// Temporarily set mock default value to Mock so that recursion works.
-				mock.DefaultValue = DefaultValue.Mock;
+				this.defaultValueProvider = mock.DefaultValueProvider;
+				mock.DefaultValueProvider = DefaultValueProvider.Mock;
 			}
 
-			public Mock Mock { get; private set; }
-
-			public Invocation Invocation { get; private set; }
-
-			public Match Match { get; private set; }
-
-			public void Dispose()
+			public override void Dispose()
 			{
 				this.Mock.DefaultValueProvider = this.defaultValueProvider;
+			}
+		}
+
+		private sealed class MatchObservation : Observation
+		{
+			public readonly Match Match;
+
+			public MatchObservation(Match match)
+			{
+				this.Match = match;
 			}
 		}
 	}

--- a/src/Moq/FluentMockContext.cs
+++ b/src/Moq/FluentMockContext.cs
@@ -17,20 +17,18 @@ namespace Moq
 
 		private List<MockInvocation> invocations = new List<MockInvocation>();
 
-		public static FluentMockContext Current
-		{
-			get { return current; }
-		}
-
 		/// <summary>
 		/// Having an active fluent mock context means that the invocation 
 		/// is being performed in "trial" mode, just to gather the 
 		/// target method and arguments that need to be matched later 
 		/// when the actual invocation is made.
 		/// </summary>
-		public static bool IsActive
+		public static bool IsActive(out FluentMockContext context)
 		{
-			get { return current != null; }
+			var current = FluentMockContext.current;
+
+			context = current;
+			return current != null;
 		}
 
 		public FluentMockContext()

--- a/src/Moq/Interception/InterceptionAspects.cs
+++ b/src/Moq/Interception/InterceptionAspects.cs
@@ -156,7 +156,7 @@ namespace Moq
 			// Track current invocation if we're in "record" mode in a fluent invocation context.
 			if (FluentMockContext.IsActive(out var context))
 			{
-				context.Add(mock, invocation);
+				context.OnInvocation(mock, invocation);
 			}
 			return InterceptionAction.Continue;
 		}

--- a/src/Moq/Interception/InterceptionAspects.cs
+++ b/src/Moq/Interception/InterceptionAspects.cs
@@ -109,7 +109,7 @@ namespace Moq
 
 		public override InterceptionAction Handle(Invocation invocation, Mock mock)
 		{
-			if (FluentMockContext.IsActive)
+			if (FluentMockContext.IsActive(out _))
 			{
 				return InterceptionAction.Continue;
 			}
@@ -154,9 +154,9 @@ namespace Moq
 		public override InterceptionAction Handle(Invocation invocation, Mock mock)
 		{
 			// Track current invocation if we're in "record" mode in a fluent invocation context.
-			if (FluentMockContext.IsActive)
+			if (FluentMockContext.IsActive(out var context))
 			{
-				FluentMockContext.Current.Add(mock, invocation);
+				context.Add(mock, invocation);
 			}
 			return InterceptionAction.Continue;
 		}
@@ -168,7 +168,7 @@ namespace Moq
 
 		public override InterceptionAction Handle(Invocation invocation, Mock mock)
 		{
-			if (FluentMockContext.IsActive)
+			if (FluentMockContext.IsActive(out _))
 			{
 				// In a fluent invocation context, which is a recorder-like
 				// mode we use to evaluate delegates by actually running them,

--- a/src/Moq/Interception/InterceptionAspects.cs
+++ b/src/Moq/Interception/InterceptionAspects.cs
@@ -111,9 +111,6 @@ namespace Moq
 		{
 			if (AmbientObserver.IsActive(out _))
 			{
-				// Having an active `AmbientObserver` means that the invocation is being performed
-				// in "trial" mode, just to gather the target method and arguments that need to be
-				// matched later, when the actual invocation will be made.
 				return InterceptionAction.Continue;
 			}
 
@@ -156,7 +153,6 @@ namespace Moq
 
 		public override InterceptionAction Handle(Invocation invocation, Mock mock)
 		{
-			// If an ambient observer is active, notify it of the current mock invocation.
 			if (AmbientObserver.IsActive(out var observer))
 			{
 				observer.OnInvocation(mock, invocation);
@@ -173,10 +169,6 @@ namespace Moq
 		{
 			if (AmbientObserver.IsActive(out _))
 			{
-				// In a fluent invocation context, which is a recorder-like
-				// mode we use to evaluate delegates by actually running them,
-				// we don't want to count the invocation, or actually run
-				// previous setups.
 				return InterceptionAction.Continue;
 			}
 

--- a/src/Moq/Interception/InterceptionAspects.cs
+++ b/src/Moq/Interception/InterceptionAspects.cs
@@ -109,8 +109,11 @@ namespace Moq
 
 		public override InterceptionAction Handle(Invocation invocation, Mock mock)
 		{
-			if (FluentMockContext.IsActive(out _))
+			if (AmbientObserver.IsActive(out _))
 			{
+				// Having an active `AmbientObserver` means that the invocation is being performed
+				// in "trial" mode, just to gather the target method and arguments that need to be
+				// matched later, when the actual invocation will be made.
 				return InterceptionAction.Continue;
 			}
 
@@ -153,10 +156,10 @@ namespace Moq
 
 		public override InterceptionAction Handle(Invocation invocation, Mock mock)
 		{
-			// Track current invocation if we're in "record" mode in a fluent invocation context.
-			if (FluentMockContext.IsActive(out var context))
+			// If an ambient observer is active, notify it of the current mock invocation.
+			if (AmbientObserver.IsActive(out var observer))
 			{
-				context.OnInvocation(mock, invocation);
+				observer.OnInvocation(mock, invocation);
 			}
 			return InterceptionAction.Continue;
 		}
@@ -168,7 +171,7 @@ namespace Moq
 
 		public override InterceptionAction Handle(Invocation invocation, Mock mock)
 		{
-			if (FluentMockContext.IsActive(out _))
+			if (AmbientObserver.IsActive(out _))
 			{
 				// In a fluent invocation context, which is a recorder-like
 				// mode we use to evaluate delegates by actually running them,

--- a/src/Moq/Match.cs
+++ b/src/Moq/Match.cs
@@ -41,28 +41,23 @@ namespace Moq
 
 		internal static T Create<T>(Match<T> match)
 		{
-			SetLastMatch(match);
-			return default(T);
-		}
+			// This method is used to set an expression as the last matcher invoked,
+			// which is used in the SetupSet to allow matchers in the prop = value
+			// delegate expression. This delegate is executed in "fluent" mode in
+			// order to capture the value being set, and construct the corresponding
+			// methodcall.
+			// This is also used in the MatcherFactory for each argument expression.
+			// This method ensures that when we execute the delegate, we
+			// also track the matcher that was invoked, so that when we create the
+			// methodcall we build the expression using it, rather than the null/default
+			// value returned from the actual invocation.
 
-		/// <devdoc>
-		/// This method is used to set an expression as the last matcher invoked, 
-		/// which is used in the SetupSet to allow matchers in the prop = value 
-		/// delegate expression. This delegate is executed in "fluent" mode in 
-		/// order to capture the value being set, and construct the corresponding 
-		/// methodcall.
-		/// This is also used in the MatcherFactory for each argument expression.
-		/// This method ensures that when we execute the delegate, we 
-		/// also track the matcher that was invoked, so that when we create the 
-		/// methodcall we build the expression using it, rather than the null/default 
-		/// value returned from the actual invocation.
-		/// </devdoc>
-		private static void SetLastMatch(Match match)
-		{
 			if (AmbientObserver.IsActive(out var observer))
 			{
 				observer.OnMatch(match);
 			}
+
+			return default(T);
 		}
 	}
 

--- a/src/Moq/Match.cs
+++ b/src/Moq/Match.cs
@@ -57,14 +57,12 @@ namespace Moq
 		/// methodcall we build the expression using it, rather than the null/default 
 		/// value returned from the actual invocation.
 		/// </devdoc>
-		private static Match<TValue> SetLastMatch<TValue>(Match<TValue> match)
+		private static void SetLastMatch(Match match)
 		{
 			if (FluentMockContext.IsActive(out var context))
 			{
-				context.LastMatch = match;
+				context.OnMatch(match);
 			}
-
-			return match;
 		}
 	}
 

--- a/src/Moq/Match.cs
+++ b/src/Moq/Match.cs
@@ -59,9 +59,9 @@ namespace Moq
 		/// </devdoc>
 		private static void SetLastMatch(Match match)
 		{
-			if (FluentMockContext.IsActive(out var context))
+			if (AmbientObserver.IsActive(out var observer))
 			{
-				context.OnMatch(match);
+				observer.OnMatch(match);
 			}
 		}
 	}

--- a/src/Moq/Match.cs
+++ b/src/Moq/Match.cs
@@ -59,9 +59,9 @@ namespace Moq
 		/// </devdoc>
 		private static Match<TValue> SetLastMatch<TValue>(Match<TValue> match)
 		{
-			if (FluentMockContext.IsActive)
+			if (FluentMockContext.IsActive(out var context))
 			{
-				FluentMockContext.Current.LastMatch = match;
+				context.LastMatch = match;
 			}
 
 			return match;

--- a/src/Moq/MatcherFactory.cs
+++ b/src/Moq/MatcherFactory.cs
@@ -87,20 +87,13 @@ namespace Moq
 
 			if (expression.NodeType == ExpressionType.Call)
 			{
-				var call = (MethodCallExpression)expression;
-
-				// Try to determine if invocation is to a matcher.
-				using (var observer = new AmbientObserver())
+				if (expression.IsMatch(out var match))
 				{
-					Expression.Lambda<Action>(call).CompileUsingExpressionCompiler().Invoke();
-
-					if (observer.LastObservationWasMatcher(out var match))
-					{
-						return match;
-					}
+					return match;
 				}
 
 #pragma warning disable 618
+				var call = (MethodCallExpression)expression;
 				if (call.Method.IsDefined(typeof(MatcherAttribute), true))
 				{
 					return new MatcherAttributeMatcher(call);
@@ -113,14 +106,9 @@ namespace Moq
 			}
 			else if (expression.NodeType == ExpressionType.MemberAccess)
 			{
-				// Try to determine if invocation is to a matcher.
-				using (var observer = new AmbientObserver())
+				if (expression.IsMatch(out var match))
 				{
-					Expression.Lambda<Action>((MemberExpression)expression).CompileUsingExpressionCompiler().Invoke();
-					if (observer.LastObservationWasMatcher(out var match))
-					{
-						return match;
-					}
+					return match;
 				}
 			}
 

--- a/src/Moq/MatcherFactory.cs
+++ b/src/Moq/MatcherFactory.cs
@@ -94,9 +94,9 @@ namespace Moq
 				{
 					Expression.Lambda<Action>(call).CompileUsingExpressionCompiler().Invoke();
 
-					if (context.LastMatch != null)
+					if (context.LastObservationWasMatcher(out var match))
 					{
-						return context.LastMatch;
+						return match;
 					}
 				}
 
@@ -117,9 +117,9 @@ namespace Moq
 				using (var context = new FluentMockContext())
 				{
 					Expression.Lambda<Action>((MemberExpression)expression).CompileUsingExpressionCompiler().Invoke();
-					if (context.LastMatch != null)
+					if (context.LastObservationWasMatcher(out var match))
 					{
-						return context.LastMatch;
+						return match;
 					}
 				}
 			}

--- a/src/Moq/MatcherFactory.cs
+++ b/src/Moq/MatcherFactory.cs
@@ -90,11 +90,11 @@ namespace Moq
 				var call = (MethodCallExpression)expression;
 
 				// Try to determine if invocation is to a matcher.
-				using (var context = new FluentMockContext())
+				using (var observer = new AmbientObserver())
 				{
 					Expression.Lambda<Action>(call).CompileUsingExpressionCompiler().Invoke();
 
-					if (context.LastObservationWasMatcher(out var match))
+					if (observer.LastObservationWasMatcher(out var match))
 					{
 						return match;
 					}
@@ -114,10 +114,10 @@ namespace Moq
 			else if (expression.NodeType == ExpressionType.MemberAccess)
 			{
 				// Try to determine if invocation is to a matcher.
-				using (var context = new FluentMockContext())
+				using (var observer = new AmbientObserver())
 				{
 					Expression.Lambda<Action>((MemberExpression)expression).CompileUsingExpressionCompiler().Invoke();
-					if (context.LastObservationWasMatcher(out var match))
+					if (observer.LastObservationWasMatcher(out var match))
 					{
 						return match;
 					}

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -502,11 +502,11 @@ namespace Moq
 
 		private static SetupSetImplResult SetupSetImpl(Mock mock, Delegate setterExpression)
 		{
-			using (var context = new FluentMockContext())
+			using (var observer = new AmbientObserver())
 			{
 				setterExpression.DynamicInvoke(mock.Object);
 
-				if (!context.LastObservationWasMockInvocation(out var lastMock, out var lastInvocation, out var lastMatches))
+				if (!observer.LastObservationWasMockInvocation(out var lastMock, out var lastInvocation, out var lastMatches))
 				{
 					throw new ArgumentException(string.Format(
 						CultureInfo.InvariantCulture,

--- a/tests/Moq.Tests/AmbientObserverFixture.cs
+++ b/tests/Moq.Tests/AmbientObserverFixture.cs
@@ -1,0 +1,160 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+using Xunit;
+
+namespace Moq.Tests
+{
+	public class AmbientObserverFixture
+	{
+		[Fact]
+		public void IsActive_returns_false_when_no_AmbientObserver_instantiated()
+		{
+			Assert.False(AmbientObserver.IsActive(out _));
+		}
+
+		[Fact]
+		public void IsActive_returns_true_when_AmbientObserver_instantiated()
+		{
+			using (var observer = new AmbientObserver())
+			{
+				Assert.True(AmbientObserver.IsActive(out _));
+			}
+		}
+
+		[Fact]
+		public void IsActive_returns_right_AmbientObserver_when_AmbientObserver_instantiated()
+		{
+			using (var observer = new AmbientObserver())
+			{
+				Assert.True(AmbientObserver.IsActive(out var active));
+				Assert.Same(observer, active);
+			}
+		}
+
+		[Fact]
+		public void LastObservationWasMatcher_returns_false_after_no_invocations()
+		{
+			using (var observer = new AmbientObserver())
+			{
+				Assert.False(observer.LastObservationWasMatcher(out _));
+			}
+		}
+
+		[Fact]
+		public void LastObservationWasMatcher_returns_false_after_a_mock_invocation()
+		{
+			var mock = Mock.Of<IMockable>();
+
+			using (var observer = new AmbientObserver())
+			{
+				mock.Method(default, default);
+
+				Assert.False(observer.LastObservationWasMatcher(out _));
+			}
+		}
+
+		[Fact]
+		public void LastObservationWasMatcher_returns_true_after_a_matcher_invocation()
+		{
+			using (var observer = new AmbientObserver())
+			{
+				_ = It.IsAny<int>();
+
+				Assert.True(observer.LastObservationWasMatcher(out _));
+			}
+		}
+
+		[Fact]
+		public void LastObservationWasMatcher_returns_right_matcher_after_several_matcher_invocations()
+		{
+			using (var observer = new AmbientObserver())
+			{
+				_ = It.IsAny<int>();
+				_ = It.IsRegex(".*");
+
+				Assert.True(observer.LastObservationWasMatcher(out var last));
+				Assert.True(last.Matches("abc"));
+			}
+		}
+
+		[Fact]
+		public void LastObservationWasMockInvocation_returns_false_after_no_invocations()
+		{
+			using (var observer = new AmbientObserver())
+			{
+				Assert.False(observer.LastObservationWasMockInvocation(out _, out _, out _));
+			}
+		}
+
+		[Fact]
+		public void LastObservationWasMockInvocation_returns_true_after_a_mock_invocation()
+		{
+			var mock = Mock.Of<IMockable>();
+
+			using (var observer = new AmbientObserver())
+			{
+				mock.Method(default, default);
+
+				Assert.True(observer.LastObservationWasMockInvocation(out _, out _, out _));
+			}
+		}
+
+		[Fact]
+		public void LastObservationWasMockInvocation_returns_last_invoation_after_several_mock_invocations()
+		{
+			var mock = Mock.Of<IMockable>();
+
+			using (var observer = new AmbientObserver())
+			{
+				mock.Method(default, default);
+				mock.Method(42, "*");
+
+				Assert.True(observer.LastObservationWasMockInvocation(out _, out var last, out _));
+				Assert.Equal(42, last.Arguments[0]);
+				Assert.Equal("*", last.Arguments[1]);
+			}
+		}
+
+		[Fact]
+		public void LastObservationWasMockInvocation_returns_right_matchers_after_mock_invocation()
+		{
+			var mock = Mock.Of<IMockable>();
+
+			using (var observer = new AmbientObserver())
+			{
+				mock.Method(It.IsAny<int>(), It.IsRegex("abc"));
+
+				Assert.True(observer.LastObservationWasMockInvocation(out _, out var _, out var matches));
+				Assert.Equal(2, matches.Count);
+				Assert.True(matches[0].Matches(42));
+				Assert.True(matches[1].Matches("abc"));
+			}
+		}
+
+		[Fact]
+		public void LastObservationWasMockInvocation_does_not_return_matchers_of_previous_mock_invocation()
+		{
+			var mock = Mock.Of<IMockable>();
+
+			using (var observer = new AmbientObserver())
+			{
+				mock.Method(It.IsInRange(1, 10, Range.Inclusive), "*");
+				mock.Method(It.IsAny<int>(), It.IsRegex("abc"));
+
+				Assert.True(observer.LastObservationWasMockInvocation(out _, out var _, out var matches));
+				Assert.Equal(2, matches.Count);
+				Assert.True(matches[0].Matches(42));
+				Assert.True(matches[1].Matches("abc"));
+			}
+		}
+
+		public interface IMockable
+		{
+			void Method(int arg1, string arg2);
+		}
+	}
+}

--- a/tests/Moq.Tests/AmbientObserverFixture.cs
+++ b/tests/Moq.Tests/AmbientObserverFixture.cs
@@ -19,7 +19,7 @@ namespace Moq.Tests
 		[Fact]
 		public void IsActive_returns_true_when_AmbientObserver_instantiated()
 		{
-			using (var observer = new AmbientObserver())
+			using (var observer = AmbientObserver.Activate())
 			{
 				Assert.True(AmbientObserver.IsActive(out _));
 			}
@@ -28,7 +28,7 @@ namespace Moq.Tests
 		[Fact]
 		public void IsActive_returns_right_AmbientObserver_when_AmbientObserver_instantiated()
 		{
-			using (var observer = new AmbientObserver())
+			using (var observer = AmbientObserver.Activate())
 			{
 				Assert.True(AmbientObserver.IsActive(out var active));
 				Assert.Same(observer, active);
@@ -38,9 +38,9 @@ namespace Moq.Tests
 		[Fact]
 		public void LastObservationWasMatcher_returns_false_after_no_invocations()
 		{
-			using (var observer = new AmbientObserver())
+			using (var observer = AmbientObserver.Activate())
 			{
-				Assert.False(observer.LastObservationWasMatcher(out _));
+				Assert.False(observer.LastIsMatch(out _));
 			}
 		}
 
@@ -49,34 +49,34 @@ namespace Moq.Tests
 		{
 			var mock = Mock.Of<IMockable>();
 
-			using (var observer = new AmbientObserver())
+			using (var observer = AmbientObserver.Activate())
 			{
 				mock.Method(default, default);
 
-				Assert.False(observer.LastObservationWasMatcher(out _));
+				Assert.False(observer.LastIsMatch(out _));
 			}
 		}
 
 		[Fact]
 		public void LastObservationWasMatcher_returns_true_after_a_matcher_invocation()
 		{
-			using (var observer = new AmbientObserver())
+			using (var observer = AmbientObserver.Activate())
 			{
 				_ = It.IsAny<int>();
 
-				Assert.True(observer.LastObservationWasMatcher(out _));
+				Assert.True(observer.LastIsMatch(out _));
 			}
 		}
 
 		[Fact]
 		public void LastObservationWasMatcher_returns_right_matcher_after_several_matcher_invocations()
 		{
-			using (var observer = new AmbientObserver())
+			using (var observer = AmbientObserver.Activate())
 			{
 				_ = It.IsAny<int>();
 				_ = It.IsRegex(".*");
 
-				Assert.True(observer.LastObservationWasMatcher(out var last));
+				Assert.True(observer.LastIsMatch(out var last));
 				Assert.True(last.Matches("abc"));
 			}
 		}
@@ -84,9 +84,9 @@ namespace Moq.Tests
 		[Fact]
 		public void LastObservationWasMockInvocation_returns_false_after_no_invocations()
 		{
-			using (var observer = new AmbientObserver())
+			using (var observer = AmbientObserver.Activate())
 			{
-				Assert.False(observer.LastObservationWasMockInvocation(out _, out _, out _));
+				Assert.False(observer.LastIsInvocation(out _, out _, out _));
 			}
 		}
 
@@ -95,11 +95,11 @@ namespace Moq.Tests
 		{
 			var mock = Mock.Of<IMockable>();
 
-			using (var observer = new AmbientObserver())
+			using (var observer = AmbientObserver.Activate())
 			{
 				mock.Method(default, default);
 
-				Assert.True(observer.LastObservationWasMockInvocation(out _, out _, out _));
+				Assert.True(observer.LastIsInvocation(out _, out _, out _));
 			}
 		}
 
@@ -108,12 +108,12 @@ namespace Moq.Tests
 		{
 			var mock = Mock.Of<IMockable>();
 
-			using (var observer = new AmbientObserver())
+			using (var observer = AmbientObserver.Activate())
 			{
 				mock.Method(default, default);
 				mock.Method(42, "*");
 
-				Assert.True(observer.LastObservationWasMockInvocation(out _, out var last, out _));
+				Assert.True(observer.LastIsInvocation(out _, out var last, out _));
 				Assert.Equal(42, last.Arguments[0]);
 				Assert.Equal("*", last.Arguments[1]);
 			}
@@ -124,11 +124,11 @@ namespace Moq.Tests
 		{
 			var mock = Mock.Of<IMockable>();
 
-			using (var observer = new AmbientObserver())
+			using (var observer = AmbientObserver.Activate())
 			{
 				mock.Method(It.IsAny<int>(), It.IsRegex("abc"));
 
-				Assert.True(observer.LastObservationWasMockInvocation(out _, out var _, out var matches));
+				Assert.True(observer.LastIsInvocation(out _, out var _, out var matches));
 				Assert.Equal(2, matches.Count);
 				Assert.True(matches[0].Matches(42));
 				Assert.True(matches[1].Matches("abc"));
@@ -140,12 +140,12 @@ namespace Moq.Tests
 		{
 			var mock = Mock.Of<IMockable>();
 
-			using (var observer = new AmbientObserver())
+			using (var observer = AmbientObserver.Activate())
 			{
 				mock.Method(It.IsInRange(1, 10, Range.Inclusive), "*");
 				mock.Method(It.IsAny<int>(), It.IsRegex("abc"));
 
-				Assert.True(observer.LastObservationWasMockInvocation(out _, out var _, out var matches));
+				Assert.True(observer.LastIsInvocation(out _, out var _, out var matches));
 				Assert.Equal(2, matches.Count);
 				Assert.True(matches[0].Matches(42));
 				Assert.True(matches[1].Matches("abc"));

--- a/tests/Moq.Tests/CustomDefaultValueProviderFixture.cs
+++ b/tests/Moq.Tests/CustomDefaultValueProviderFixture.cs
@@ -93,7 +93,7 @@ namespace Moq.Tests
 		}
 
 		[Fact]
-		public void FluentMockContext_properly_restores_custom_default_value_provider()
+		public void AmbientObserver_properly_restores_custom_default_value_provider()
 		{
 			var customDefaultValueProvider = new ConstantDefaultValueProvider(42);
 			var mock = new Mock<IFoo>() { DefaultValueProvider = customDefaultValueProvider };


### PR DESCRIPTION
Moq currently cannot correctly deal with setter setups using more one matcher, e.g. when setting up an indexer's setter. This is because the `FluentMockContext` only associates at most one matcher with observed invocations.

This PR changes how `FluentMockContext` records its observations and how it lets the outside world access them. When asked for the last observed mock invocation, `FluentMockContext` now returns *all*
matchers observed immediately before the final invocation.

The class is also renamed to `AmbientObserver` (way too many things in Moq's code base are called "fluent") and documented somewhat better using XML documentation comments and tests.