### PR TITLE
 Don't list setups in `Verify(...)` error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This release contains several **minor breaking changes**. Please review your cod
 * `mock.Verify[All]` now performs a more thorough error aggregation. Error messages of inner/recursive mocks are included in the error message using indentation to show the relationship between mocks. (@stakx, #762)
 * `mock.Verify` no longer creates setups, nor will it override existing setups, as a side-effect of using a recursive expression. (@stakx, #765)
 * More accurate detection of argument matchers with `SetupSet` and `VerifySet`, especially when used in fluent setup expressions or with indexers (@stakx, #767)
+* `mock.Verify(expression)` no longer includes setups in its error message, as they are completely irrelevant in the context of this method (@stakx, #779)
 
 #### Added
 

--- a/src/Moq/MockException.cs
+++ b/src/Moq/MockException.cs
@@ -76,17 +76,7 @@ namespace Moq
 			return new MockException(
 				MockExceptionReasons.NoMatchingCalls,
 				times.GetExceptionMessage(failMessage, expression.PartialMatcherAwareEval().ToStringFixed(), callCount) +
-				Environment.NewLine + FormatSetupsInfo() +
 				Environment.NewLine + FormatInvocations());
-
-			string FormatSetupsInfo()
-			{
-				var expressionSetups = setups.Select(s => s.ToString()).ToArray();
-
-				return expressionSetups.Length == 0 ?
-					Resources.NoSetupsConfigured :
-					Environment.NewLine + string.Format(Resources.ConfiguredSetups, Environment.NewLine + string.Join(Environment.NewLine, expressionSetups));
-			}
 
 			string FormatInvocations()
 			{

--- a/src/Moq/Properties/Resources.Designer.cs
+++ b/src/Moq/Properties/Resources.Designer.cs
@@ -106,15 +106,6 @@ namespace Moq.Properties {
 		}
 		
 		/// <summary>
-		///   Looks up a localized string similar to Configured setups: {0}.
-		/// </summary>
-		internal static string ConfiguredSetups {
-			get {
-				return ResourceManager.GetString("ConfiguredSetups", resourceCulture);
-			}
-		}
-		
-		/// <summary>
 		///   Looks up a localized string similar to Constructor arguments cannot be passed for delegate mocks..
 		/// </summary>
 		internal static string ConstructorArgsForDelegate {

--- a/src/Moq/Properties/Resources.resx
+++ b/src/Moq/Properties/Resources.resx
@@ -277,9 +277,6 @@ Expected invocation on the mock once, but was {4} times: {1}</value>
 	<data name="UnhandledExpressionType" xml:space="preserve">
 		<value>Unhandled expression type: {0}</value>
 	</data>
-	<data name="ConfiguredSetups" xml:space="preserve">
-		<value>Configured setups: {0}</value>
-	</data>
 	<data name="DelaysMustBeGreaterThanZero" xml:space="preserve">
 		<value>Delays have to be greater than zero to ensure an async callback is used.</value>
 	</data>

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -3082,64 +3082,6 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
-		#region #183
-
-		public class _183
-		{
-			[Fact]
-			public void Test()
-			{
-				var mock = new Mock<IFoo>();
-				mock.Setup(m => m.Execute(1));
-				mock.Setup(m => m.Execute(It.IsInRange(2, 20, Range.Exclusive)));
-				mock.Setup(m => m.Execute(3, "Caption"));
-
-				mock.Object.Execute(3);
-				mock.Object.Execute(4);
-				mock.Object.Execute(5);
-
-				var e = Assert.Throws<MockException>(() => mock.Verify(m => m.Execute(0)));
-				Assert.True(e.Message.ContainsConsecutiveLines(
-					"Configured setups: ",
-					"IssueReportsFixture._183.IFoo m => m.Execute(1)",
-					"IssueReportsFixture._183.IFoo m => m.Execute(It.IsInRange<int>(2, 20, Range.Exclusive))"));
-			}
-
-			[Fact]
-			public void TestGeneric()
-			{
-				var mock = new Mock<IFoo>();
-				mock.Setup(m => m.Execute<int>(1, 10));
-				mock.Setup(m => m.Execute<string>(1, "Foo"));
-
-				mock.Object.Execute(1, 10);
-
-				var e = Assert.Throws<MockException>(() => mock.Verify(m => m.Execute<int>(1, 1)));
-				Assert.True(e.Message.ContainsConsecutiveLines(
-					"Configured setups: ",
-					"IssueReportsFixture._183.IFoo m => m.Execute<int>(1, 10)"));
-			}
-
-			[Fact]
-			public void TestNoSetups()
-			{
-				var mock = new Mock<IFoo>();
-
-				var e = Assert.Throws<MockException>(() => mock.Verify(m => m.Execute(1)));
-				Assert.Contains("No setups configured.", e.Message);
-
-			}
-
-			public interface IFoo
-			{
-				void Execute(int param);
-				void Execute(int param, string caption);
-				void Execute<T>(int p, T param);
-			}
-		}
-
-		#endregion
-
 		#region #186
 
 		public class _186

--- a/tests/Moq.Tests/VerifyFixture.cs
+++ b/tests/Moq.Tests/VerifyFixture.cs
@@ -861,17 +861,6 @@ namespace Moq.Tests
 		}
 
 		[Fact]
-		public void IncludesActualValuesFromSetups()
-		{
-			var expectedArg = "lorem,ipsum";
-			var mock = new Moq.Mock<IFoo>();
-			mock.Setup(f => f.Save(expectedArg.Substring(0, 5)));
-
-			var mex = Assert.Throws<MockException>(() => mock.Verify(foo => foo.Save("never")));
-			Assert.Contains("f.Save(\"lorem\")", mex.Message);
-		}
-
-		[Fact]
 		public void IncludesMessageAboutNoActualCallsInFailureMessage()
 		{
 			var mock = new Moq.Mock<IFoo>();
@@ -879,16 +868,6 @@ namespace Moq.Tests
 			MockException mex = Assert.Throws<MockException>(() => mock.Verify(f => f.Execute("pong")));
 
 			Assert.Contains("No invocations performed.", mex.Message);
-		}
-
-		[Fact]
-		public void IncludesMessageAboutNoSetupCallsInFailureMessage()
-		{
-			var mock = new Moq.Mock<IFoo>();
-
-			MockException mex = Assert.Throws<MockException>(() => mock.Verify(f => f.Execute("pong")));
-
-			Assert.Contains("No setups configured.", mex.Message);
 		}
 
 		[Fact]
@@ -1431,30 +1410,6 @@ namespace Moq.Tests
 
 			mock.VerifyAll();
 			mock.VerifyNoOtherCalls();
-		}
-
-		[Fact]
-		public void Verification_error_message_contains_setup_for_delegate_mock()
-		{
-			var mock = new Mock<Action>();
-			mock.Setup(m => m());
-
-			var ex = Record.Exception(() => mock.Verify(m => m(), Times.Once()));
-
-			Assert.Contains("Configured setups:", ex.Message);
-			Assert.Contains("Action m => m()", ex.Message);
-		}
-
-		[Fact]
-		public void Verification_error_message_contains_setup_for_delegate_mock_with_parameters()
-		{
-			var mock = new Mock<Action<int, int>>();
-			mock.Setup(m => m(1, It.IsAny<int>()));
-
-			var ex = Record.Exception(() => mock.Verify(m => m(1, 2), Times.Once()));
-
-			Assert.Contains("Configured setups:", ex.Message);
-			Assert.Contains("Action<int, int> m => m(1, It.IsAny<int>())", ex.Message);
 		}
 
 		[Fact]


### PR DESCRIPTION
Unlike `mock.Verify()` and `mock.VerifyAll()`, which look at a mock's setups, `mock.Verify(m => ...)` has absolutely no relation to setups. Listing configured setups in that method's error message can only mislead users into thinking otherwise.

This commit removes setup information from these error messages. (The list of performed invocations is of course preserved.)