### PR TITLE
De-deprecate `[Matcher]` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,13 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 ## Unreleased
 
-#### Unobsoleted
+#### Changed
 
-* The `[Matcher]` attribute, which was deprecated in version 4.8.0-rc1, is being de-deprecated for performance and correctness reasons; see first items under 'Fixed' and 'Changed' (below) (@stakx, #732)
+* **Breaking change:** All custom argument matcher methods (including those using `Match.Create<T>`) must now be marked with the `[Matcher]` attribute. For this reason, `MatcherAttribute` is no longer marked obsolete (@stakx, #732)
 
 #### Fixed
 
 * `InvalidOperationException` when specifiying setup on mock with mock containing property of type `Nullable<T>` (@dav1dev, #725)
-
-#### Changed
-
-* **Breaking change:** All custom matchers (including those created using `Match.Create<T>`) must now be marked as such with the `[Matcher]` attribute (@stakx, #732)
 
 
 ## 4.10.1 (2018-12-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 #### Unobsoleted
 
-* The `[Matcher]` attribute, which was deprecated in version 4.8.0-rc1, is being de-deprecated for performance and correctness reasons (@stakx, #732)
+* The `[Matcher]` attribute, which was deprecated in version 4.8.0-rc1, is being de-deprecated for performance and correctness reasons; see first items under 'Fixed' and 'Changed' (below) (@stakx, #732)
+
+#### Fixed
+
+* `InvalidOperationException` when specifiying setup on mock with mock containing property of type `Nullable<T>` (@dav1dev, #725)
+
+#### Changed
+
+* **Breaking change:** All custom matchers (including those created using `Match.Create<T>`) must now be marked as such with the `[Matcher]` attribute (@stakx, #732)
 
 
 ## 4.10.1 (2018-12-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
+## Unreleased
+
+#### Unobsoleted
+
+* The `[Matcher]` attribute, which was deprecated in version 4.8.0-rc1, is being de-deprecated for performance and correctness reasons (@stakx, #732)
+
+
 ## 4.10.1 (2018-12-03)
 
 #### Fixed

--- a/src/Moq/Capture.cs
+++ b/src/Moq/Capture.cs
@@ -28,6 +28,7 @@ namespace Moq
 		/// Assert.Equal("Hello!", parameters.Single());
 		/// </code>
 		/// </example>
+		[Matcher]
 		public static T In<T>(ICollection<T> collection)
 		{
 			var match = new CaptureMatch<T>(collection.Add);
@@ -51,6 +52,7 @@ namespace Moq
 		/// Assert.Equal("Hello!", parameters.Single());
 		/// </code>
 		/// </example>
+		[Matcher]
 		public static T In<T>(IList<T> collection, Expression<Func<T, bool>> predicate)
 		{
 			var match = new CaptureMatch<T>(collection.Add, predicate);
@@ -73,6 +75,7 @@ namespace Moq
 		/// Assert.Equal("Hello!", capturedValue);
 		/// </code>
 		/// </example>
+		[Matcher]
 		public static T With<T>(CaptureMatch<T> match)
 		{
 			return Match.Create(match);

--- a/src/Moq/ExpressionExtensions.cs
+++ b/src/Moq/ExpressionExtensions.cs
@@ -123,8 +123,10 @@ namespace Moq
 					return false;
 
 				case ExpressionType.Call:
+					return !((MethodCallExpression)expression).Method.IsDefined(typeof(MatcherAttribute), true);
+
 				case ExpressionType.MemberAccess:
-					return !expression.IsMatch(out _);
+					return !((MemberExpression)expression).Member.IsDefined(typeof(MatcherAttribute), true);
 
 				default:
 					return true;

--- a/src/Moq/It.cs
+++ b/src/Moq/It.cs
@@ -30,6 +30,7 @@ namespace Moq
 		}
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsAny"]/*'/>
+		[Matcher]
 		public static TValue IsAny<TValue>()
 		{
 			return Match<TValue>.Create(
@@ -43,6 +44,7 @@ namespace Moq
 		}
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsNotNull"]/*'/>
+		[Matcher]
 		public static TValue IsNotNull<TValue>()
 		{
 			return Match<TValue>.Create(
@@ -57,6 +59,7 @@ namespace Moq
 
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.Is"]/*'/>
+		[Matcher]
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
 		public static TValue Is<TValue>(Expression<Func<TValue, bool>> match)
 		{
@@ -66,6 +69,7 @@ namespace Moq
 		}
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsInRange"]/*'/>
+		[Matcher]
 		public static TValue IsInRange<TValue>(TValue from, TValue to, Range rangeKind)
 			where TValue : IComparable
 		{
@@ -87,30 +91,35 @@ namespace Moq
 		}
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsIn(enumerable)"]/*'/>
+		[Matcher]
 		public static TValue IsIn<TValue>(IEnumerable<TValue> items)
 		{
 			return Match<TValue>.Create(value => items.Contains(value), () => It.IsIn(items));
 		}
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsIn(params)"]/*'/>
+		[Matcher]
 		public static TValue IsIn<TValue>(params TValue[] items)
 		{
 			return Match<TValue>.Create(value => items.Contains(value), () => It.IsIn(items));
 		}
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsNotIn(enumerable)"]/*'/>
+		[Matcher]
 		public static TValue IsNotIn<TValue>(IEnumerable<TValue> items)
 		{
 			return Match<TValue>.Create(value => !items.Contains(value), () => It.IsNotIn(items));
 		}
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsNotIn(params)"]/*'/>
+		[Matcher]
 		public static TValue IsNotIn<TValue>(params TValue[] items)
 		{
 			return Match<TValue>.Create(value => !items.Contains(value), () => It.IsNotIn(items));
 		}
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsRegex(regex)"]/*'/>
+		[Matcher]
 		public static string IsRegex(string regex)
 		{
 			Guard.NotNull(regex, nameof(regex));
@@ -123,6 +132,7 @@ namespace Moq
 		}
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsRegex(regex,options)"]/*'/>
+		[Matcher]
 		public static string IsRegex(string regex, RegexOptions options)
 		{
 			Guard.NotNull(regex, nameof(regex));

--- a/src/Moq/Match.cs
+++ b/src/Moq/Match.cs
@@ -15,6 +15,7 @@ namespace Moq
 		/// Provided for the sole purpose of rendering the delegate passed to the 
 		/// matcher constructor if no friendly render lambda is provided.
 		/// </devdoc>
+		[Matcher]
 		internal static TValue Matcher<TValue>()
 		{
 			return default(TValue);

--- a/src/Moq/MatcherAttribute.cs
+++ b/src/Moq/MatcherAttribute.cs
@@ -2,7 +2,6 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
-using System.ComponentModel;
 
 namespace Moq
 {
@@ -12,9 +11,6 @@ namespace Moq
 	/// matching rules.
 	/// </summary>
 	/// <remarks>
-	/// <b>This feature has been deprecated in favor of the new 
-	/// and simpler <see cref="Match{T}"/>.
-	/// </b>
 	/// <para>
 	/// The argument matching is used to determine whether a concrete 
 	/// invocation in the mock matches a given setup. This 
@@ -120,8 +116,6 @@ namespace Moq
 	/// </code>
 	/// </example>
 	[AttributeUsage(AttributeTargets.Method, Inherited = true)]
-	[EditorBrowsable(EditorBrowsableState.Never)]
-	[Obsolete("This feature has been deprecated in favor of `Match.Create`.")]
 	public sealed class MatcherAttribute : Attribute
 	{
 	}

--- a/src/Moq/MatcherAttribute.cs
+++ b/src/Moq/MatcherAttribute.cs
@@ -12,6 +12,10 @@ namespace Moq
 	/// </summary>
 	/// <remarks>
 	/// <para>
+	/// This attribute may be used in conjunction with <see cref="Match.Create{T}"/>,
+	/// or with the older mechanism described below.
+	/// </para>
+	/// <para>
 	/// The argument matching is used to determine whether a concrete 
 	/// invocation in the mock matches a given setup. This 
 	/// matching mechanism is fully extensible. 
@@ -115,7 +119,7 @@ namespace Moq
 	/// // use mock, invoke Save, and have the matcher filter.
 	/// </code>
 	/// </example>
-	[AttributeUsage(AttributeTargets.Method, Inherited = true)]
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = true)]
 	public sealed class MatcherAttribute : Attribute
 	{
 	}

--- a/src/Moq/MatcherFactory.cs
+++ b/src/Moq/MatcherFactory.cs
@@ -92,13 +92,11 @@ namespace Moq
 					return match;
 				}
 
-#pragma warning disable 618
 				var call = (MethodCallExpression)expression;
 				if (call.Method.IsDefined(typeof(MatcherAttribute), true))
 				{
 					return new MatcherAttributeMatcher(call);
 				}
-#pragma warning restore 618
 				else
 				{
 					return new LazyEvalMatcher(originalExpression);

--- a/src/Moq/MatcherFactory.cs
+++ b/src/Moq/MatcherFactory.cs
@@ -85,28 +85,28 @@ namespace Moq
 				return matchExpression.Match;
 			}
 
-			if (expression.NodeType == ExpressionType.Call)
+			if (expression is MethodCallExpression call)
 			{
-				if (expression.IsMatch(out var match))
-				{
-					return match;
-				}
-
-				var call = (MethodCallExpression)expression;
 				if (call.Method.IsDefined(typeof(MatcherAttribute), true))
 				{
+					if (expression.IsMatch(out var match))
+					{
+						return match;
+					}
+
 					return new MatcherAttributeMatcher(call);
 				}
-				else
-				{
-					return new LazyEvalMatcher(originalExpression);
-				}
+
+				return new LazyEvalMatcher(originalExpression);
 			}
-			else if (expression.NodeType == ExpressionType.MemberAccess)
+			else if (expression is MemberExpression memberAccess)
 			{
-				if (expression.IsMatch(out var match))
+				if (memberAccess.Member.IsDefined(typeof(MatcherAttribute), true))
 				{
-					return match;
+					if (expression.IsMatch(out var match))
+					{
+						return match;
+					}
 				}
 			}
 

--- a/tests/Moq.Tests/CustomMatcherFixture.cs
+++ b/tests/Moq.Tests/CustomMatcherFixture.cs
@@ -30,11 +30,13 @@ namespace Moq.Tests
 			Assert.True(mock.Object.Do(5));
 		}
 
+		[Matcher]
 		public TValue Any<TValue>()
 		{
 			return Match.Create<TValue>(v => true);
 		}
 
+		[Matcher]
 		public TValue Between<TValue>(TValue from, TValue to, Range rangeKind)
 			where TValue : IComparable
 		{
@@ -89,8 +91,10 @@ namespace Moq.Tests
 
 		public class Toy
 		{
+			[Matcher]
 			public static Toy IsRed => Match.Create((Toy toy) => toy.Color == "red");
 
+			[Matcher]
 			public static Toy IsGreen() => Match.Create((Toy toy) => toy.Color == "green");
 
 			public string Color { get; set; }

--- a/tests/Moq.Tests/ExtensibilityFixture.cs
+++ b/tests/Moq.Tests/ExtensibilityFixture.cs
@@ -62,12 +62,30 @@ namespace Moq.Tests
 		}
 
 		[Fact]
-		public void SetterMatcherRendersNicely()
+		public void Built_in_matcher_renders_nicely_when_using_delegate_based_setup_expression()
 		{
 			var mock = new Mock<IOrderRepository>();
 
 			var ex = Record.Exception(() => mock.VerifySet(repo => repo.Value = It.IsAny<int>()));
 			Assert.Contains("repo => repo.Value = It.IsAny<int>()", ex.Message);
+		}
+
+		[Fact]
+		public void Custom_matcher_with_render_expression_renders_nicely_when_using_delegate_based_setup_expression()
+		{
+			var mock = new Mock<IOrderRepository>();
+
+			var ex = Record.Exception(() => mock.VerifySet(repo => repo.OrderSavedLast = Order.IsBig()));
+			Assert.Contains("repo => repo.OrderSavedLast = Order.IsBig()", ex.Message);
+		}
+
+		[Fact]
+		public void Custom_matcher_without_render_expression_renders_semi_nicely_when_using_delegate_based_setup_expression()
+		{
+			var mock = new Mock<IOrderRepository>();
+
+			var ex = Record.Exception(() => mock.VerifySet(repo => repo.OrderSavedLast = Order.IsSmall));
+			Assert.Contains("repo => repo.OrderSavedLast = Match.Matcher<Order>()", ex.Message);
 		}
 	}
 
@@ -84,6 +102,7 @@ namespace Moq.Tests
 	{
 		void Save(Order order);
 		void Save(IEnumerable<Order> orders);
+		Order OrderSavedLast { get; set; }
 		int Value { get; set; }
 	}
 
@@ -94,7 +113,7 @@ namespace Moq.Tests
 		[Matcher]
 		public static Order IsBig()
 		{
-			return Match.Create<Order>(o => o.Amount >= 1000);
+			return Match.Create<Order>(o => o.Amount >= 1000, () => Order.IsBig());
 		}
 
 

--- a/tests/Moq.Tests/ExtensibilityFixture.cs
+++ b/tests/Moq.Tests/ExtensibilityFixture.cs
@@ -82,6 +82,7 @@ namespace Moq.Tests
 
 	public static class Orders
 	{
+		[Matcher]
 		public static IEnumerable<Order> Contains(Order order)
 		{
 			return Match.Create<IEnumerable<Order>>(orders => orders.Contains(order));
@@ -92,6 +93,7 @@ namespace Moq.Tests
 			return Match.Create<Order>(o => o.Amount >= 1000);
 		}
 
+		[Matcher]
 		public static Order IsSmall
 		{
 			get
@@ -110,6 +112,7 @@ namespace Moq.Tests
 
 	public static class OrderIs
 	{
+		[Matcher]
 		public static Order Big()
 		{
 			return Match.Create<Order>(o => o.Amount >= 1000);

--- a/tests/Moq.Tests/ExtensibilityFixture.cs
+++ b/tests/Moq.Tests/ExtensibilityFixture.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using Xunit;
 
 namespace Moq.Tests
@@ -14,7 +15,7 @@ namespace Moq.Tests
 		public void ShouldExtendMatching()
 		{
 			var mock = new Mock<IOrderRepository>();
-			mock.Setup(repo => repo.Save(OrderIs.Big()))
+			mock.Setup(repo => repo.Save(Order.IsBig()))
 				.Throws(new InvalidOperationException());
 
 			try
@@ -46,7 +47,7 @@ namespace Moq.Tests
 		public void ShouldExtendWithPropertyMatchers()
 		{
 			var mock = new Mock<IOrderRepository>();
-			mock.Setup(repo => repo.Save(Orders.IsSmall))
+			mock.Setup(repo => repo.Save(Order.IsSmall))
 				.Throws(new InvalidOperationException());
 
 			try
@@ -60,24 +61,14 @@ namespace Moq.Tests
 			}
 		}
 
-		//[Fact]
-		//public void SetterMatcherRendersNicely()
-		//{
-		//	var mock = new Mock<IOrderRepository>();
+		[Fact]
+		public void SetterMatcherRendersNicely()
+		{
+			var mock = new Mock<IOrderRepository>();
 
-		//	try
-		//	{
-		//		mock.VerifySet(repo => repo.Value = It.IsAny<int>());
-		//	}
-		//	catch (MockException me)
-		//	{
-		//		Console.WriteLine(me.Message);
-		//	}
-
-		//	mock.Object.Value = 25;
-
-		//	mock.VerifySet(repo => repo.Value = It.IsInRange(10, 25, Range.Inclusive));
-		//}
+			var ex = Record.Exception(() => mock.VerifySet(repo => repo.Value = It.IsAny<int>()));
+			Assert.Contains("repo => repo.Value = It.IsAny<int>()", ex.Message);
+		}
 	}
 
 	public static class Orders
@@ -86,20 +77,6 @@ namespace Moq.Tests
 		public static IEnumerable<Order> Contains(Order order)
 		{
 			return Match.Create<IEnumerable<Order>>(orders => orders.Contains(order));
-		}
-
-		public static Order IsBig()
-		{
-			return Match.Create<Order>(o => o.Amount >= 1000);
-		}
-
-		[Matcher]
-		public static Order IsSmall
-		{
-			get
-			{
-				return Match.Create<Order>(o => o.Amount <= 1000);
-			}
 		}
 	}
 
@@ -110,17 +87,18 @@ namespace Moq.Tests
 		int Value { get; set; }
 	}
 
-	public static class OrderIs
-	{
-		[Matcher]
-		public static Order Big()
-		{
-			return Match.Create<Order>(o => o.Amount >= 1000);
-		}
-	}
-
 	public class Order
 	{
 		public int Amount { get; set; }
+
+		[Matcher]
+		public static Order IsBig()
+		{
+			return Match.Create<Order>(o => o.Amount >= 1000);
+		}
+
+
+		[Matcher]
+		public static Order IsSmall => Match.Create<Order>(o => o.Amount <= 1000);
 	}
 }

--- a/tests/Moq.Tests/Linq/SupportedQuerying.cs
+++ b/tests/Moq.Tests/Linq/SupportedQuerying.cs
@@ -238,6 +238,7 @@ namespace Moq.Tests.Linq
 				Assert.Equal("foo", foo.Do(5));
 			}
 
+			[Matcher]
 			public TValue Any<TValue>()
 			{
 				return Match.Create<TValue>(v => true);

--- a/tests/Moq.Tests/MatcherAttributeFixture.cs
+++ b/tests/Moq.Tests/MatcherAttributeFixture.cs
@@ -6,7 +6,6 @@ using Xunit;
 
 namespace Moq.Tests
 {
-	[Obsolete("This fixture contains tests related to `" + nameof(MatcherAttribute) + "`, which is obsolete.")]
 	public class MatcherAttributeFixture
 	{
 		public interface IFoo

--- a/tests/Moq.Tests/MockFixture.cs
+++ b/tests/Moq.Tests/MockFixture.cs
@@ -707,6 +707,7 @@ namespace Moq.Tests
 			Assert.Equal(3, mock.Object.Echo(3));
 		}
 
+		[Matcher]
 		private int IsMultipleOf(int value)
 		{
 			return Match.Create<int>(i => i % value == 0);

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2237,9 +2237,6 @@ namespace Moq.Tests.Regressions
 		#region #49
 
 		[Fact]
-#pragma warning disable 618
-		[Obsolete("This test is related to `" + nameof(MatcherAttribute) + "`, which is obsolete.")]
-#pragma warning restore 618
 		public void UsesCustomMatchersWithGenerics()
 		{
 			var mock = new Mock<IEvaluateLatest>();
@@ -2251,7 +2248,6 @@ namespace Moq.Tests.Regressions
 			Assert.Equal(2, mock.Object.Method(6));
 		}
 
-		[Obsolete("This class contains matchers using `" + nameof(MatcherAttribute) + "`, which is obsolete.")]
 		public static class IsEqual
 		{
 			[Matcher]

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2056,6 +2056,40 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 725
+
+		public sealed class Issue725
+		{
+			public interface IUseGuid
+			{
+				void Use(Guid id);
+				void UseNullable(Guid? id);
+			}
+
+			public interface IHaveGuid
+			{
+				Guid? Id { get; }
+			}
+
+			[Fact]
+			public void Setup_Do_should_succeed()
+			{
+				var id = Guid.NewGuid();
+				var data = Mock.Of<IHaveGuid>(x => x.Id == id);
+				new Mock<IUseGuid>().Setup(x => x.Use(data.Id.Value));
+			}
+
+			[Fact]
+			public void Setup_DoNullable_should_succeed()
+			{
+				var id = Guid.NewGuid();
+				var data = Mock.Of<IHaveGuid>(x => x.Id == id);
+				new Mock<IUseGuid>().Setup(x => x.UseNullable(data.Id));
+			}
+		}
+
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47


### PR DESCRIPTION
Fixes #725 (though that is not the only reason behind this change).