### PR TITLE
Make handling of `MatchExpression` more robust

### DIFF
--- a/src/Moq/Evaluator.cs
+++ b/src/Moq/Evaluator.cs
@@ -33,7 +33,7 @@ namespace Moq
 		/// <returns>A new tree with sub-trees evaluated and replaced.</returns>
 		public static Expression PartialEval(Expression expression)
 		{
-			return PartialEval(expression, e => e.NodeType != ExpressionType.Parameter);
+			return PartialEval(expression, e => e.NodeType != ExpressionType.Parameter && !(e is MatchExpression));
 		}
 
 		/// <summary>

--- a/src/Moq/ExpressionExtensions.cs
+++ b/src/Moq/ExpressionExtensions.cs
@@ -334,6 +334,9 @@ namespace Moq
 				case ExpressionType.Parameter:
 					return false;
 
+				case ExpressionType.Extension:
+					return !(expression is MatchExpression);
+
 				case ExpressionType.Call:
 					return !((MethodCallExpression)expression).Method.IsDefined(typeof(MatcherAttribute), true);
 

--- a/src/Moq/ExpressionStringBuilder.cs
+++ b/src/Moq/ExpressionStringBuilder.cs
@@ -122,6 +122,13 @@ namespace Moq
 				case ExpressionType.ListInit:
 					ToStringListInit((ListInitExpression)exp);
 					return;
+				case ExpressionType.Extension:
+					if (exp is MatchExpression me)
+					{
+						ToStringMatch(me);
+						return;
+					}
+					goto default;
 				default:
 					throw new Exception(string.Format(Resources.UnhandledExpressionType, exp.NodeType));
 			}
@@ -468,6 +475,12 @@ namespace Moq
 					builder.Append(']');
 					return;
 			}
+		}
+
+		private void ToStringMatch(MatchExpression node)
+		{
+			ToString(node.Match.RenderExpression);
+			return;
 		}
 
 		private void AsCommaSeparatedValues<T>(IEnumerable<T> source, Action<T> toStringAction) where T : Expression

--- a/src/Moq/It.cs
+++ b/src/Moq/It.cs
@@ -12,6 +12,8 @@ using System.Reflection;
 using static System.Runtime.InteropServices.Marshal;
 #endif
 
+using Moq.Protected;
+
 namespace Moq
 {
 	/// <include file='It.xdoc' path='docs/doc[@for="It"]/*'/>
@@ -65,7 +67,7 @@ namespace Moq
 		{
 			return Match<TValue>.Create(
 				value => match.CompileUsingExpressionCompiler().Invoke(value),
-				() => It.Is<TValue>(match));
+				Expression.Lambda<Func<TValue>>(ItExpr.Is<TValue>(match)));
 		}
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsInRange"]/*'/>

--- a/src/Moq/MatchExpression.cs
+++ b/src/Moq/MatchExpression.cs
@@ -6,23 +6,26 @@ using System.Linq.Expressions;
 
 namespace Moq
 {
-	internal class MatchExpression : Expression
+	internal sealed class MatchExpression : Expression
 	{
+		public readonly Match Match;
+
 		public MatchExpression(Match match)
 		{
 			this.Match = match;
 		}
 
-		public override ExpressionType NodeType
-		{
-			get { return ExpressionType.Call; }
-		}
+		public override ExpressionType NodeType => ExpressionType.Extension;
 
-		public override Type Type
-		{
-			get { return typeof(Match); }
-		}
+		public override Type Type => this.Match.RenderExpression.Type;
 
-		public Match Match { get; private set; }
+		// This node type is irreducible in order to prevent compilation.
+		// The best possible reduction would involve `RenderExpression`,
+		// which isn't intended to be used for that purpose.
+		public override bool CanReduce => false;
+
+		protected override Expression VisitChildren(ExpressionVisitor visitor) => this;
+
+		public override string ToString() => this.Match.RenderExpression.ToString();
 	}
 }

--- a/tests/Moq.Tests/MatchExpressionFixture.cs
+++ b/tests/Moq.Tests/MatchExpressionFixture.cs
@@ -55,6 +55,28 @@ namespace Moq.Tests
 			Assert.Same(matchExpression, FindMatchExpression(evaluatedExpression));
 		}
 
