### PR TITLE
Document that "reachability" bug has been fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ This release contains several **minor breaking changes**. Please review your cod
 
 * `InvalidOperationException` when specifiying setup on mock with mock containing property of type `Nullable<T>` (@dav1dev, #725)
 * `Verify` gets confused between the same generic and non-generic signature (@lepijohnny, #749)
-
+* Setup gets included in `Verify` despite being "unreachable" (@stakx, #703)
 
 ## 4.10.1 (2018-12-03)
 


### PR DESCRIPTION
The previous commit #760 has fixed #703. From its description:

> 2. One example of this is when a setup for some mock member has been overridden, but there is still an `InnerMocks` entry for that same member. This typically leads to "unreachable" inner mocks being included in recursive verification when they should no longer be included.

Add tests that document this is now fixed.

(It would have been nicer to add these tests in a failing state first, but I didn't know precisely which bugs the previous refactoring would fix.)