### PR TITLE
Remove expression execution from `Setup` and `Verify` & make them recursive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This release contains several **minor breaking changes**. Please review your cod
 * All custom argument matcher methods (including those using `Match.Create<T>`) must now be marked with the `[Matcher]` attribute. For this reason, `MatcherAttribute` is no longer marked obsolete (@stakx, #732)
 * Method overload resolution for `mock.Protected().Setup("VoidMethod", ...)`, `mock.Protected().Verify("VoidMethod", ...)` and `mock.Protected().Verify<TResult>("NonVoidMethod", ...)` may change due to a new overloads: If the first argument is a `bool`, make sure that argument gets interpreted as part of `args`, not as `exactParameterMatch` (see also *Added* section below). (@stakx & @Shereef, #751, #753)
 * `mock.Verify[All]` now performs a more thorough error aggregation. Error messages of inner/recursive mocks are included in the error message using indentation to show the relationship between mocks. (@stakx, #762)
+* `mock.Verify` no longer creates setups, nor will it override existing setups, as a side-effect of using a recursive expression. (@stakx, #765)
 
 #### Added
 
@@ -25,6 +26,7 @@ This release contains several **minor breaking changes**. Please review your cod
 * `InvalidOperationException` when specifiying setup on mock with mock containing property of type `Nullable<T>` (@dav1dev, #725)
 * `Verify` gets confused between the same generic and non-generic signature (@lepijohnny, #749)
 * Setup gets included in `Verify` despite being "unreachable" (@stakx, #703)
+* `Verify` can create setups that cause subsequent `VerifyAll` to fail (@stakx & @lepijohnny, #699)
 
 ## 4.10.1 (2018-12-03)
 

--- a/src/Moq/ExpressionComparer.cs
+++ b/src/Moq/ExpressionComparer.cs
@@ -44,6 +44,7 @@ namespace Moq
 						return this.EqualsUnary((UnaryExpression)x, (UnaryExpression)y);
 					case ExpressionType.Add:
 					case ExpressionType.AddChecked:
+					case ExpressionType.Assign:
 					case ExpressionType.Subtract:
 					case ExpressionType.SubtractChecked:
 					case ExpressionType.Multiply:
@@ -86,6 +87,8 @@ namespace Moq
 					case ExpressionType.NewArrayInit:
 					case ExpressionType.NewArrayBounds:
 						return this.EqualsNewArray((NewArrayExpression)x, (NewArrayExpression)y);
+					case ExpressionType.Index:
+						return this.EqualsIndex((IndexExpression)x, (IndexExpression)y);
 					case ExpressionType.Invoke:
 						return this.EqualsInvocation((InvocationExpression)x, (InvocationExpression)y);
 					case ExpressionType.MemberInit:
@@ -140,6 +143,13 @@ namespace Moq
 		private bool EqualsElementInit(ElementInit x, ElementInit y)
 		{
 			return x.AddMethod == y.AddMethod && Equals(x.Arguments, y.Arguments, this.Equals);
+		}
+
+		private bool EqualsIndex(IndexExpression x, IndexExpression y)
+		{
+			return this.Equals(x.Object, y.Object)
+			    && Equals(x.Indexer, y.Indexer)
+			    && Equals(x.Arguments, y.Arguments, this.Equals);
 		}
 
 		private bool EqualsInvocation(InvocationExpression x, InvocationExpression y)

--- a/src/Moq/ExpressionExtensions.cs
+++ b/src/Moq/ExpressionExtensions.cs
@@ -353,59 +353,5 @@ namespace Moq
 		{
 			return new ExpressionStringBuilder().Append(expression).ToString();
 		}
-
-		/// <summary>
-		/// Extracts, into a common form, information from a <see cref="LambdaExpression" />
-		/// around either a <see cref="MethodCallExpression" /> (for a normal method call)
-		/// or a <see cref="InvocationExpression" /> (for a delegate invocation).
-		/// </summary>
-		internal static CallInfo GetCallInfo(this LambdaExpression expression, Mock mock)
-		{
-			Guard.NotNull(expression, nameof(expression));
-
-			if (mock.IsDelegateMock)
-			{
-				// We're a mock for a delegate, so this call can only
-				// possibly be the result of invoking the delegate.
-				var invocation = (InvocationExpression)expression.Body;
-
-				// But the expression we have is for a call on the delegate, not our
-				// delegate interface proxy, so we need to map instead to the
-				// method on that interface, which is the property we've just tested for.
-				_ = ProxyFactory.Instance.GetDelegateProxyInterface(mock.TargetType, out var delegateInterfaceMethod);
-				return new CallInfo(invocation.Expression, delegateInterfaceMethod, invocation.Arguments);
-			}
-
-			if (expression.Body is MethodCallExpression methodCall)
-			{
-				return new CallInfo(methodCall.Object, methodCall.Method, methodCall.Arguments);
-			}
-
-			throw new ArgumentException(string.Format(
-				CultureInfo.CurrentCulture,
-				Resources.SetupNotMethod,
-				expression.ToStringFixed()));
-		}
-	}
-
-	internal readonly struct CallInfo
-	{
-		private readonly Expression expression;
-		private readonly MethodInfo method;
-		private readonly IReadOnlyList<Expression> arguments;
-
-		public CallInfo(Expression expression, MethodInfo method, IReadOnlyList<Expression> arguments)
-		{
-			this.expression = expression;
-			this.method = method;
-			this.arguments = arguments;
-		}
-
-		public void Deconstruct(out Expression expression, out MethodInfo method, out IReadOnlyList<Expression> arguments)
-		{
-			expression = this.expression;
-			method = this.method;
-			arguments = this.arguments;
-		}
 	}
 }

--- a/src/Moq/ExpressionExtensions.cs
+++ b/src/Moq/ExpressionExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
@@ -38,30 +39,241 @@ namespace Moq
 		}
 
 		/// <summary>
+		///   Splits an expression such as `<c>m => m.A.B(x).C[y] = z</c>` into a chain of parts
+		///   that can be set up one at a time:
+		///   <list>
+		///     <item>`<c>m => m.A</c>`</item>,
+		///     <item>`<c>... => ....B(x)</c>`</item>,
+		///     <item>`<c>... => ....C</c>`</item>,
+		///     <item>`<c>... => ...[y] = z</c>`</item>.
+		///   </list>
+		///   <para>
+		///     The split points are chosen such that each part has exactly one associated
+		///     <see cref="MethodInfo"/> and optionally some argument expressions.
+		///   </para>
+		/// </summary>
+		/// <exception cref="ArgumentException">
+		///   It was not possible to completely split up the expression.
+		/// </exception>
+		internal static Stack<LambdaExpressionPart> Split(this LambdaExpression expression)
+		{
+			Debug.Assert(expression != null);
+
+			var parts = new Stack<LambdaExpressionPart>();
+
+			Expression remainder = expression.Body;
+			while (CanSplit(remainder))
+			{
+				Split(remainder, out remainder, out var part);
+				parts.Push(part);
+			}
+
+			if (parts.Count > 0 && remainder is ParameterExpression)
+			{
+				return parts;
+			}
+			else
+			{
+				throw new ArgumentException(
+					string.Format(
+						CultureInfo.CurrentCulture,
+						Resources.UnsupportedExpression,
+						remainder.ToStringFixed()));
+			}
+
+			bool CanSplit(Expression e)
+			{
+				switch (e.NodeType)
+				{
+					case ExpressionType.Assign:
+					{
+						var assignmentExpression = (BinaryExpression)e;
+						return CanSplit(assignmentExpression.Left);
+					}
+
+					case ExpressionType.Call:
+					case ExpressionType.Index:
+					{
+						return true;
+					}
+
+					case ExpressionType.Invoke:
+					{
+						var invocationExpression = (InvocationExpression)e;
+						return typeof(Delegate).IsAssignableFrom(invocationExpression.Expression.Type);
+					}
+
+					case ExpressionType.MemberAccess:
+					{
+						var memberAccessExpression = (MemberExpression)e;
+						return memberAccessExpression.Member is PropertyInfo;
+					}
+
+					case ExpressionType.Parameter:
+					default:
+					{
+						return false;
+					}
+				}
+			}
+
+			void Split(Expression e, out Expression r /* remainder */, out LambdaExpressionPart p /* part */)
+			{
+				const string ParameterName = "...";
+
+				switch (e.NodeType)
+				{
+					case ExpressionType.Assign:  // assignment to a property or indexer
+					{
+						var assignmentExpression = (BinaryExpression)e;
+						Split(assignmentExpression.Left, out r, out var lhs);
+						PropertyInfo property;
+						if (lhs.Expression.Body is MemberExpression me)
+						{
+							Debug.Assert(me.Member is PropertyInfo);
+							property = (PropertyInfo)me.Member;
+						}
+						else
+						{
+							Debug.Assert(lhs.Expression.Body is IndexExpression);
+							property = ((IndexExpression)lhs.Expression.Body).Indexer;
+						}
+						var parameter = Expression.Parameter(r.Type, r is ParameterExpression ope ? ope.Name : ParameterName);
+						var arguments = new Expression[lhs.Arguments.Count + 1];
+						for (var ai = 0; ai < arguments.Length - 1; ++ai)
+						{
+							arguments[ai] = lhs.Arguments[ai];
+						}
+						arguments[arguments.Length - 1] = assignmentExpression.Right;
+						p = new LambdaExpressionPart(
+							expression: Expression.Lambda(
+								Expression.Assign(lhs.Expression.Body, assignmentExpression.Right),
+								parameter),
+							method: property.GetSetMethod(true),
+							arguments);
+						return;
+					}
+
+					case ExpressionType.Call:  // regular method call
+					{
+						var methodCallExpression = (MethodCallExpression)e;
+						if (!methodCallExpression.Method.IsStatic)
+						{
+							r = methodCallExpression.Object;
+							var parameter = Expression.Parameter(r.Type, r is ParameterExpression ope ? ope.Name : ParameterName);
+							var method = methodCallExpression.Method;
+							var arguments = methodCallExpression.Arguments;
+							p = new LambdaExpressionPart(
+										expression: Expression.Lambda(
+											Expression.Call(parameter, method, arguments),
+											parameter),
+										method,
+										arguments);
+						}
+						else
+						{
+							Debug.Assert(methodCallExpression.Method.IsExtensionMethod());
+							Debug.Assert(methodCallExpression.Arguments.Count > 0);
+							r = methodCallExpression.Arguments[0];
+							var parameter = Expression.Parameter(r.Type, r is ParameterExpression ope ? ope.Name : ParameterName);
+							var method = methodCallExpression.Method;
+							var arguments = methodCallExpression.Arguments.ToArray();
+							arguments[0] = parameter;
+							p = new LambdaExpressionPart(
+										expression: Expression.Lambda(
+											Expression.Call(method, arguments),
+											parameter),
+										method,
+										arguments);
+						}
+						return;
+					}
+
+					case ExpressionType.Index:  // indexer query
+					{
+						var indexExpression = (IndexExpression)e;
+						r = indexExpression.Object;
+						var parameter = Expression.Parameter(r.Type, r is ParameterExpression ope ? ope.Name : ParameterName);
+						var indexer = indexExpression.Indexer;
+						var arguments = indexExpression.Arguments;
+						p = new LambdaExpressionPart(
+									expression: Expression.Lambda(
+										Expression.MakeIndex(parameter, indexer, arguments),
+										parameter),
+									method: indexer.GetGetMethod(true),
+									arguments);
+						return;
+					}
+
+					case ExpressionType.Invoke:  // delegate invocation
+					{
+						var invocationExpression = (InvocationExpression)e;
+						Debug.Assert(invocationExpression.Expression.Type.IsDelegate());
+						r = invocationExpression.Expression;
+						var parameter = Expression.Parameter(r.Type, r is ParameterExpression ope ? ope.Name : ParameterName);
+						var arguments = invocationExpression.Arguments;
+						p = new LambdaExpressionPart(
+									expression: Expression.Lambda(
+										Expression.Invoke(parameter, arguments),
+										parameter),
+									method: r.Type.GetMethod("Invoke", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance),
+									arguments);
+						return;
+					}
+
+					case ExpressionType.MemberAccess:  // property query
+					{
+						var memberAccessExpression = (MemberExpression)e;
+						Debug.Assert(memberAccessExpression.Member is PropertyInfo);
+						r = memberAccessExpression.Expression;
+						var parameter = Expression.Parameter(r.Type, r is ParameterExpression ope ? ope.Name : ParameterName);
+						var property = memberAccessExpression.GetReboundProperty();
+						p = new LambdaExpressionPart(
+									expression: Expression.Lambda(
+										Expression.MakeMemberAccess(parameter, property),
+										parameter),
+									method: property.GetGetMethod(true));
+						return;
+					}
+
+					default:
+						Debug.Assert(!CanSplit(e));
+						throw new InvalidOperationException();  // this should be unreachable
+				}
+			}
+		}
+
+		internal static PropertyInfo GetReboundProperty(this MemberExpression expression)
+		{
+			Debug.Assert(expression.Member is PropertyInfo);
+
+			var property = (PropertyInfo)expression.Member;
+
+			// the following block is required because .NET compilers put the wrong PropertyInfo into MemberExpression
+			// for properties originally declared in base classes; they will put the base class' PropertyInfo into
+			// the expression. we attempt to correct this here by checking whether the type of the accessed object
+			// has a property by the same name whose base definition equals the property in the expression; if so,
+			// we "upgrade" to the derived property.
+			if (property.DeclaringType != expression.Expression.Type)
+			{
+				var derivedProperty = expression.Expression.Type.GetProperty(property.Name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+				if (derivedProperty != null && derivedProperty.GetMethod.GetBaseDefinition() == property.GetMethod)
+				{
+					return derivedProperty;
+				}
+			}
+
+			return property;
+		}
+
+		/// <summary>
 		/// Converts the body of the lambda expression into the <see cref="PropertyInfo"/> referenced by it.
 		/// </summary>
 		public static PropertyInfo ToPropertyInfo(this LambdaExpression expression)
 		{
 			if (expression.Body is MemberExpression prop)
 			{
-				if (prop.Member is PropertyInfo info)
-				{
-					// the following block is required because .NET compilers put the wrong PropertyInfo into MemberExpression
-					// for properties originally declared in base classes; they will put the base class' PropertyInfo into
-					// the expression. we attempt to correct this here by checking whether the type of the accessed object
-					// has a property by the same name whose base definition equals the property in the expression; if so,
-					// we "upgrade" to the derived property.
-					if (info.DeclaringType != prop.Expression.Type && info.CanRead)
-					{
-						var propertyInLeft = prop.Expression.Type.GetProperty(info.Name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-						if (propertyInLeft != null && propertyInLeft.GetMethod.GetBaseDefinition() == info.GetMethod)
-						{
-							info = propertyInLeft;
-						}
-					}
-
-					return info;
-				}
+				return prop.GetReboundProperty();
 			}
 
 			throw new ArgumentException(string.Format(

--- a/src/Moq/ExpressionStringBuilder.cs
+++ b/src/Moq/ExpressionStringBuilder.cs
@@ -59,8 +59,11 @@ namespace Moq
 					return;
 				case ExpressionType.Add:
 				case ExpressionType.AddChecked:
+				case ExpressionType.AddAssign:
+				case ExpressionType.Assign:
 				case ExpressionType.Subtract:
 				case ExpressionType.SubtractChecked:
+				case ExpressionType.SubtractAssign:
 				case ExpressionType.Multiply:
 				case ExpressionType.MultiplyChecked:
 				case ExpressionType.Divide:
@@ -498,6 +501,12 @@ namespace Moq
 				case ExpressionType.AddChecked:
 					return "+";
 
+				case ExpressionType.AddAssign:
+					return "+=";
+
+				case ExpressionType.Assign:
+					return "=";
+
 				case ExpressionType.And:
 					return "&";
 
@@ -556,6 +565,9 @@ namespace Moq
 				case ExpressionType.Subtract:
 				case ExpressionType.SubtractChecked:
 					return "-";
+
+				case ExpressionType.SubtractAssign:
+					return "-=";
 			}
 			return nodeType.ToString();
 		}

--- a/src/Moq/LambdaExpressionPart.cs
+++ b/src/Moq/LambdaExpressionPart.cs
@@ -1,0 +1,42 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Moq
+{
+	/// <summary>
+	///   A thin wrapper around a <see cref="LambdaExpression"/> that has been split off
+	///   a larger expression by <see cref="ExpressionExtensions.Split(LambdaExpression)"/>.
+	///   It addition to the partial expression itself, it carries a <see cref="MethodInfo"/>
+	///   and optional arguments associated with it.
+	/// </summary>
+	internal readonly struct LambdaExpressionPart
+	{
+		private static readonly IReadOnlyList<Expression> none = new Expression[0];
+
+		public readonly LambdaExpression Expression;
+		public readonly MethodInfo Method;
+		public readonly IReadOnlyList<Expression> Arguments;
+
+		public LambdaExpressionPart(LambdaExpression expression, MethodInfo method, IReadOnlyList<Expression> arguments = null)
+		{
+			Debug.Assert(expression != null);
+			Debug.Assert(method != null);
+
+			this.Expression = expression;
+			this.Method = method;
+			this.Arguments = arguments ?? none;
+		}
+
+		public void Deconstruct(out LambdaExpression expression, out MethodInfo method, out IReadOnlyList<Expression> arguments)
+		{
+			expression = this.Expression;
+			method = this.Method;
+			arguments = this.Arguments;
+		}
+	}
+}

--- a/src/Moq/Language/Flow/WhenPhrase.cs
+++ b/src/Moq/Language/Flow/WhenPhrase.cs
@@ -20,13 +20,13 @@ namespace Moq.Language.Flow
 
 		public ISetup<T> Setup(Expression<Action<T>> expression)
 		{
-			var setup = Mock.SetupVoid(mock, expression, this.condition);
+			var setup = Mock.Setup(mock, expression, this.condition);
 			return new VoidSetupPhrase<T>(setup);
 		}
 
 		public ISetup<T, TResult> Setup<TResult>(Expression<Func<T, TResult>> expression)
 		{
-			var setup = Mock.SetupNonVoid(mock, expression, this.condition);
+			var setup = Mock.Setup(mock, expression, this.condition);
 			return new NonVoidSetupPhrase<T, TResult>(setup);
 		}
 

--- a/src/Moq/Mock.Generic.cs
+++ b/src/Moq/Mock.Generic.cs
@@ -302,7 +302,7 @@ namespace Moq
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public ISetup<T> Setup(Expression<Action<T>> expression)
 		{
-			var setup = Mock.SetupVoid(this, expression, null);
+			var setup = Mock.Setup(this, expression, null);
 			return new VoidSetupPhrase<T>(setup);
 		}
 
@@ -310,7 +310,7 @@ namespace Moq
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public ISetup<T, TResult> Setup<TResult>(Expression<Func<T, TResult>> expression)
 		{
-			var setup = Mock.SetupNonVoid(this, expression, null);
+			var setup = Mock.Setup(this, expression, null);
 			return new NonVoidSetupPhrase<T, TResult>(setup);
 		}
 

--- a/src/Moq/Mock.Generic.cs
+++ b/src/Moq/Mock.Generic.cs
@@ -400,14 +400,14 @@ namespace Moq
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify(Expression<Action<T>> expression)
 		{
-			Mock.VerifyVoid(this, expression, Times.AtLeastOnce(), null);
+			Mock.Verify(this, expression, Times.AtLeastOnce(), null);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify(Expression<Action<T>> expression, Times times)
 		{
-			Mock.VerifyVoid(this, expression, times, null);
+			Mock.Verify(this, expression, times, null);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times)"]/*'/>
@@ -421,56 +421,56 @@ namespace Moq
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify(Expression<Action<T>> expression, string failMessage)
 		{
-			Mock.VerifyVoid(this, expression, Times.AtLeastOnce(), failMessage);
+			Mock.Verify(this, expression, Times.AtLeastOnce(), failMessage);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times,failMessage)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify(Expression<Action<T>> expression, Times times, string failMessage)
 		{
-			Mock.VerifyVoid(this, expression, times, failMessage);
+			Mock.Verify(this, expression, times, failMessage);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify(expression,times,failMessage)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify(Expression<Action<T>> expression, Func<Times> times, string failMessage)
 		{
-			VerifyVoid(this, expression, times(), failMessage);
+			Mock.Verify(this, expression, times(), failMessage);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify<TResult>(Expression<Func<T, TResult>> expression)
 		{
-			Mock.VerifyNonVoid(this, expression, Times.AtLeastOnce(), null);
+			Mock.Verify(this, expression, Times.AtLeastOnce(), null);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,times)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify<TResult>(Expression<Func<T, TResult>> expression, Times times)
 		{
-			Mock.VerifyNonVoid(this, expression, times, null);
+			Mock.Verify(this, expression, times, null);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,times)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify<TResult>(Expression<Func<T, TResult>> expression, Func<Times> times)
 		{
-			VerifyNonVoid(this, expression, times(), null);
+			Mock.Verify(this, expression, times(), null);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,failMessage)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify<TResult>(Expression<Func<T, TResult>> expression, string failMessage)
 		{
-			Mock.VerifyNonVoid(this, expression, Times.AtLeastOnce(), failMessage);
+			Mock.Verify(this, expression, Times.AtLeastOnce(), failMessage);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Verify{TResult}(expression,times,failMessage)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public void Verify<TResult>(Expression<Func<T, TResult>> expression, Times times, string failMessage)
 		{
-			Mock.VerifyNonVoid(this, expression, times, failMessage);
+			Mock.Verify(this, expression, times, failMessage);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyGet(expression)"]/*'/>

--- a/src/Moq/PexProtector.cs
+++ b/src/Moq/PexProtector.cs
@@ -21,12 +21,6 @@ namespace Moq
 		}
 
 		[DebuggerHidden]
-		public static void Invoke<T1>(Action<T1> action, T1 arg1)
-		{
-			action(arg1);
-		}
-
-		[DebuggerHidden]
 		public static void Invoke<T1, T2>(Action<T1, T2> action, T1 arg1, T2 arg2)
 		{
 			action(arg1, arg2);
@@ -36,6 +30,12 @@ namespace Moq
 		public static TResult Invoke<T1, T2, T3, TResult>(Func<T1, T2, T3, TResult> function, T1 arg1, T2 arg2, T3 arg3)
 		{
 			return function(arg1, arg2, arg3);
+		}
+
+		[DebuggerHidden]
+		public static TResult Invoke<T1, T2, T3, T4, TResult>(Func<T1, T2, T3, T4, TResult> function, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+		{
+			return function(arg1, arg2, arg3, arg4);
 		}
 	}
 }

--- a/src/Moq/Protected/ProtectedAsMock.cs
+++ b/src/Moq/Protected/ProtectedAsMock.cs
@@ -149,7 +149,7 @@ namespace Moq.Protected
 				throw new ArgumentException(ex.Message, nameof(expression));
 			}
 
-			Mock.VerifyVoid(this.mock, rewrittenExpression, times ?? Times.AtLeastOnce(), failMessage);
+			Mock.Verify(this.mock, rewrittenExpression, times ?? Times.AtLeastOnce(), failMessage);
 		}
 
 		public void Verify<TResult>(Expression<Func<TAnalog, TResult>> expression, Times? times = null, string failMessage = null)
@@ -166,7 +166,7 @@ namespace Moq.Protected
 				throw new ArgumentException(ex.Message, nameof(expression));
 			}
 
-			Mock.VerifyNonVoid(this.mock, rewrittenExpression, times ?? Times.AtLeastOnce(), failMessage);
+			Mock.Verify(this.mock, rewrittenExpression, times ?? Times.AtLeastOnce(), failMessage);
 		}
 
 		public void VerifyGet<TProperty>(Expression<Func<TAnalog, TProperty>> expression, Times? times = null, string failMessage = null)

--- a/src/Moq/Protected/ProtectedAsMock.cs
+++ b/src/Moq/Protected/ProtectedAsMock.cs
@@ -42,7 +42,7 @@ namespace Moq.Protected
 				throw new ArgumentException(ex.Message, nameof(expression));
 			}
 
-			var setup = Mock.SetupVoid(this.mock, rewrittenExpression, null);
+			var setup = Mock.Setup(this.mock, rewrittenExpression, null);
 			return new VoidSetupPhrase<T>(setup);
 		}
 
@@ -60,7 +60,7 @@ namespace Moq.Protected
 				throw new ArgumentException(ex.Message, nameof(expression));
 			}
 
-			var setup = Mock.SetupNonVoid(this.mock, rewrittenExpression, null);
+			var setup = Mock.Setup(this.mock, rewrittenExpression, null);
 			return new NonVoidSetupPhrase<T, TResult>(setup);
 		}
 

--- a/src/Moq/Protected/ProtectedMock.cs
+++ b/src/Moq/Protected/ProtectedMock.cs
@@ -47,7 +47,7 @@ namespace Moq.Protected
 			ThrowIfMemberMissing(methodName, method);
 			ThrowIfPublicMethod(method, typeof(T).Name);
 
-			var setup = Mock.SetupVoid(mock, GetMethodCall(method, args), null);
+			var setup = Mock.Setup(mock, GetMethodCall(method, args), null);
 			return new VoidSetupPhrase<T>(setup);
 		}
 
@@ -76,7 +76,7 @@ namespace Moq.Protected
 			ThrowIfVoidMethod(method);
 			ThrowIfPublicMethod(method, typeof(T).Name);
 
-			var setup = Mock.SetupNonVoid(mock, GetMethodCall<TResult>(method, args), null);
+			var setup = Mock.Setup(mock, GetMethodCall<TResult>(method, args), null);
 			return new NonVoidSetupPhrase<T, TResult>(setup);
 		}
 

--- a/src/Moq/Protected/ProtectedMock.cs
+++ b/src/Moq/Protected/ProtectedMock.cs
@@ -167,7 +167,7 @@ namespace Moq.Protected
 			ThrowIfMemberMissing(methodName, method);
 			ThrowIfPublicMethod(method, typeof(T).Name);
 
-			Mock.VerifyVoid(mock, GetMethodCall(method, args), times, null);
+			Mock.Verify(mock, GetMethodCall(method, args), times, null);
 		}
 
 		public void Verify<TResult>(string methodName, Times times, object[] args)
@@ -192,7 +192,7 @@ namespace Moq.Protected
 			ThrowIfMemberMissing(methodName, method);
 			ThrowIfPublicMethod(method, typeof(T).Name);
 
-			Mock.VerifyNonVoid(mock, GetMethodCall<TResult>(method, args), times, null);
+			Mock.Verify(mock, GetMethodCall<TResult>(method, args), times, null);
 		}
 
 		// TODO should receive args to support indexers

