### PR TITLE
Thorough aggregation of verification errors & more complete error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This release contains several **minor breaking changes**. Please review your cod
 
 * All custom argument matcher methods (including those using `Match.Create<T>`) must now be marked with the `[Matcher]` attribute. For this reason, `MatcherAttribute` is no longer marked obsolete (@stakx, #732)
 * Method overload resolution for `mock.Protected().Setup("VoidMethod", ...)`, `mock.Protected().Verify("VoidMethod", ...)` and `mock.Protected().Verify<TResult>("NonVoidMethod", ...)` may change due to a new overloads: If the first argument is a `bool`, make sure that argument gets interpreted as part of `args`, not as `exactParameterMatch` (see also *Added* section below). (@stakx & @Shereef, #751, #753)
+* `mock.Verify[All]` now performs a more thorough error aggregation. Error messages of inner/recursive mocks are included in the error message using indentation to show the relationship between mocks. (@stakx, #762)
 
 #### Added
 

--- a/src/Moq/AutoImplementedPropertyGetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertyGetterSetup.cs
@@ -29,14 +29,14 @@ namespace Moq
 			invocation.Return(this.getter.Invoke());
 		}
 
-		public override void Verify()
+		public override MockException TryVerify()
 		{
-			this.VerifyInnerMock(innerMock => innerMock.Verify());
+			return this.TryVerifyInnerMock(innerMock => innerMock.TryVerify());
 		}
 
-		public override void VerifyAll()
+		public override MockException TryVerifyAll()
 		{
-			this.VerifyInnerMock(innerMock => innerMock.VerifyAll());
+			return this.TryVerifyInnerMock(innerMock => innerMock.TryVerifyAll());
 		}
 	}
 }

--- a/src/Moq/AutoImplementedPropertyGetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertyGetterSetup.cs
@@ -29,8 +29,14 @@ namespace Moq
 			invocation.Return(this.getter.Invoke());
 		}
 
+		public override void Verify()
+		{
+			this.VerifyInnerMock(innerMock => innerMock.Verify());
+		}
+
 		public override void VerifyAll()
 		{
+			this.VerifyInnerMock(innerMock => innerMock.VerifyAll());
 		}
 	}
 }

--- a/src/Moq/AutoImplementedPropertyGetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertyGetterSetup.cs
@@ -29,6 +29,8 @@ namespace Moq
 			invocation.Return(this.getter.Invoke());
 		}
 
-		public override bool TryVerifyAll() => true;
+		public override void VerifyAll()
+		{
+		}
 	}
 }

--- a/src/Moq/AutoImplementedPropertySetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertySetterSetup.cs
@@ -30,8 +30,6 @@ namespace Moq
 			invocation.Return();
 		}
 
-		public override void VerifyAll()
-		{
-		}
+		public override MockException TryVerifyAll() => null;
 	}
 }

--- a/src/Moq/AutoImplementedPropertySetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertySetterSetup.cs
@@ -30,6 +30,8 @@ namespace Moq
 			invocation.Return();
 		}
 
-		public override bool TryVerifyAll() => true;
+		public override void VerifyAll()
+		{
+		}
 	}
 }

--- a/src/Moq/IDeterministicReturnValueSetup.cs
+++ b/src/Moq/IDeterministicReturnValueSetup.cs
@@ -27,19 +27,18 @@ namespace Moq
 			return mock != null;
 		}
 
-		public static void VerifyInnerMock(this IDeterministicReturnValueSetup setup, Action<Mock> verify)
+		public static MockException TryVerifyInnerMock(this IDeterministicReturnValueSetup setup, Func<Mock, MockException> verify)
 		{
 			if (setup.ReturnsInnerMock(out var innerMock))
 			{
-				try
+				var error = verify(innerMock);
+				if (error?.IsVerificationError == true)
 				{
-					verify(innerMock);
-				}
-				catch (MockException error) when (error.IsVerificationError)
-				{
-					throw MockException.FromInnerMockOf(setup, error);
+					return MockException.FromInnerMockOf(setup, error);
 				}
 			}
+
+			return null;
 		}
 	}
 }

--- a/src/Moq/IDeterministicReturnValueSetup.cs
+++ b/src/Moq/IDeterministicReturnValueSetup.cs
@@ -26,5 +26,20 @@ namespace Moq
 			mock = (Unwrap.ResultIfCompletedTask(setup.ReturnValue) as IMocked)?.Mock;
 			return mock != null;
 		}
