### PR TITLE
Fix regression with incomplete `Verify` expression validation

### DIFF
--- a/src/Moq/InvocationShape.cs
+++ b/src/Moq/InvocationShape.cs
@@ -35,6 +35,9 @@ namespace Moq
 			Debug.Assert(expression != null);
 			Debug.Assert(method != null);
 
+			Guard.IsOverridable(method, expression);
+			Guard.IsVisibleToProxyFactory(method);
+
 			this.Expression = expression;
 			this.Method = method;
 			this.Arguments = arguments ?? noArguments;

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -300,7 +300,7 @@ namespace Moq
 				part = new InvocationShape(expr, method, arguments);
 			}
 
-			ThrowIfVerifyExpressionInvolvesUnsupportedMember(expr, method);
+			Guard.IsOverridable(method, expression);
 
 			if (parts.Count == 0)
 			{
@@ -485,8 +485,8 @@ namespace Moq
 				part = new InvocationShape(expr, method, arguments);
 			}
 
-			ThrowIfSetupExpressionInvolvesUnsupportedMember(expr, method);
-			ThrowIfSetupMethodNotVisibleToProxyFactory(method);
+			Guard.IsOverridable(method, expression);
+			Guard.IsVisibleToProxyFactory(method);
 
 			if (parts.Count == 0)
 			{
@@ -600,55 +600,6 @@ namespace Moq
 		{
 			var param = Expression.Parameter(mockType, "m");
 			return Expression.Lambda(Expression.MakeMemberAccess(param, property), param);
-		}
-
-		private static void ThrowIfSetupMethodNotVisibleToProxyFactory(MethodInfo method)
-		{
-			if (ProxyFactory.Instance.IsMethodVisible(method, out string messageIfNotVisible) == false)
-			{
-				throw new ArgumentException(string.Format(
-					CultureInfo.CurrentCulture,
-					Resources.MethodNotVisibleToProxyFactory,
-					method.DeclaringType.Name,
-					method.Name,
-					messageIfNotVisible));
-			}
-		}
-
-		private static void ThrowIfSetupExpressionInvolvesUnsupportedMember(Expression setup, MethodInfo method)
-		{
-			if (method.IsStatic)
-			{
-				throw new NotSupportedException(string.Format(
-					CultureInfo.CurrentCulture,
-					method.IsExtensionMethod() ? Resources.SetupOnExtensionMethod : Resources.SetupOnStaticMember,
-					setup.ToStringFixed()));
-			}
-			else if (!method.CanOverride())
-			{
-				throw new NotSupportedException(string.Format(
-					CultureInfo.CurrentCulture,
-					Resources.SetupOnNonVirtualMember,
-					setup.ToStringFixed()));
-			}
-		}
-
-		private static void ThrowIfVerifyExpressionInvolvesUnsupportedMember(Expression verify, MethodInfo method)
-		{
-			if (method.IsStatic)
-			{
-				throw new NotSupportedException(string.Format(
-					CultureInfo.CurrentCulture,
-					method.IsExtensionMethod() ? Resources.VerifyOnExtensionMethod : Resources.VerifyOnStaticMember,
-					verify.ToStringFixed()));
-			}
-			else if (!method.CanOverride())
-			{
-				throw new NotSupportedException(string.Format(
-					CultureInfo.CurrentCulture,
-					Resources.VerifyOnNonVirtualMember,
-					verify.ToStringFixed()));
-			}
 		}
 
 		#endregion
@@ -821,8 +772,8 @@ namespace Moq
 				Debug.Assert(method == property.GetGetMethod(true));
 			}
 
-			ThrowIfSetupExpressionInvolvesUnsupportedMember(expression, method);
-			ThrowIfSetupMethodNotVisibleToProxyFactory(method);
+			Guard.IsOverridable(method, expression);
+			Guard.IsVisibleToProxyFactory(method);
 
 			this.Setups.Add(new InnerMockSetup(new InvocationShape(expression, method, arguments), returnValue));
 		}

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -300,8 +300,6 @@ namespace Moq
 				part = new InvocationShape(expr, method, arguments);
 			}
 
-			Guard.IsOverridable(method, expression);
-
 			if (parts.Count == 0)
 			{
 				verifyLast(part, mock);
@@ -484,9 +482,6 @@ namespace Moq
 				_ = ProxyFactory.Instance.GetDelegateProxyInterface(mock.TargetType, out method);
 				part = new InvocationShape(expr, method, arguments);
 			}
