### PR TITLE
Merge `HandleTracking` interception aspect into `RecordInvocation`

### DIFF
--- a/src/Moq/Interception/InterceptionAspects.cs
+++ b/src/Moq/Interception/InterceptionAspects.cs
@@ -147,28 +147,15 @@ namespace Moq
 		}
 	}
 
-	internal sealed class HandleTracking : InterceptionAspect
-	{
-		public static HandleTracking Instance { get; } = new HandleTracking();
-
-		public override InterceptionAction Handle(Invocation invocation, Mock mock)
-		{
-			if (AmbientObserver.IsActive(out var observer))
-			{
-				observer.OnInvocation(mock, invocation);
-			}
-			return InterceptionAction.Continue;
-		}
-	}
-
 	internal sealed class RecordInvocation : InterceptionAspect
 	{
 		public static RecordInvocation Instance { get; } = new RecordInvocation();
 
 		public override InterceptionAction Handle(Invocation invocation, Mock mock)
 		{
-			if (AmbientObserver.IsActive(out _))
+			if (AmbientObserver.IsActive(out var observer))
 			{
+				observer.OnInvocation(mock, invocation);
 				return InterceptionAction.Continue;
 			}
 

--- a/src/Moq/Interception/Mock.cs
+++ b/src/Moq/Interception/Mock.cs
@@ -7,7 +7,6 @@ namespace Moq
 	{
 		private static InterceptionAspect[] aspects = new InterceptionAspect[]
 		{
-			HandleTracking.Instance,
 			HandleWellKnownMethods.Instance,
 			RecordInvocation.Instance,
 			FindAndExecuteMatchingSetup.Instance,


### PR DESCRIPTION
The first of these two interception aspects basically has the same purpose as the latter: recording that an invocation happened. For this reason, it would make sense to do combine the former into the latter, and thus to speed up the interception pipeline.

There's one possible **BUT** against moving the logic of `HandleTracking` into `RecordInvocation`: In `RecordInvocation`, we no longer have the chance to record invocations of "well-known methods" (such as those defined by `System.Object`) because the interception pipeline might already have stopped at that point.

Fortunately, this doesn't matter as we are typically not interested in those well-known methods when making use of `AmbientObserver`: they don't have signatures that allow chaining or assignment, nor are they matchers.