### PR TITLE
Fix `IProxy` interface visibility

### DIFF
--- a/src/Moq/ProxyFactories/IProxy.cs
+++ b/src/Moq/ProxyFactories/IProxy.cs
@@ -1,15 +1,17 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
-namespace Moq
+using System.ComponentModel;
+
+namespace Moq.Internals
 {
-	/// <summary>
-	///   All proxies created by a <see cref="ProxyFactory"/> should implement this interface.
-	/// </summary>
-	// Interface proxies require this to be able to forward invocations of `object` members
-	// to their `IInterceptor`.
-	internal interface IProxy
+	/// <summary>Do not use. (Moq requires this interface so that <see langword="object"/> methods can be set up on interface mocks.)</summary>
+	// NOTE: This type is actually specific to our DynamicProxy implementation of `ProxyFactory`.
+	// It is directly related to `InterfaceProxy`, see the comment there.
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public interface IProxy
 	{
-		IInterceptor Interceptor { get; }
+		/// <summary/>
+		object Interceptor { get; }
 	}
 }

--- a/src/Moq/ProxyFactories/InterfaceProxy.cs
+++ b/src/Moq/ProxyFactories/InterfaceProxy.cs
@@ -26,7 +26,7 @@ namespace Moq.Internals
 		{
 			// Forward this call to the interceptor, so that `object.Equals` can be set up.
 			var invocation = new Invocation(equalsMethod, obj);
-			((IProxy)this).Interceptor.Intercept(invocation);
+			((IInterceptor)((IProxy)this).Interceptor).Intercept(invocation);
 			return (bool)invocation.ReturnValue;
 		}
 
@@ -36,7 +36,7 @@ namespace Moq.Internals
 		{
 			// Forward this call to the interceptor, so that `object.GetHashCode` can be set up.
 			var invocation = new Invocation(getHashCodeMethod);
-			((IProxy)this).Interceptor.Intercept(invocation);
+			((IInterceptor)((IProxy)this).Interceptor).Intercept(invocation);
 			return (int)invocation.ReturnValue;
 		}
 
@@ -46,7 +46,7 @@ namespace Moq.Internals
 		{
 			// Forward this call to the interceptor, so that `object.ToString` can be set up.
 			var invocation = new Invocation(toStringMethod);
-			((IProxy)this).Interceptor.Intercept(invocation);
+			((IInterceptor)((IProxy)this).Interceptor).Intercept(invocation);
 			return (string)invocation.ReturnValue;
 		}
 


### PR DESCRIPTION
Otherwise DynamicProxy will not be able to implement it for the same reason it couldn't use `InterfaceProxy` as a proxy base class; so basically , the same explanation from 75d9d8ba applies.