-
-			Guard.IsOverridable(method, expression);
-			Guard.IsVisibleToProxyFactory(method);
 
 			if (parts.Count == 0)
 			{
@@ -771,9 +766,6 @@ namespace Moq
 
 				Debug.Assert(method == property.GetGetMethod(true));
 			}
-
-			Guard.IsOverridable(method, expression);
-			Guard.IsVisibleToProxyFactory(method);
 
 			this.Setups.Add(new InnerMockSetup(new InvocationShape(expression, method, arguments), returnValue));
 		}

--- a/src/Moq/Properties/Resources.Designer.cs
+++ b/src/Moq/Properties/Resources.Designer.cs
@@ -590,33 +590,6 @@ namespace Moq.Properties {
 		}
 		
 		/// <summary>
-		///   Looks up a localized string similar to Invalid setup on an extension method: {0}.
-		/// </summary>
-		internal static string SetupOnExtensionMethod {
-			get {
-				return ResourceManager.GetString("SetupOnExtensionMethod", resourceCulture);
-			}
-		}
-		
-		/// <summary>
-		///   Looks up a localized string similar to Invalid setup on a non-virtual (overridable in VB) member: {0}.
-		/// </summary>
-		internal static string SetupOnNonVirtualMember {
-			get {
-				return ResourceManager.GetString("SetupOnNonVirtualMember", resourceCulture);
-			}
-		}
-		
-		/// <summary>
-		///   Looks up a localized string similar to Invalid setup on a static member: {0}.
-		/// </summary>
-		internal static string SetupOnStaticMember {
-			get {
-				return ResourceManager.GetString("SetupOnStaticMember", resourceCulture);
-			}
-		}
-		
-		/// <summary>
 		///   Looks up a localized string similar to Type {0} does not implement required interface {1}.
 		/// </summary>
 		internal static string TypeNotImplementInterface {
@@ -704,11 +677,38 @@ namespace Moq.Properties {
 		}
 		
 		/// <summary>
+		///   Looks up a localized string similar to Extension methods (here: {0}) may not be used in setup / verification expressions..
+		/// </summary>
+		internal static string UnsupportedExtensionMethod {
+			get {
+				return ResourceManager.GetString("UnsupportedExtensionMethod", resourceCulture);
+			}
+		}
+		
+		/// <summary>
 		///   Looks up a localized string similar to Member {0} is not supported for protected mocking..
 		/// </summary>
 		internal static string UnsupportedMember {
 			get {
 				return ResourceManager.GetString("UnsupportedMember", resourceCulture);
+			}
+		}
+		
+		/// <summary>
+		///   Looks up a localized string similar to Non-overridable members (here: {0}) may not be used in setup / verification expressions..
+		/// </summary>
+		internal static string UnsupportedNonOverridableMember {
+			get {
+				return ResourceManager.GetString("UnsupportedNonOverridableMember", resourceCulture);
+			}
+		}
+		
+		/// <summary>
+		///   Looks up a localized string similar to Static members (here: {0}) may not be used in setup / verification expressions..
+		/// </summary>
+		internal static string UnsupportedStaticMember {
+			get {
+				return ResourceManager.GetString("UnsupportedStaticMember", resourceCulture);
 			}
 		}
 		
@@ -756,33 +756,6 @@ namespace Moq.Properties {
 		internal static string VerificationErrorsOfMockRepository {
 			get {
 				return ResourceManager.GetString("VerificationErrorsOfMockRepository", resourceCulture);
-			}
-		}
-		
-		/// <summary>
-		///   Looks up a localized string similar to Invalid verify on an extension method: {0}.
-		/// </summary>
-		internal static string VerifyOnExtensionMethod {
-			get {
-				return ResourceManager.GetString("VerifyOnExtensionMethod", resourceCulture);
-			}
-		}
-		
-		/// <summary>
-		///   Looks up a localized string similar to Invalid verify on a non-virtual (overridable in VB) member: {0}.
-		/// </summary>
-		internal static string VerifyOnNonVirtualMember {
-			get {
-				return ResourceManager.GetString("VerifyOnNonVirtualMember", resourceCulture);
-			}
-		}
-		
-		/// <summary>
-		///   Looks up a localized string similar to Invalid verify on a static member: {0}.
-		/// </summary>
-		internal static string VerifyOnStaticMember {
-			get {
-				return ResourceManager.GetString("VerifyOnStaticMember", resourceCulture);
 			}
 		}
 	}

--- a/src/Moq/Properties/Resources.resx
+++ b/src/Moq/Properties/Resources.resx
@@ -271,24 +271,6 @@ Expected invocation on the mock once, but was {4} times: {1}</value>
 	<data name="PropertyGetNotFound" xml:space="preserve">
 		<value>Property {0}.{1} does not have a getter.</value>
 	</data>
-	<data name="SetupOnNonVirtualMember" xml:space="preserve">
-		<value>Invalid setup on a non-virtual (overridable in VB) member: {0}</value>
-	</data>
-	<data name="VerifyOnNonVirtualMember" xml:space="preserve">
-		<value>Invalid verify on a non-virtual (overridable in VB) member: {0}</value>
-	</data>
-	<data name="SetupOnStaticMember" xml:space="preserve">
-		<value>Invalid setup on a static member: {0}</value>
-	</data>
-	<data name="VerifyOnStaticMember" xml:space="preserve">
-		<value>Invalid verify on a static member: {0}</value>
-	</data>
-	<data name="SetupOnExtensionMethod" xml:space="preserve">
-		<value>Invalid setup on an extension method: {0}</value>
-	</data>
-	<data name="VerifyOnExtensionMethod" xml:space="preserve">
-		<value>Invalid verify on an extension method: {0}</value>
-	</data>
 	<data name="UnhandledBindingType" xml:space="preserve">
 		<value>Unhandled binding type: {0}</value>
 	</data>
@@ -374,5 +356,14 @@ This mock failed verification due to the following:</value>
 	<data name="MatcherAssignmentFailedDuringExpressionReconstruction" xml:space="preserve">
 		<value>Could not determine the correct positions for all argument matchers ({0} in total) used in a call to this method: {1}.
 This could be caused by an unrecognized type conversion, coercion, narrowing, or widening, and is most likely a bug in Moq. Please report your use case to the Moq team.</value>
+	</data>
+	<data name="UnsupportedExtensionMethod" xml:space="preserve">
+		<value>Extension methods (here: {0}) may not be used in setup / verification expressions.</value>
+	</data>
+	<data name="UnsupportedNonOverridableMember" xml:space="preserve">
+		<value>Non-overridable members (here: {0}) may not be used in setup / verification expressions.</value>
+	</data>
+	<data name="UnsupportedStaticMember" xml:space="preserve">
+		<value>Static members (here: {0}) may not be used in setup / verification expressions.</value>
 	</data>
 </root>

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -3151,7 +3151,8 @@ namespace Moq.Tests.Regressions
 				mock.Setup(m => m.OnExecute());
 
 				var e = Assert.Throws<NotSupportedException>(() => mock.Verify(m => m.Execute()));
-				Assert.StartsWith("Invalid verify", e.Message);
+				Assert.Contains("non-overridable", e.Message, StringComparison.CurrentCultureIgnoreCase);
+				Assert.Contains("Foo.Execute", e.Message);
 			}
 
 			public class Foo

--- a/tests/Moq.Tests/VerifyFixture.cs
+++ b/tests/Moq.Tests/VerifyFixture.cs
@@ -1528,6 +1528,14 @@ namespace Moq.Tests
 			mock.Protected().Verify("Populate", Times.Once(), exactParameterMatch: true, ItExpr.Ref<ChildDto>.IsAny);
 		}
 
+		[Fact]
+		public void Verify_on_non_overridable_method_throws_NotSupportedException()
+		{
+			var mock = new Mock<Child>();
+			Assert.Throws<NotSupportedException>(() =>
+				mock.Verify(m => m.InvokePopulate(ref It.Ref<ChildDto>.IsAny), Times.Never));
+		}
+
 		public class Exclusion_of_unreachable_inner_mocks
 		{
 			[Fact]


### PR DESCRIPTION
A regression has been introduced (possibly in #765) that led to `Verify` no longer noticing attempts to verify non-overridable members. There was no unit test to catch this, so this PR adds one and fixes the problem.