+
+		public static void VerifyInnerMock(this IDeterministicReturnValueSetup setup, Action<Mock> verify)
+		{
+			if (setup.ReturnsInnerMock(out var innerMock))
+			{
+				try
+				{
+					verify(innerMock);
+				}
+				catch (MockException error) when (error.IsVerificationError)
+				{
+					throw MockException.FromInnerMockOf(setup, error);
+				}
+			}
+		}
 	}
 }

--- a/src/Moq/InnerMockSetup.cs
+++ b/src/Moq/InnerMockSetup.cs
@@ -24,8 +24,14 @@ namespace Moq
 			invocation.Return(this.returnValue);
 		}
 
+		public override void Verify()
+		{
+			this.VerifyInnerMock(innerMock => innerMock.Verify());
+		}
+
 		public override void VerifyAll()
 		{
+			this.VerifyInnerMock(innerMock => innerMock.VerifyAll());
 		}
 	}
 }

--- a/src/Moq/InnerMockSetup.cs
+++ b/src/Moq/InnerMockSetup.cs
@@ -24,14 +24,14 @@ namespace Moq
 			invocation.Return(this.returnValue);
 		}
 
-		public override void Verify()
+		public override MockException TryVerify()
 		{
-			this.VerifyInnerMock(innerMock => innerMock.Verify());
+			return this.TryVerifyInnerMock(innerMock => innerMock.TryVerify());
 		}
 
-		public override void VerifyAll()
+		public override MockException TryVerifyAll()
 		{
-			this.VerifyInnerMock(innerMock => innerMock.VerifyAll());
+			return this.TryVerifyInnerMock(innerMock => innerMock.TryVerifyAll());
 		}
 	}
 }

--- a/src/Moq/InnerMockSetup.cs
+++ b/src/Moq/InnerMockSetup.cs
@@ -24,9 +24,8 @@ namespace Moq
 			invocation.Return(this.returnValue);
 		}
 
-		public override bool TryVerifyAll()
+		public override void VerifyAll()
 		{
-			return true;
 		}
 	}
 }

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -310,9 +310,12 @@ namespace Moq
 			this.returnOrThrowResponse = new ThrowExceptionResponse(exception);
 		}
 
-		public override bool TryVerifyAll()
+		public override void VerifyAll()
 		{
-			return (this.flags & Flags.Invoked) != 0;
+			if ((this.flags & Flags.Invoked) == 0)
+			{
+				throw MockException.UnmatchedSetup(this);
+			}
 		}
 
 		public void Verifiable()

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -310,12 +310,9 @@ namespace Moq
 			this.returnOrThrowResponse = new ThrowExceptionResponse(exception);
 		}
 
-		public override void VerifyAll()
+		public override MockException TryVerifyAll()
 		{
-			if ((this.flags & Flags.Invoked) == 0)
-			{
-				throw MockException.UnmatchedSetup(this);
-			}
+			return (this.flags & Flags.Invoked) == 0 ? MockException.UnmatchedSetup(this) : null;
 		}
 
 		public void Verifiable()

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -202,7 +202,7 @@ namespace Moq
 				invocation.MarkAsVerifiedIfMatchedByVerifiableSetup();
 			}
 
-			this.VerifySetups(setup => setup.Verify(), innerMock => innerMock.Verify());
+			this.VerifySetups(setup => setup.Verify());
 		}
 
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.VerifyAll"]/*'/>
@@ -213,10 +213,10 @@ namespace Moq
 				invocation.MarkAsVerifiedIfMatchedBySetup();
 			}
 
-			this.VerifySetups(setup => setup.VerifyAll(), innerMock => innerMock.VerifyAll());
+			this.VerifySetups(setup => setup.VerifyAll());
 		}
 