+		[Fact]
+		public void Is_correctly_handled_by_MatcherFactory()
+		{
+			var expression = GetExpression();
+			var matchExpression = FindMatchExpression(expression);
+			Debug.Assert(matchExpression != null);
+			var matcher = MatcherFactory.CreateMatcher(matchExpression);
+			Assert.IsType<Match<int>>(matcher);
+		}
+
+		[Fact]
+		public void Is_handled_correctly_in_setup_and_verification()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(GetExpression()).Verifiable();
+			Assert.Throws<MockException>(() => mock.Verify());
+			mock.Object.M(1);
+			Assert.Throws<MockException>(() => mock.Verify());
+			mock.Object.M(5);
+			mock.Verify();
+		}
+
 		private Expression<Action<IX>> GetExpression()
 		{
 			var x = Expression.Parameter(typeof(IX), "x");

--- a/tests/Moq.Tests/MatchExpressionFixture.cs
+++ b/tests/Moq.Tests/MatchExpressionFixture.cs
@@ -1,0 +1,46 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.Linq.Expressions;
+
+using Xunit;
+
+namespace Moq.Tests
+{
+	public class MatchExpressionFixture
+	{
+		[Fact]
+		public void Prevents_compilation()
+		{
+			var ex = Assert.Throws<ArgumentException>(() =>
+				GetExpression().CompileUsingExpressionCompiler());
+			Assert.Contains("reducible", ex.Message);
+		}
+
+		[Fact]
+		public void Can_be_rendered_using_ToString()
+		{
+			Assert.Equal(
+				"x => x.M(Is(arg => (arg == 5)))",
+				GetExpression().ToString());
+		}
+
+		private Expression<Action<IX>> GetExpression()
+		{
+			var x = Expression.Parameter(typeof(IX), "x");
+			return Expression.Lambda<Action<IX>>(
+				Expression.Call(
+					x,
+					typeof(IX).GetMethod(nameof(IX.M)),
+					new MatchExpression(
+						new Match<int>(arg => arg == 5, () => It.Is<int>(arg => arg == 5)))),
+				x);
+		}
+
+		public interface IX
+		{
+			void M(int arg);
+		}
+	}
+}

--- a/tests/Moq.Tests/MatchExpressionFixture.cs
+++ b/tests/Moq.Tests/MatchExpressionFixture.cs
@@ -26,6 +26,14 @@ namespace Moq.Tests
 				GetExpression().ToString());
 		}
 