--- a/tests/Moq.Tests/ExpressionSplitFixture.cs
+++ b/tests/Moq.Tests/ExpressionSplitFixture.cs
@@ -1,0 +1,358 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+
+using Xunit;
+
+namespace Moq.Tests
+{
+	public class ExpressionSplitFixture
+	{
+		[Fact]
+		public void Split_parameter_fails()
+		{
+			// a => a
+			var expression = E((IA a) => a);
+
+			AssertSplitFails(expression);
+		}
+
+		[Fact]
+		public void Split_parameter_assignment_fails()
+		{
+			// a => a = ...
+			var expression = A((IA a) => a, D<IA>());
+
+			AssertSplitFails(expression);
+		}
+
+		[Fact]
+		public void Split_delegate_invocation()
+		{
+			// a => a()
+			var expression = E((ADelegate a) => a());
+
+			AssertSplitYields(expression,
+				E((ADelegate a) => a()));
+		}
+
+		[Fact]
+		public void Split_one_property_get_access()
+		{
+			// a => a.B
+			var expression = E((IA a) => a.B);
+
+			AssertSplitYields(expression,
+				E((IA a) => a.B));
+		}
+
+		[Fact]
+		public void Split_one_property_set_access()
+		{
+			// a => a.B = ...
+			var expression = A((IA a) => a.B, D<IB>());
+
+			AssertSplitYields(expression,
+				A((IA a) => a.B, D<IB>()));
+		}
+
+		[Fact]
+		public void Split_two_property_get_accesses()
+		{
+			// a => a.B.C
+			var expression = E((IA a) => a.B.C);
+
+			AssertSplitYields(expression,
+				E((IA a) => a.B),
+				E((IB b) => b.C));
+		}
+
+		[Fact]
+		public void Split_one_method_call()
+		{
+			// a => a.GetB()
+			var expression = E((IA a) => a.GetB());
+
+			AssertSplitYields(expression,
+				E((IA a) => a.GetB()));
+		}
+
+		[Fact]
+		public void Split_one_method_call_with_arg()
+		{
+			// a => a.GetB(...)
+			var expression = E((IA a) => a.GetB(1));
+
+			AssertSplitYields(expression,
+				E((IA a) => a.GetB(1)));
+		}
+
+		[Fact]
+		public void Split_two_method_calls()
+		{
+			// a => a.GetB().GetC()
+			var expression = E((IA a) => a.GetB().GetC());
+
+			AssertSplitYields(expression,
+				E((IA a) => a.GetB()),
+				E((IB b) => b.GetC()));
+		}
+
+		[Fact]
+		public void Split_two_method_calls_with_args()
+		{
+			// a => a.GetB(...).GetC(...)
+			var expression = E((IA a) => a.GetB(1).GetC(false, true));
+
+			AssertSplitYields(expression,
+				E((IA a) => a.GetB(1)),
+				E((IB b) => b.GetC(false, true)));
+		}
+
+		[Fact]
+		public void Split_one_property_get_access_and_one_method_calls()
+		{
+			// a => a.B.GetC()
+			var expression = E((IA a) => a.B.GetC());
+
+			AssertSplitYields(expression,
+				E((IA a) => a.B),
+				E((IB b) => b.GetC()));
+		}
+
+		[Fact]
+		public void Split_one_method_call_and_one_property_get_access()
+		{
+			// a => GetB().C
+			var expression = E((IA a) => a.GetB().C);
+
+			AssertSplitYields(expression,
+				E((IA a) => a.GetB()),
+				E((IB b) => b.C));
+		}
+
+		[Fact]
+		public void Split_one_method_call_and_one_property_set_access()
+		{
+			// a => a.GetB().C = ...
+			var expression = A((IA a) => a.GetB().C, D<IC>());
+
+			AssertSplitYields(expression,
+				E((IA a) => a.GetB()),
+				A((IB b) => b.C, D<IC>()));
+		}
+
+		[Fact]
+		public void Split_one_delegate_invocation_and_one_property_get_access()
+		{
+			// a => a().C
+			var expression = E((ADelegate a) => a().C);
+
+			AssertSplitYields(expression,
+				E((ADelegate a) => a()),
+				E((IB b) => b.C));
+		}
+
+		[Fact]
+		public void Split_one_property_getter_and_one_delegate_invocation_and_one_property_get_access()
+		{
+			// a => a.DelegateB().C
+			var expression = E((IA a) => a.DelegateB().C);
+
+			AssertSplitYields(expression,
+				E((IA a) => a.DelegateB),
+				E((ADelegate a) => a()),
+				E((IB b) => b.C));
+		}
+
+		[Fact]
+		public void Split_one_indexer_get_access()
+		{
+			// a => a[...]
+			var expression = E((IA a) => a[1]);
+
+			AssertSplitYields(expression,
+				E((IA a) => a[1]));
+		}
+
+		[Fact]
+		public void Split_two_indexer_get_accesses()
+		{
+			// a => a[...][...]
+			var expression = E((IA a) => a[1][false, true]);
+
+			AssertSplitYields(expression,
+				E((IA a) => a[1]),
+				E((IB b) => b[false, true]));
+		}
+
+		[Fact]
+		public void Split_one_property_get_access_and_one_indexer_access()
+		{
+			// a => a.B[...]
+			var expression = E((IA a) => a.B[true, false]);
+
+			AssertSplitYields(expression,
+				E((IA a) => a.B),
+				E((IB b) => b[true, false]));
+		}
+
+		[Fact]
+		public void Split_one_indexer_get_access_and_one_property_get_access()
+		{
+			// a => a[...].C
+			var expression = E((IA a) => a[1].C);
+
+			AssertSplitYields(expression,
+				E((IA a) => a[1]),
+				E((IB b) => b.C));
+		}
+
+		[Fact]
+		public void Split_one_method_call_and_one_indexer_get_access()
+		{
+			// a => a.GetB()[...]
+			var expression = E((IA a) => a.GetB()[false, false]);
+
+			AssertSplitYields(expression,
+				E((IA a) => a.GetB()),
+				E((IB b) => b[false, false]));
+		}
+
+		[Fact]
+		public void Split_one_indexer_get_access_and_one_method_call()
+		{
+			// a => a[...].GetC()
+			var expression = E((IA a) => a[1].GetC());
+
+			AssertSplitYields(expression,
+				E((IA a) => a[1]),
+				E((IB b) => b.GetC()));
+		}
+
+		[Fact]
+		public void Split_one_indexer_set_access()
+		{
+			// a => a[...] = ...
+			var expression = A((IA a) => a[1], D<IB>());
+
+			AssertSplitYields(expression,
+				A((IA a) => a[1], D<IB>()));
+		}
+
+		[Fact]
+		public void Split_one_property_get_access_and_one_indexer_set_access()
+		{
+			// a => a.B[...] = ...
+			var expression = A((IA a) => a.B[true, true], D<IC>());
+
+			AssertSplitYields(expression,
+				E((IA a) => a.B),
+				A((IB b) => b[true, true], D<IC>()));
+		}
+
+		[Fact]
+		public void Split_one_indexer_get_access_and_one_property_set_access()
+		{
+			// a => a[...].C = ...
+			var expression = A((IA a) => a[1].C, D<IC>());
+
+			AssertSplitYields(expression,
+				E((IA a) => a[1]),
+				A((IB b) => b.C, D<IC>()));
+		}
+
+		private void AssertSplitFails(LambdaExpression expression, params LambdaExpression[] expected)
+		{
+			Assert.Throws<ArgumentException>(() => expression.Split());
+		}
+
+		private void AssertSplitYields(LambdaExpression expression, params LambdaExpression[] expected)
+		{
+			Assert.Equal(expected, expression.Split().Select(e => e.Expression), ExpressionComparer.Default);
+		}
+
+		/// <summary>
+		///   Helper method producing an assignment <see cref="BinaryExpression"/>.
+		///   Useful because C# does not allow assignments in literal expressions.
+		/// </summary>
+		private static LambdaExpression A<T, TResult>(Expression<Func<T, TResult>> left, Expression right)
+		{
+			return Expression.Lambda(
+				Expression.Assign(
+					IndexerReplacer.Instance.Visit(left.Body),
+					IndexerReplacer.Instance.Visit(right)),
+				left.Parameters);
+		}
+
+		/// <summary>
+		///   Helper method producing a <see cref="ConstantExpression"/> for the default value of <typeparamref name="T"/>.
+		/// </summary>
+		private static ConstantExpression D<T>()
+		{
+			return Expression.Constant(default(T), typeof(T));
+		}
+
+		/// <summary>
+		///   Helper method producing a <see cref="LambdaExpression"/>.
+		/// </summary>
+		private static LambdaExpression E<T, TResult>(Expression<Func<T, TResult>> expression)
+		{
+			return (LambdaExpression)IndexerReplacer.Instance.Visit(expression);
+		}
+
+		/// <summary>
+		/// Expression visitor that compensates the Roslyn C# compiler's encoding
+		/// indexer accesses as plain method calls. The visitor "lifts" such method
+		/// calls into indexer access representations so we can use them in our unit
+		/// tests without having to construct expression trees manually.
+		/// </summary>
+		private sealed class IndexerReplacer : ExpressionVisitor
+		{
+			public static readonly IndexerReplacer Instance = new IndexerReplacer();
+
+			protected override Expression VisitMethodCall(MethodCallExpression node)
+			{
+				if (node.Method.IsSpecialName && node.Method.Name == "get_Item")
+				{
+					var indexer = node.Method.DeclaringType.GetProperty("Item");
+					return Expression.MakeIndex(
+						this.Visit(node.Object),
+						indexer,
+						node.Arguments.Select(a => this.Visit(a)));
+				}
+				else
+				{
+					return Expression.Call(
+						this.Visit(node.Object),
+						node.Method,
+						node.Arguments.Select(a => this.Visit(a)));
+				}
+			}
+		}
+
+		public interface IA
+		{
+			IB B { get; set; }
+			IB GetB();
+			IB GetB(int arg);
+			IB this[int index] { get; set; }
+			ADelegate DelegateB { get; }
+		}
+
+		public interface IB
+		{
+			IC C { get; set; }
+			IC GetC();
+			IC GetC(bool arg1, bool arg2);
+			IC this[bool arg1, bool arg2] { get; set; }
+		}
+
+		public interface IC
+		{
+
+		}
+
+		public delegate IB ADelegate();
+	}
+}