-		private void VerifySetups(Action<Setup> verifySetup, Action<Mock> verifyInnerMock)
+		private void VerifySetups(Action<Setup> verifySetup)
 		{
 			var errors = new List<MockException>();
 
@@ -225,18 +225,6 @@ namespace Moq
 				try
 				{
 					verifySetup(setup);
-				}
-				catch (MockException error) when (error.IsVerificationError)
-				{
-					errors.Add(error);
-				}
-			}
-
-			foreach (var inner in this.GetInnerMockSetups())
-			{
-				try
-				{
-					verifyInnerMock(inner.GetInnerMock());
 				}
 				catch (MockException error) when (error.IsVerificationError)
 				{

--- a/src/Moq/MockException.cs
+++ b/src/Moq/MockException.cs
@@ -126,17 +126,16 @@ namespace Moq
 		}
 
 		/// <summary>
-		///   Returns the exception to be thrown when <see cref="Mock.Verify"/> or <see cref="MockFactory.Verify"/> find a setup that has not been invoked.
+		///   Returns the exception to be thrown when a setup has not been invoked.
 		/// </summary>
-		internal static MockException UnmatchedSetups(Mock mock, IEnumerable<Setup> setups)
+		internal static MockException UnmatchedSetup(Setup setup)
 		{
 			return new MockException(
-				MockExceptionReasons.UnmatchedSetups,
+				MockExceptionReasons.UnmatchedSetup,
 				string.Format(
 					CultureInfo.CurrentCulture,
-					Resources.UnmatchedSetups,
-					mock.ToString(),
-					setups.Aggregate(new StringBuilder(), (builder, setup) => builder.AppendLine(setup.ToString())).ToString()));
+					Resources.UnmatchedSetup,
+					setup));
 		}
 
 		/// <summary>
@@ -144,16 +143,28 @@ namespace Moq
 		///   and whose reason(s) is the combination of the given <paramref name="errors"/>' reason(s).
 		///   Used by <see cref="MockFactory.VerifyMocks(Action{Mock})"/> when it finds one or more mocks with verification errors.
 		/// </summary>
-		internal static MockException Combined(IEnumerable<MockException> errors)
+		internal static MockException Combined(IEnumerable<MockException> errors, string preamble)
 		{
 			Debug.Assert(errors != null);
 			Debug.Assert(errors.Any());
 
-			return new MockException(
-				errors.Select(error => error.Reasons).Aggregate((a, r) => a | r),
-				string.Join(
-					Environment.NewLine,
-					errors.Select(error => error.Message)));
+			var reasons = default(MockExceptionReasons);
+			var message = new StringBuilder();
+
+			if (preamble != null)
+			{
+				message.Append(preamble).TrimEnd().AppendLine()
+				       .AppendLine();
+			}
+
+			foreach (var error in errors)
+			{
+				reasons |= error.Reasons;
+				message.AppendIndented(error.Message, count: 3).TrimEnd().AppendLine()
+				       .AppendLine();
+			}
+
+			return new MockException(reasons, message.TrimEnd().ToString());
 		}
 
 		/// <summary>
@@ -161,13 +172,17 @@ namespace Moq
 		/// </summary>
 		internal static MockException UnverifiedInvocations(Mock mock, IEnumerable<Invocation> invocations)
 		{
-			return new MockException(
-				MockExceptionReasons.UnverifiedInvocations,
-				string.Format(
-					CultureInfo.CurrentCulture,
-					Resources.UnverifiedInvocations,
-					mock.ToString(),
-					invocations.Aggregate(new StringBuilder(), (builder, setup) => builder.AppendLine(setup.ToString())).ToString()));
+			var message = new StringBuilder();
+
+			message.AppendLine(string.Format(CultureInfo.CurrentCulture, Resources.UnverifiedInvocations, mock)).TrimEnd().AppendLine()
+			       .AppendLine();
+
+			foreach (var invocation in invocations)
+			{
+				message.AppendIndented(invocation.ToString(), count: 3).TrimEnd().AppendLine();
+			}
+
+			return new MockException(MockExceptionReasons.UnverifiedInvocations, message.TrimEnd().ToString());
 		}
 
 		private readonly MockExceptionReasons reasons;
@@ -188,7 +203,7 @@ namespace Moq
 			get
 			{
 				const MockExceptionReasons verificationErrorMask = MockExceptionReasons.NoMatchingCalls
-				                                                 | MockExceptionReasons.UnmatchedSetups
+				                                                 | MockExceptionReasons.UnmatchedSetup
 				                                                 | MockExceptionReasons.UnverifiedInvocations;
 				return (this.reasons & verificationErrorMask) != 0;
 			}

--- a/src/Moq/MockException.cs
+++ b/src/Moq/MockException.cs
@@ -138,6 +138,18 @@ namespace Moq
 					setup));
 		}
 
+		internal static MockException FromInnerMockOf(IDeterministicReturnValueSetup setup, MockException error)
+		{
+			var message = new StringBuilder();
+
+			message.AppendLine(string.Format(CultureInfo.CurrentCulture, Resources.VerificationErrorsOfInnerMock, setup)).TrimEnd().AppendLine()
+			       .AppendLine();
+
+			message.AppendIndented(error.Message, count: 3);
+
+			return new MockException(error.Reasons, message.ToString());
+		}
+
 		/// <summary>
 		///   Returns an exception whose message is the concatenation of the given <paramref name="errors"/>' messages
 		///   and whose reason(s) is the combination of the given <paramref name="errors"/>' reason(s).