+		[Fact]
+		public void Can_be_rendered_using_ToStringFixed()
+		{
+			Assert.Equal(
+				"x => x.M(It.Is<int>(arg => arg == 5))",
+				GetExpression().ToStringFixed());
+		}
+
 		private Expression<Action<IX>> GetExpression()
 		{
 			var x = Expression.Parameter(typeof(IX), "x");

--- a/tests/Moq.Tests/MatchFixture.cs
+++ b/tests/Moq.Tests/MatchFixture.cs
@@ -1,0 +1,265 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using Moq.Protected;
+using System;
+using System.Linq.Expressions;
+
+using Xunit;
+
+namespace Moq.Tests
+{
+	public class MatchFixture
+	{
+		public class RenderExpression
+		{
+			[Fact]
+			public void RenderExpression_of_It_Is_includes_formatted_predicate_expression()
+			{
+				var match = GetMatch(() => It.Is<int>(i => i == 123));
+				Assert.Equal("It.Is<int>(i => i == 123)", match.RenderExpression.ToStringFixed());
+			}
+
+			[Fact]
+			public void Two_custom_matchers_with_render_expression_have_equal_render_expression()
+			{
+				var first  = GetMatch(() => Order.IsSmallRE());
+				var second = GetMatch(() => Order.IsSmallRE());
+				Assert.Equal(first.RenderExpression, second.RenderExpression, ExpressionComparer.Default);
+			}
+
+			[Fact]
+			public void Two_parameterized_custom_matchers_with_render_expression_have_equal_render_expressions()
+			{
+				var first  = GetMatch(() => Order.IsSmallerThanRE(123M));
+				var second = GetMatch(() => Order.IsSmallerThanRE(123M));
+				Assert.Equal(first.RenderExpression, second.RenderExpression, ExpressionComparer.Default);
+			}
+		}
+
+		public class Equality
+		{
+			[Fact]
+			public void It_IsAny_with_equal_generic_arguments()
+			{
+				var first  = GetMatch(() => It.IsAny<int>());
+				var second = GetMatch(() => It.IsAny<int>());
+				Assert.Equal(first, second);
+			}
+
+			[Fact]
+			public void It_Is_with_equal_arguments_1()
+			{
+				var first  = GetMatch(() => It.Is<int>(i => i == 123));
+				var second = GetMatch(() => It.Is<int>(i => i == 123));
+				Assert.Equal(first, second);
+			}
+
+			[Fact]
+			public void It_Is_with_equal_arguments_2()
+			{
+				Expression<Func<int, bool>> comparison = i => i == 123;
+				var first  = GetMatch(() => It.Is<int>(comparison));
+				var second = GetMatch(() => It.Is<int>(comparison));
+				Assert.Equal(first, second);
+			}
+
+			[Fact]
+			public void It_IsRegex_with_equal_arguments()
+			{
+				var first  = GetMatch(() => It.IsRegex("^.*$"));
+				var second = GetMatch(() => It.IsRegex("^.*$"));
+				Assert.Equal(first, second);
+			}
+
+			[Fact]
+			public void Custom_matchers_with_render_expression()
+			{
+				var first  = GetMatch(() => Order.IsSmallRE());
+				var second = GetMatch(() => Order.IsSmallRE());
+				Assert.Equal(first, second);
+			}
+
+			[Fact]
+			public void Custom_matcher_without_render_expressions()
+			{
+				var first  = GetMatch(() => Order.IsSmall());
+				var second = GetMatch(() => Order.IsSmall());
+				Assert.Equal(first, second);
+			}
+
+			[Fact]
+			public void Parameterized_custom_matchers_with_render_expression_and_equal_arguments()
+			{
+				var first  = GetMatch(() => Order.IsSmallerThanRE(123M));
+				var second = GetMatch(() => Order.IsSmallerThanRE(123M));
+				Assert.Equal(first, second);
+			}
+		}
+
+		public class Inequality
+		{
+			[Fact]
+			public void Different_custom_matchers_without_render_expressions()
+			{
+				var first  = GetMatch(() => Order.IsSmall());
+				var second = GetMatch(() => Order.IsLarge());
+				Assert.NotEqual(first, second);
+			}
+
+			[Fact]
+			public void Different_custom_matchers_with_render_expressions()
+			{
+				var first  = GetMatch(() => Order.IsSmallRE());
+				var second = GetMatch(() => Order.IsLargeRE());
+				Assert.NotEqual(first, second);
+			}
+
+			[Fact]
+			public void Different_parameterized_custom_matchers_without_render_expressions_but_equal_arguments()
+			{
+				var first  = GetMatch(() => Order.IsSmallerThan(123M));
+				var second = GetMatch(() => Order.IsLargerThan(123M));
+				Assert.NotEqual(first, second);
+			}
+
+			[Fact]
+			public void Different_parameterized_custom_matchers_with_render_expressions_and_equal_arguments()
+			{
+				var first  = GetMatch(() => Order.IsSmallerThanRE(123M));
+				var second = GetMatch(() => Order.IsLargerThanRE(123M));
+				Assert.NotEqual(first, second);
+			}
+
+			[Fact]
+			public void Different_parameterized_custom_matchers_without_render_expressions_and_different_arguments()
+			{
+				var first  = GetMatch(() => Order.IsSmallerThan(123M));
+				var second = GetMatch(() => Order.IsLargerThan(456M));
+				Assert.NotEqual(first, second);
+			}
+
+			[Fact]
+			public void Different_parameterized_custom_matchers_with_render_expressions_but_different_arguments()
+			{
+				var first  = GetMatch(() => Order.IsSmallerThanRE(123M));
+				var second = GetMatch(() => Order.IsLargerThanRE(456M));
+				Assert.NotEqual(first, second);
+			}
+
+			[Fact]
+			public void Parameterized_custom_matcher_without_render_expressions_and_different_arguments()
+			{
+				var first  = GetMatch(() => Order.IsSmallerThan(123M));
+				var second = GetMatch(() => Order.IsSmallerThan(456M));
+				Assert.NotEqual(first, second);
+			}
+
+			[Fact]
+			public void Parameterized_custom_matcher_with_render_expressions_but_different_arguments()
+			{
+				var first  = GetMatch(() => Order.IsSmallerThanRE(123M));
+				var second = GetMatch(() => Order.IsSmallerThanRE(456M));
+				Assert.NotEqual(first, second);
+			}
+
+			[Fact]
+			public void Different_matchers_with_same_render_expression()
+			{
+				var first  = GetMatch(() => It.IsAny<Order>());
+				var second = GetMatch(() => Order.PretendIsAny());
+				Assert.NotEqual(first, second);
+			}
+		}
+
+		public class Equality_ambiguity
+		{
+			[Fact]
+			public void Parameterized_custom_matcher_without_render_expression_but_equal_arguments()
+			{
+				// This is almost guaranteed to trip someone up sooner or later, as the reason why
+				// below two matchers aren't equal is not obvious at first glance.
+				//
+				// If a parameterized custom matcher only provides a predicate (delegate) but no
+				// render expression, how do we get at the parameters in order to compare them?
+				// Short answer: They typically sit on the delegate's target object, which we'd have
+				// to compare for structural equality. Which is is kind of expensive.
+				//
+				// So for the moment, this ambiguity is left unresolved. If you run into this, the
+				// easiest way to work around it is to provide a render expression to `Match.Create`.
+
+				var first  = GetMatch(() => Order.IsSmallerThan(123M));
+				var second = GetMatch(() => Order.IsSmallerThan(123M));
+				Assert.NotEqual(first, second);
+			}
+		}
+
+		private static Match GetMatch<T>(Func<T> func)
+		{
+			using (var observer = AmbientObserver.Activate())
+			{
+				_ = func();
+				return observer.LastIsMatch(out var match) ? match as Match<T> : null;
+			}
+		}
+
+		private abstract class Order
+		{
+			public abstract decimal MetricTons { get; }
+
+			[Matcher]
+			public static Order IsSmall()
+			{
+				return Match.Create<Order>(order => order.MetricTons < 1000M);
+			}
+
+			[Matcher]
+			public static Order IsSmallRE()
+			{
+				return Match.Create<Order>(order => order.MetricTons < 1000M, () => Order.IsSmallRE());
+			}
+
+			[Matcher]
+			public static Order IsLarge()
+			{
+				return Match.Create<Order>(order => order.MetricTons >= 1000M);
+			}
+
+			[Matcher]
+			public static Order IsLargeRE()
+			{
+				return Match.Create<Order>(order => order.MetricTons >= 1000M, () => Order.IsLargeRE());
+			}
+
+			[Matcher]
+			public static Order IsSmallerThan(decimal threshold)
+			{
+				return Match.Create<Order>(order => order.MetricTons < threshold);
+			}
+
+			[Matcher]
+			public static Order IsSmallerThanRE(decimal threshold)
+			{
+				return Match.Create<Order>(order => order.MetricTons < threshold, () => Order.IsSmallerThanRE(threshold));
+			}
+
+			[Matcher]
+			public static Order IsLargerThan(decimal threshold)
+			{
+				return Match.Create<Order>(order => order.MetricTons > threshold);
+			}
+
+			[Matcher]
+			public static Order IsLargerThanRE(decimal threshold)
+			{
+				return Match.Create<Order>(order => order.MetricTons < threshold, () => Order.IsLargerThanRE(threshold));
+			}
+
+			[Matcher]
+			public static Order PretendIsAny()
+			{
+				return Match.Create<Order>(order => false, () => It.IsAny<Order>());
+			}
+		}
+	}
+}


### PR DESCRIPTION
This is extracted from, and required by, #767. Moq should be able to process expressions containing a `MatchExpression` more or less everywhere except during compilation (because it doesn't carry enough information to properly allow that scenario).