--- a/tests/Moq.Tests/RecursiveMocksFixture.cs
+++ b/tests/Moq.Tests/RecursiveMocksFixture.cs
@@ -263,7 +263,7 @@ namespace Moq.Tests
 		{
 			var mock = new Mock<Foo>();
 
-			Assert.Throws<NotSupportedException>(() => mock.Setup(m => m.BarField.Do("ping")));
+			Assert.Throws<ArgumentException>(() => mock.Setup(m => m.BarField.Do("ping")));
 		}
 
 		[Fact]
@@ -271,7 +271,7 @@ namespace Moq.Tests
 		{
 			var mock = new Mock<IFoo>();
 
-			Assert.Throws<NotSupportedException>(() => mock.Setup(m => m.Bar.Value.ToString()));
+			Assert.Throws<ArgumentException>(() => mock.Setup(m => m.Bar.Value.ToString()));
 		}
 
 		[Fact]

--- a/tests/Moq.Tests/RecursiveMocksFixture.cs
+++ b/tests/Moq.Tests/RecursiveMocksFixture.cs
@@ -139,7 +139,7 @@ namespace Moq.Tests
 		[Fact]
 		public void VerifiesHierarchyMethodWithExpression()
 		{
-			var mock = new Mock<IFoo>();
+			var mock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock };
 
 			Assert.Throws<MockException>(() => mock.Verify(m => m.Bar.Do("ping")));
 