--- a/src/Moq/MockExceptionReasons.cs
+++ b/src/Moq/MockExceptionReasons.cs
@@ -13,7 +13,7 @@ namespace Moq
 		NoMatchingCalls = 4,
 		NoSetup = 8,
 		ReturnValueRequired = 16,
-		UnmatchedSetups = 32,
+		UnmatchedSetup = 32,
 		UnverifiedInvocations = 64,
 	}
 }

--- a/src/Moq/Obsolete/MockFactory.cs
+++ b/src/Moq/Obsolete/MockFactory.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 
+using Moq.Properties;
+
 namespace Moq
 {
 	/// <summary>
@@ -363,7 +365,7 @@ namespace Moq
 
 			if (errors.Count > 0)
 			{
-				throw MockException.Combined(errors);
+				throw MockException.Combined(errors, preamble: Resources.VerificationErrorsOfMockRepository);
 			}
 		}
 	}

--- a/src/Moq/Properties/Resources.Designer.cs
+++ b/src/Moq/Properties/Resources.Designer.cs
@@ -694,6 +694,15 @@ namespace Moq.Properties {
 		}
 		
 		/// <summary>
+		///   Looks up a localized string similar to {0}:.
+		/// </summary>
+		internal static string VerificationErrorsOfInnerMock {
+			get {
+				return ResourceManager.GetString("VerificationErrorsOfInnerMock", resourceCulture);
+			}
+		}
+		
+		/// <summary>
 		///   Looks up a localized string similar to {0}:
 		///This mock failed verification due to the following:.
 		/// </summary>

--- a/src/Moq/Properties/Resources.Designer.cs
+++ b/src/Moq/Properties/Resources.Designer.cs
@@ -647,12 +647,12 @@ namespace Moq.Properties {
 		}
 		
 		/// <summary>
-		///   Looks up a localized string similar to The following setups on mock &apos;{0}&apos; were not matched:
-		///{1}.
+		///   Looks up a localized string similar to {0}:
+		///This setup was not matched..
 		/// </summary>
