### PR TITLE
`InvocationShape` should be equality-comparable

### DIFF
--- a/src/Moq/ExpressionExtensions.cs
+++ b/src/Moq/ExpressionExtensions.cs
@@ -350,9 +350,9 @@ namespace Moq
 			return Evaluator.PartialEval(expression);
 		}
 
-		public static LambdaExpression PartialMatcherAwareEval(this LambdaExpression expression)
+		public static Expression PartialMatcherAwareEval(this Expression expression)
 		{
-			return (LambdaExpression)Evaluator.PartialEval(
+			return Evaluator.PartialEval(
 				expression,
 				PartialMatcherAwareEval_ShouldEvaluate);
 		}

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -21,6 +21,8 @@ namespace Moq
 
 		public virtual Condition Condition => null;
 
+		public InvocationShape Expectation => this.expectation;
+
 		public LambdaExpression Expression => this.expectation.Expression;
 
 		public virtual bool IsVerifiable => false;

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -86,7 +86,7 @@ namespace Moq
 			// The following verification logic will remember each processed setup so that duplicate setups
 			// (that is, setups overridden by later setups with an equivalent expression) can be detected.
 			// To speed up duplicate detection, they are partitioned according to the method they target.
-			var visitedSetupsPerMethod = new Dictionary<MethodInfo, List<Expression>>();
+			var visitedSetupsPerMethod = new Dictionary<MethodInfo, List<InvocationShape>>();
 
 			lock (this.setups)
 			{
@@ -97,15 +97,14 @@ namespace Moq
 						continue;
 					}
 
-					List<Expression> visitedSetupsForMethod;
+					List<InvocationShape> visitedSetupsForMethod;
 					if (!visitedSetupsPerMethod.TryGetValue(setup.Method, out visitedSetupsForMethod))
 					{
-						visitedSetupsForMethod = new List<Expression>();
+						visitedSetupsForMethod = new List<InvocationShape>();
 						visitedSetupsPerMethod.Add(setup.Method, visitedSetupsForMethod);
 					}
 
-					var expr = setup.Expression.PartialMatcherAwareEval();
-					if (visitedSetupsForMethod.Any(vc => ExpressionComparer.Default.Equals(vc, expr)))
+					if (visitedSetupsForMethod.Contains(setup.Expectation))
 					{
 						continue;
 					}
@@ -115,7 +114,7 @@ namespace Moq
 						matchingSetups.Push(setup);
 					}
 
-					visitedSetupsForMethod.Add(expr);
+					visitedSetupsForMethod.Add(setup.Expectation);
 				}
 			}
 


### PR DESCRIPTION
Another refactoring that makes `InvocationShape` that will be needed shortly. It also permits a clearer phrasing in `SetupCollection` when a setup overrides another.