@@ -150,7 +150,7 @@ namespace Moq.Tests
 		[Fact]
 		public void VerifiesHierarchyPropertyGetWithExpression()
 		{
-			var mock = new Mock<IFoo>();
+			var mock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock };
 
 			Assert.Throws<MockException>(() => mock.VerifyGet(m => m.Bar.Value));
 


### PR DESCRIPTION
When `Setup` and `Verify` are given "recursive" / "fluent" expressions, e.g.

```csharp
mock.Setup(m => m.Foo.Bar.Baz.DoSomething())...;
```

... then up until now, Moq simply compiled that expression & executed it with `DefaultValue.Mock` temporarily enabled to set up the mock object graph leading up to `baz.DoSomething`. As elsewhere, expression compilation and execution has a variety of side effects (e.g. #699), so it would be good to avoid it.

We can actually do something fairly simple: We break apart the given expression into several setup expressions:

* `m => m.Foo`
* `(foo) => (foo).Bar`
* `(bar) => (bar).Baz`
* `(baz) => (baz).DoSomething()`

... then set these sub-expressions recursively: The original `mock` sets up the first expression to yield an inner mock of type `IBar`, who will set up the next expression to return an inner mock of type `IBaz`, and so on.

Recursive verification by `Verify` works similarly, except that it never sets up inner mocks that aren't already there. Instead, it has one additional rule: The absence of an inner mock is treated as a verification error if the expected call count on an inner mock's method is anything other than `Times.Never`.

We can only do this change for `Setup` and `Verify` methods that are already expression-based; i.e. this excludes `SetupSet` and `VerifySet`. We'll deal with those in a later PR.

Fixes #699.