-		internal static string UnmatchedSetups {
+		internal static string UnmatchedSetup {
 			get {
-				return ResourceManager.GetString("UnmatchedSetups", resourceCulture);
+				return ResourceManager.GetString("UnmatchedSetup", resourceCulture);
 			}
 		}
 		
@@ -675,8 +675,8 @@ namespace Moq.Properties {
 		}
 		
 		/// <summary>
-		///   Looks up a localized string similar to The following invocations were not verified:
-		///{0}.
+		///   Looks up a localized string similar to {0}:
+		///This mock failed verification due to the following unverified invocations:.
 		/// </summary>
 		internal static string UnverifiedInvocations {
 			get {
@@ -690,6 +690,25 @@ namespace Moq.Properties {
 		internal static string UseItExprIsNullRatherThanNullArgumentValue {
 			get {
 				return ResourceManager.GetString("UseItExprIsNullRatherThanNullArgumentValue", resourceCulture);
+			}
+		}
+		
+		/// <summary>
+		///   Looks up a localized string similar to {0}:
+		///This mock failed verification due to the following:.
+		/// </summary>
+		internal static string VerificationErrorsOfMock {
+			get {
+				return ResourceManager.GetString("VerificationErrorsOfMock", resourceCulture);
+			}
+		}
+		
+		/// <summary>
+		///   Looks up a localized string similar to The mock repository failed verification due to the following:.
+		/// </summary>
+		internal static string VerificationErrorsOfMockRepository {
+			get {
+				return ResourceManager.GetString("VerificationErrorsOfMockRepository", resourceCulture);
 			}
 		}
 		

--- a/src/Moq/Properties/Resources.resx
+++ b/src/Moq/Properties/Resources.resx
@@ -358,4 +358,7 @@ This mock failed verification due to the following:</value>
 	<data name="VerificationErrorsOfMockRepository" xml:space="preserve">
 		<value>The mock repository failed verification due to the following:</value>
 	</data>
+	<data name="VerificationErrorsOfInnerMock" xml:space="preserve">
+		<value>{0}:</value>
+	</data>
 </root>

--- a/src/Moq/Properties/Resources.resx
+++ b/src/Moq/Properties/Resources.resx
@@ -136,9 +136,9 @@
 	<data name="ReturnValueRequired" xml:space="preserve">
 		<value>Invocation needs to return a value and therefore must have a corresponding setup that provides it.</value>
 	</data>
-	<data name="UnmatchedSetups" xml:space="preserve">
-		<value>The following setups on mock '{0}' were not matched:
-{1}</value>
+	<data name="UnmatchedSetup" xml:space="preserve">
+		<value>{0}:
+This setup was not matched.</value>
 	</data>
 	<data name="ConstructorArgsForInterface" xml:space="preserve">
 		<value>Constructor arguments cannot be passed for interface mocks.</value>
@@ -345,10 +345,17 @@ Expected invocation on the mock once, but was {4} times: {1}</value>
 		<value>Invalid callback. Setup on method with {0} parameter(s) cannot invoke callback with different number of parameters ({1}).</value>
 	</data>
 	<data name="UnverifiedInvocations" xml:space="preserve">
-		<value>The following invocations on mock '{0}' were not verified:
-{1}</value>
+		<value>{0}:
+This mock failed verification due to the following unverified invocations:</value>
 	</data>
 	<data name="CallBaseCannotBeUsedWithDelegateMocks" xml:space="preserve">
 		<value>CallBase cannot be used with Delegate mocks.</value>
+	</data>
+	<data name="VerificationErrorsOfMock" xml:space="preserve">
+		<value>{0}:
+This mock failed verification due to the following:</value>
+	</data>
+	<data name="VerificationErrorsOfMockRepository" xml:space="preserve">
+		<value>The mock repository failed verification due to the following:</value>
 	</data>
 </root>

--- a/src/Moq/SequenceSetup.cs
+++ b/src/Moq/SequenceSetup.cs
@@ -95,9 +95,12 @@ namespace Moq
 			}
 		}
 
-		public override bool TryVerifyAll()
+		public override void VerifyAll()
 		{
-			return this.invoked;
+			if (!this.invoked)
+			{
+				throw MockException.UnmatchedSetup(this);
+			}
 		}
 
 		private readonly struct Response

--- a/src/Moq/SequenceSetup.cs
+++ b/src/Moq/SequenceSetup.cs
@@ -95,12 +95,9 @@ namespace Moq
 			}
 		}
 
-		public override void VerifyAll()
+		public override MockException TryVerifyAll()
 		{
-			if (!this.invoked)
-			{
-				throw MockException.UnmatchedSetup(this);
-			}
+			return this.invoked ? null : MockException.UnmatchedSetup(this);
 		}
 
 		private readonly struct Response

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -53,14 +53,11 @@ namespace Moq
 			return builder.ToString();
 		}
 
-		public virtual void Verify()
+		public virtual MockException TryVerify()
 		{
-			if (this.IsVerifiable)
-			{
-				this.VerifyAll();
-			}
+			return this.IsVerifiable ? this.TryVerifyAll() : null;
 		}
 
-		public abstract void VerifyAll();
+		public abstract MockException TryVerifyAll();
 	}
 }

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -53,11 +53,14 @@ namespace Moq
 			return builder.ToString();
 		}
 
-		public bool TryVerify()
+		public virtual void Verify()
 		{
-			return !this.IsVerifiable || this.TryVerifyAll();
+			if (this.IsVerifiable)
+			{
+				this.VerifyAll();
+			}
 		}
 
-		public abstract bool TryVerifyAll();
+		public abstract void VerifyAll();
 	}
 }

--- a/src/Moq/StringBuilderExtensions.cs
+++ b/src/Moq/StringBuilderExtensions.cs
@@ -13,6 +13,27 @@ namespace Moq
 {
 	internal static class StringBuilderExtensions
 	{
+		public static StringBuilder AppendIndented(this StringBuilder stringBuilder, string str, int count = 1, char indentChar = ' ')
+		{
+			var i = 0;
+			while (i < str.Length)
+			{
+				stringBuilder.Append(indentChar, count);
+				var j = str.IndexOf('\n', i + 1);
+				if (j > i)
+				{
+					stringBuilder.Append(str, i, j - i + 1);
+					i = j + 1;
+				}
+				else
+				{
+					break;
+				}
+			}
+			stringBuilder.Append(str, i, str.Length - i);
+			return stringBuilder;
+		}
+
 		public static StringBuilder AppendNameOf(this StringBuilder stringBuilder, MethodInfo method, bool includeGenericArgumentList)
 		{
 			stringBuilder.Append(method.Name);
@@ -99,6 +120,15 @@ namespace Moq
 				stringBuilder.Append(obj.ToString());
 			}
 
+			return stringBuilder;
+		}
+
+		public static StringBuilder TrimEnd(this StringBuilder stringBuilder)
+		{
+			while (char.IsWhiteSpace(stringBuilder[stringBuilder.Length - 1]))
+			{
+				--stringBuilder.Length;
+			}
 			return stringBuilder;
 		}
 	}

