### PR TITLE
Remove catch & (re-) throw in `Raise`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ This release contains several **minor breaking changes**. Please review your cod
 * `Verify` gets confused between the same generic and non-generic signature (@lepijohnny, #749)
 * Setup gets included in `Verify` despite being "unreachable" (@stakx, #703)
 * `Verify` can create setups that cause subsequent `VerifyAll` to fail (@stakx & @lepijohnny, #699)
+* Incomplete stack trace when raising an event with `mock.Raise` throws (@MutatedTomato, #738)
+
 
 ## 4.10.1 (2018-12-03)
 

--- a/src/Moq/Mock.Generic.cs
+++ b/src/Moq/Mock.Generic.cs
@@ -566,38 +566,18 @@ namespace Moq
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Raise"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate", Justification = "Raises the event, rather than being one.")]
-		[SuppressMessage("Microsoft.Usage", "CA2200:RethrowToPreserveStackDetails", Justification = "We want to reset the stack trace to avoid Moq noise in it.")]
 		public void Raise(Action<T> eventExpression, EventArgs args)
 		{
 			var (ev, target) = eventExpression.GetEventWithTarget(this.Object);
-
-			try
-			{
-				target.DoRaise(ev, args);
-			}
-			catch (Exception e)
-			{
-				// Reset stack trace so user gets this call site only.
-				throw e;
-			}
+			target.DoRaise(ev, args);
 		}
 
 		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.Raise(args)"]/*'/>
 		[SuppressMessage("Microsoft.Design", "CA1030:UseEventsWhereAppropriate", Justification = "Raises the event, rather than being one.")]
-		[SuppressMessage("Microsoft.Usage", "CA2200:RethrowToPreserveStackDetails", Justification = "We want to reset the stack trace to avoid Moq noise in it.")]
 		public void Raise(Action<T> eventExpression, params object[] args)
 		{
 			var (ev, target) = eventExpression.GetEventWithTarget(this.Object);
-
-			try
-			{
-				target.DoRaise(ev, args);
-			}
-			catch (Exception e)
-			{
-				// Reset stack trace so user gets this call site only.
-				throw e;
-			}
+			target.DoRaise(ev, args);
 		}
 
 #endregion


### PR DESCRIPTION
Two reasons for this:

 1. It is one of the very few, if not the only, place where we do this "to keep Moq noise out" of the stack trace.

 2. An earlier refactor in `InvokePreserveStack` that switched to using `ExceptionDispatchInfo` already leads to cleaner stack traces than what we had previously. It's likely the "Moq noise" is at a tolerable level now. (If it weren't, we'd have to introduce the same re-throwing pattern in all other public APIs.

Resolves #738.