### PR TITLE
Verify gets confused between the same generic and non-generic signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 #### Fixed
 
 * `InvalidOperationException` when specifiying setup on mock with mock containing property of type `Nullable<T>` (@dav1dev, #725)
+* `Verify` gets confused between the same generic and non-generic signature (@lepijohnny, #749)
 
 
 ## 4.10.1 (2018-12-03)

--- a/src/Moq/InvocationShape.cs
+++ b/src/Moq/InvocationShape.cs
@@ -77,7 +77,7 @@ namespace Moq
 				return false;
 			}
 
-			if (method.IsGenericMethod)
+			if (method.IsGenericMethod || invocationMethod.IsGenericMethod)
 			{
 				if (!method.GetGenericArguments().CompareTo(invocationMethod.GetGenericArguments(), exact: false))
 				{

--- a/tests/Moq.Tests/VerifyFixture.cs
+++ b/tests/Moq.Tests/VerifyFixture.cs
@@ -900,17 +900,48 @@ namespace Moq.Tests
 		}
 
 		[Fact]
-		public void MatchDerivedTypesForGenericParameters()
+		public void Should_verify_derived_as_generic_parameters()
 		{
+			//Arrange
 			var mock = new Mock<IBaz>();
 
+			//Act
 			mock.Object.Subscribe<BazParam2>();
 			mock.Object.Subscribe<BazParam>();
 			mock.Object.Subscribe<IBazParam>();
 
+			//Assert
 			mock.Verify(foo => foo.Subscribe<IBazParam>(), Times.Exactly(3));
 			mock.Verify(foo => foo.Subscribe<BazParam>(), Times.Exactly(2));
 			mock.Verify(foo => foo.Subscribe<BazParam2>(), Times.Once);
+		}
+
+		[Fact]
+		public void Should_not_verify_nongeneric_when_generic_invoked()
+		{
+			//Arrange
+			var mock = new Mock<IBaz>();
+
+			//Act
+			mock.Object.Subscribe<IBazParam>();
+
+			//Assert
+			mock.Verify(foo => foo.Subscribe<IBazParam>(), Times.Once);
+			mock.Verify(foo => foo.Subscribe(), Times.Never);
+		}
+
+		[Fact]
+		public void Should_not_verify_generic_when_nongeneric_invoked()
+		{
+			//Arrange
+			var mock = new Mock<IBaz>();
+
+			//Act
+			mock.Object.Subscribe();
+
+			//Assert
+			mock.Verify(foo => foo.Subscribe<IBazParam>(), Times.Never);
+			mock.Verify(foo => foo.Subscribe(), Times.Once);
 		}
 
 		[Fact]
@@ -1511,6 +1542,7 @@ namespace Moq.Tests
 		{
 			void Call<T>(T param) where T:IBazParam;
 			void Subscribe<T>() where T : IBazParam;
+			void Subscribe();
 		}
 
 		public class BazParam:IBazParam

--- a/tests/Moq.Tests/VerifyFixture.cs
+++ b/tests/Moq.Tests/VerifyFixture.cs
@@ -900,6 +900,20 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public void MatchDerivedTypesForGenericParameters()
+		{
+			var mock = new Mock<IBaz>();
+
+			mock.Object.Subscribe<BazParam2>();
+			mock.Object.Subscribe<BazParam>();
+			mock.Object.Subscribe<IBazParam>();
+
+			mock.Verify(foo => foo.Subscribe<IBazParam>(), Times.Exactly(3));
+			mock.Verify(foo => foo.Subscribe<BazParam>(), Times.Exactly(2));
+			mock.Verify(foo => foo.Subscribe<BazParam2>(), Times.Once);
+		}
+
+		[Fact]
 		public void NullArrayValuesForActualInvocationArePrintedAsNullInMockExeptionMessage()
 		{
 			var strings = new string[] { "1", null, "3" };
@@ -1496,6 +1510,7 @@ namespace Moq.Tests
 		public interface IBaz
 		{
 			void Call<T>(T param) where T:IBazParam;
+			void Subscribe<T>() where T : IBazParam;
 		}
 
 		public class BazParam:IBazParam


### PR DESCRIPTION
The fix for #749. I also added a few tests to verify the derived generic parameters verification. It is already existing functionality in moq but the tests were missing. IMO it cannot be harmful anyway to add more tests.