### PR TITLE
Add new `mock.Protected().Setup()` method overload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 #### Changed
 
-* **Breaking change:** All custom argument matcher methods (including those using `Match.Create<T>`) must now be marked with the `[Matcher]` attribute. For this reason, `MatcherAttribute` is no longer marked obsolete (@stakx, #732)
+This release contains several **minor breaking changes**. Please review your code with respect to the following:
+
+* All custom argument matcher methods (including those using `Match.Create<T>`) must now be marked with the `[Matcher]` attribute. For this reason, `MatcherAttribute` is no longer marked obsolete (@stakx, #732)
+* Method overload resolution for `mock.Protected().Setup("VoidMethod", ...)` may change due to a new overload: If you set up a `void` method whose first argument is a `bool`, make sure that argument gets interpreted as part of `args`, not as `exactParameterMatch` (see also *Added* section below). (@stakx, #751)
+
+#### Added
+
+* New method overload `mock.Protected().Setup("VoidMethod", exactParameterMatch, args)` overload having a `bool exactParameterMatch` parameter. Due to method overload resolution, it was easy to think this already existed resolution when in fact it did not, leading to failing tests. (@stakx, #751)
 
 #### Fixed
 

--- a/src/Moq/Protected/IProtectedMock.cs
+++ b/src/Moq/Protected/IProtectedMock.cs
@@ -39,6 +39,16 @@ namespace Moq.Protected
 		ISetup<TMock> Setup(string voidMethodName, params object[] args);
 
 		/// <summary>
+		/// Specifies a setup for a void method invocation with the given
+		/// <paramref name="voidMethodName"/>, optionally specifying arguments for the method call.
+		/// </summary>
+		/// <param name="voidMethodName">The name of the void method to be invoked.</param>
+		/// <param name="exactParameterMatch">Should the parameter types match exactly types that were provided</param>
+		/// <param name="args">The optional arguments for the invocation. If argument matchers are used,
+		/// remember to use <see cref="ItExpr"/> rather than <see cref="It"/>.</param>
+		ISetup<TMock> Setup(string voidMethodName, bool exactParameterMatch, params object[] args);
+
+		/// <summary>
 		/// Specifies a setup for an invocation on a property or a non void method with the given 
 		/// <paramref name="methodOrPropertyName"/>, optionally specifying arguments for the method call.
 		/// </summary>

--- a/src/Moq/Protected/ProtectedMock.cs
+++ b/src/Moq/Protected/ProtectedMock.cs
@@ -36,7 +36,14 @@ namespace Moq.Protected
 		{
 			Guard.NotNullOrEmpty(methodName, nameof(methodName));
 
-			var method = GetMethod(methodName, args);
+			return this.Setup(methodName, false, args);
+		}
+
+		public ISetup<T> Setup(string methodName, bool exactParameterMatch, params object[] args)
+		{
+			Guard.NotNullOrEmpty(methodName, nameof(methodName));
+
+			var method = GetMethod(methodName, exactParameterMatch, args);
 			ThrowIfMemberMissing(methodName, method);
 			ThrowIfPublicMethod(method, typeof(T).Name);
 

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2090,6 +2090,44 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 735
+
+		public class Issue735
+		{
+			[Fact]
+			public void Protected_Setup_should_find_and_distinguish_between_two_method_overloads()
+			{
+				int which = 0;
+				var mockedRule = new Mock<MyAbstractClass>();
+				mockedRule.Protected().Setup("ApplyRule", true, ItExpr.IsAny<IDictionary<string, object>>()).Callback(() => which = 1);
+				mockedRule.Protected().Setup("ApplyRule", true, ItExpr.IsAny<object>()).Callback(() => which = 2);
+
+				mockedRule.Object.InvokeApplyRule(new object());
+				Assert.Equal(2, which);
+
+				mockedRule.Object.InvokeApplyRule(new Dictionary<string, object>());
+				Assert.Equal(1, which);
+			}
+
+			public abstract class MyAbstractClass
+			{
+				protected abstract void ApplyRule(IDictionary<string, object> tokens);
+				protected abstract void ApplyRule(object obj);
+
+				public void InvokeApplyRule(IDictionary<string, object> tokens)
+				{
+					this.ApplyRule(tokens);
+				}
+
+				public void InvokeApplyRule(object obj)
+				{
+					this.ApplyRule(obj);
+				}
+			}
+		}
+
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47


### PR DESCRIPTION
This adds a new method overload for `mock.Protected().Setup()`:

```csharp
ISetup<TMock> Setup(string voidMethodName, bool exactParameterMatch, params object[] args);
```

in addition to the existing one:

```csharp
ISetup<TMock> Setup(string voidMethodName, params object[] args);
```

This means that with a call such as the following:

```csharp
mock.Protected().Setup("SomeVoidMethod", true, arg, anotherArg);
```

`true` will be interpreted as the `exactParameterMatch` parameter instead of as the first method argument. **This can break existing code**, but it can also help new code where the `exactParameterMatch` is needed to choose the right method to be setup (e.g. fixes #735).