### PR TITLE
Make `System.Object` members interceptable by *any* interceptor

### DIFF
--- a/src/Moq/ProxyFactories/IProxy.cs
+++ b/src/Moq/ProxyFactories/IProxy.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+namespace Moq
+{
+	/// <summary>
+	///   All proxies created by a <see cref="ProxyFactory"/> should implement this interface.
+	/// </summary>
+	// Interface proxies require this to be able to forward invocations of `object` members
+	// to their `IInterceptor`.
+	internal interface IProxy
+	{
+		IInterceptor Interceptor { get; }
+	}
+}

--- a/src/Moq/ProxyFactories/InterfaceProxy.cs
+++ b/src/Moq/ProxyFactories/InterfaceProxy.cs
@@ -26,7 +26,7 @@ namespace Moq.Internals
 		{
 			// Forward this call to the interceptor, so that `object.Equals` can be set up.
 			var invocation = new Invocation(equalsMethod, obj);
-			((IInterceptor)((IMocked)this).Mock).Intercept(invocation);
+			((IProxy)this).Interceptor.Intercept(invocation);
 			return (bool)invocation.ReturnValue;
 		}
 
@@ -36,7 +36,7 @@ namespace Moq.Internals
 		{
 			// Forward this call to the interceptor, so that `object.GetHashCode` can be set up.
 			var invocation = new Invocation(getHashCodeMethod);
-			((IInterceptor)((IMocked)this).Mock).Intercept(invocation);
+			((IProxy)this).Interceptor.Intercept(invocation);
 			return (int)invocation.ReturnValue;
 		}
 
@@ -46,7 +46,7 @@ namespace Moq.Internals
 		{
 			// Forward this call to the interceptor, so that `object.ToString` can be set up.
 			var invocation = new Invocation(toStringMethod);
-			((IInterceptor)((IMocked)this).Mock).Intercept(invocation);
+			((IProxy)this).Interceptor.Intercept(invocation);
 			return (string)invocation.ReturnValue;
 		}
 

--- a/tests/Moq.Tests/InterceptorFixture.cs
+++ b/tests/Moq.Tests/InterceptorFixture.cs
@@ -1,0 +1,72 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+
+using Xunit;
+
+namespace Moq.Tests
+{
+	public class InterceptorFixture
+	{
+		/// <summary>
+		///   These tests document which methods can be intercepted (i.e. seen) by <see cref="IInterceptor"/>s.
+		/// </summary>
+		public class Method_interceptability
+		{
+			[Theory]
+			[InlineData(typeof(ClassType))]
+			[InlineData(typeof(IInterfaceType))]
+			public void Object_Equals(Type typeToProxy)
+			{
+				var proxy = CreateProxy(typeToProxy, new Echo(true));
+				var returnValue = proxy.Equals(42);
+				Assert.True(returnValue);
+			}
+
+			[Theory]
+			[InlineData(typeof(ClassType))]
+			[InlineData(typeof(IInterfaceType))]
+			public void Object_GetHashCode(Type typeToProxy)
+			{
+				var proxy = CreateProxy(typeToProxy, new Echo(42));
+				var returnValue = proxy.GetHashCode();
+				Assert.Equal(42, returnValue);
+			}
+
+			[Theory]
+			[InlineData(typeof(ClassType))]
+			[InlineData(typeof(IInterfaceType))]
+			public void Object_ToString(Type typeToProxy)
+			{
+				var proxy = CreateProxy(typeToProxy, new Echo("42"));
+				var returnValue = proxy.ToString();
+				Assert.Equal("42", returnValue);
+			}
+
+			public abstract class ClassType { }
+
+			public interface IInterfaceType { }
+		}
+
+		private static object CreateProxy(Type type, IInterceptor interceptor)
+		{
+			return ProxyFactory.Instance.CreateProxy(type, interceptor, Type.EmptyTypes, new object[0]);
+		}
+
+		private sealed class Echo : IInterceptor
+		{
+			private readonly object returnValue;
+
+			public Echo(object returnValue)
+			{
+				this.returnValue = returnValue;
+			}
+
+			public void Intercept(Invocation invocation)
+			{
+				invocation.Return(this.returnValue);
+			}
+		}
+	}
+}


### PR DESCRIPTION
`System.Object` methods are currently not interceptable if the proxied type is an interface type, and the interceptor used is not an instance of the `Mock` class. These methods should be interceptable by all interceptors, regardless of their type.

As it happens, this requires the introduction of an `IProxy` interface which is to `IInterceptor` what `IMocked` is to `Mock`. It works in exactly the same fashion, too.

This PR might seem a bit pointless, since the only implementation of `IInterceptor` *is* the `Mock` class, so at the surface `IMocked` should suffice.

However, this lays the groundwork for my next PR, which will introduce some new machinery for converting `Action<T>` delegates back to `Expression<Action<T>>` (which is important to fix some long-standing bugs with e.g. `SetupSet`). That PR will require a new interceptor type... so we'll need `IProxy` anyway.