--- a/tests/Moq.Tests/MockRepositoryFixture.cs
+++ b/tests/Moq.Tests/MockRepositoryFixture.cs
@@ -52,7 +52,7 @@ namespace Moq.Tests
 			}
 			catch (MockException mex)
 			{
-				Assert.Equal(MockExceptionReasons.UnmatchedSetups, mex.Reasons);
+				Assert.Equal(MockExceptionReasons.UnmatchedSetup, mex.Reasons);
 			}
 		}
 
@@ -103,11 +103,16 @@ namespace Moq.Tests
 
 			Assert.NotNull(ex);
 			Assert.True(ex.Message.ContainsConsecutiveLines(
-				$"The following invocations on mock \'{fooMock}\' were not verified:",
-				$"IFoo.Do()",
-				$"",
-				$"The following invocations on mock \'{barMock}\' were not verified:",
-				$"IBar.Redo()"));
+				$"   {fooMock}:",
+				$"   This mock failed verification due to the following unverified invocations:",
+				$"   ",
+				$"      IFoo.Do()"));
+
+			Assert.True(ex.Message.ContainsConsecutiveLines(
+				$"   {barMock}:",
+				$"   This mock failed verification due to the following unverified invocations:",
+				$"   ",
+				$"      IBar.Redo()"));
 		}
 
 		[Fact]
@@ -125,7 +130,7 @@ namespace Moq.Tests
 			}
 			catch (MockException mex)
 			{
-				Assert.Equal(MockExceptionReasons.UnmatchedSetups, mex.Reasons);
+				Assert.Equal(MockExceptionReasons.UnmatchedSetup, mex.Reasons);
 				Expression<Action<IFoo>> doExpr = foo => foo.Do();
 				Assert.DoesNotContain(doExpr.ToString(), mex.Message);
 			}
@@ -145,11 +150,16 @@ namespace Moq.Tests
 
 			Assert.NotNull(ex);
 			Assert.True(ex.Message.ContainsConsecutiveLines(
-				$"The following setups on mock \'{foo}\' were not matched:",
-				$"MockRepositoryFixture.IFoo f => f.Do()",
-				$"",
-				$"The following setups on mock \'{bar}\' were not matched:",
-				$"MockRepositoryFixture.IBar b => b.Redo()"));
+				$"   {foo}:",
+				$"   This mock failed verification due to the following:",
+				$"   ",
+				$"      MockRepositoryFixture.IFoo f => f.Do():"));
+
+			Assert.True(ex.Message.ContainsConsecutiveLines(
+				$"   {bar}:",
+				$"   This mock failed verification due to the following:",
+				$"   ",
+				$"      MockRepositoryFixture.IBar b => b.Redo()"));
 		}
 
 		[Fact]


### PR DESCRIPTION
Verification using `mock.Verify[All]` has always been performed in a "recursive" manner (i.e. inner mocks were verified along with the outer / owning mock). However, in the case of failure, verification would often stop and only describe the first error in the message.

This PR makes verification more thorough by aggregating verification errors at all levels:

* Mock repositories aggregate errors of all their mocks. (This was done already.)
* Mocks aggregate errors of all setups. (This is new.)
* Setups can forward errors from an inner mock. (This is also new.)

For example, given this code:

```csharp
var mock = new Mock<IOuter>();
mock.Setup(m => m.Inner.Method());
mock.Setup(m => m.AnotherMethod());
mock.VerifyAll();
```

you might now see such error message:

```
Mock<IOuter:00000001>:
This mock failed verification due to the following:

   IOuter mock => mock.Inner:

      Mock<IInner:00000001>:
      This mock failed verification due to the following:

         IOuter m => m.Inner.Method():
         This setup was not matched.

   IInner m => m.AnotherMethod():
   This setup was not matched.
``` 

instead of the previous:

```
The following setups on mock 'Mock<IOuter:00000001>' were not matched:
IOuter mock => mock.Inner
IOuter m => m.AnotherMethod()
```

The trade-off here is obviously brevity vs. completeness. The latter probably makes more sense in an error message (IMO).