### PR TITLE
Arguments in recursive expressions should not be treated like `It.IsAny` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This release contains several **minor breaking changes**. Please review your cod
 * `mock.Verify[All]` now performs a more thorough error aggregation. Error messages of inner/recursive mocks are included in the error message using indentation to show the relationship between mocks. (@stakx, #762)
 * `mock.Verify` no longer creates setups, nor will it override existing setups, as a side-effect of using a recursive expression. (@stakx, #765)
 * More accurate detection of argument matchers with `SetupSet` and `VerifySet`, especially when used in fluent setup expressions or with indexers (@stakx, #767)
-* `mock.Verify(expression)` no longer includes setups in its error message, as they are completely irrelevant in the context of this method (@stakx, #779)
+* `mock.Verify(expression)` error messages now contain a full listing of all invocations that occurred across all involved mocks. Setups are no longer listed, since they are completely irrelevant in the context of call verification. (@stakx, #779, #780)
 
 #### Added
 

--- a/src/Moq/AsInterface.cs
+++ b/src/Moq/AsInterface.cs
@@ -2,9 +2,7 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Reflection;
 
 namespace Moq
 {
@@ -73,6 +71,11 @@ namespace Moq
 		protected override object OnGetObject()
 		{
 			return this.owner.Object;
+		}
+
+		public override string ToString()
+		{
+			return this.owner.ToString();
 		}
 	}
 }

--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -273,11 +273,26 @@ namespace Moq
 			}
 		}
 
-		public static bool TryFind(this IEnumerable<IDeterministicReturnValueSetup> setups, MethodInfo method, out IDeterministicReturnValueSetup setup)
+		public static bool TryFind(this IEnumerable<IDeterministicReturnValueSetup> setups, InvocationShape expectation, out IDeterministicReturnValueSetup setup)
 		{
 			foreach (Setup s in setups)
 			{
-				if (s.Method == method)
+				if (s.Expectation.Equals(expectation))
+				{
+					setup = (IDeterministicReturnValueSetup)s;
+					return true;
+				}
+			}
+
+			setup = default;
+			return false;
+		}
+
+		public static bool TryFind(this IEnumerable<IDeterministicReturnValueSetup> setups, Invocation invocation, out IDeterministicReturnValueSetup setup)
+		{
+			foreach (Setup s in setups)
+			{
+				if (s.Matches(invocation))
 				{
 					setup = (IDeterministicReturnValueSetup)s;
 					return true;

--- a/src/Moq/FluentMockVisitor.cs
+++ b/src/Moq/FluentMockVisitor.cs
@@ -172,7 +172,7 @@ namespace Moq
 
 			Mock fluentMock;
 			object result;
-			if (mock.GetInnerMockSetups().TryFind(info, out var inner))
+			if (mock.GetInnerMockSetups().TryFind(new InvocationShape(setup, info, arguments), out var inner))
 			{
 				fluentMock = inner.GetInnerMock();
 				result = inner.ReturnValue;

--- a/src/Moq/ImmutablePoppableStack.cs
+++ b/src/Moq/ImmutablePoppableStack.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Moq
+{
+	internal readonly struct ImmutablePopOnlyStack<T>
+	{
+		private readonly T[] items;
+		private readonly int index;
+
+		public ImmutablePopOnlyStack(IEnumerable<T> items)
+		{
+			Debug.Assert(items != null);
+
+			this.items = items.ToArray();
+			this.index = 0;
+		}
+
+		private ImmutablePopOnlyStack(T[] items, int index)
+		{
+			Debug.Assert(items != null);
+			Debug.Assert(0 <= index && index <= items.Length);
+
+			this.items = items;
+			this.index = index;
+		}
+
+		public bool Empty => this.index == this.items.Length;
+
+		public T Pop(out ImmutablePopOnlyStack<T> stackBelowTop)
+		{
+			Debug.Assert(this.index < this.items.Length);
+
+			var top = this.items[this.index];
+			stackBelowTop = new ImmutablePopOnlyStack<T>(this.items, this.index + 1);
+			return top;
+		}
+	}
+}

--- a/src/Moq/Interception/InterceptionAspects.cs
+++ b/src/Moq/Interception/InterceptionAspects.cs
@@ -332,7 +332,7 @@ namespace Moq
 				var returnValue = mock.GetDefaultValue(method, out var innerMock);
 				if (innerMock != null)
 				{
-					mock.AddInnerMockSetup(method, returnValue);
+					mock.AddInnerMockSetup(invocation, returnValue);
 				}
 				invocation.Return(returnValue);
 			}

--- a/src/Moq/Invocation.cs
+++ b/src/Moq/Invocation.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
@@ -13,6 +12,7 @@ namespace Moq
 	{
 		private object[] arguments;
 		private MethodInfo method;
+		private object returnValue;
 		private VerificationState verificationState;
 
 		/// <summary>
@@ -44,6 +44,8 @@ namespace Moq
 		public object[] Arguments => this.arguments;
 
 		IReadOnlyList<object> IInvocation.Arguments => this.arguments;
+
+		public object ReturnValue => this.returnValue;
 
 		internal bool Verified => this.verificationState == VerificationState.Verified;
 
@@ -79,6 +81,7 @@ namespace Moq
 		/// and that no more calls to any of the three <c>Return</c> methods will be made.
 		/// <para>
 		/// Implementations must ensure that any by-reference parameters are written back from <see cref="Arguments"/>.
+		/// Implementations must also call <see cref="SetReturnValue(object)"/>.
 		/// </para>
 		/// </remarks>
 		public abstract void Return(object value);
@@ -117,6 +120,13 @@ namespace Moq
 			{
 				this.verificationState = VerificationState.Verified;
 			}
+		}
+
+		protected void SetReturnValue(object returnValue)
+		{
+			Debug.Assert(this.returnValue == null);  // quick & dirty check against double invocations
+
+			this.returnValue = returnValue;
 		}
 
 		/// <inheritdoc/>

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -307,7 +307,7 @@ namespace Moq
 			else
 			{
 				Mock innerMock;
-				if (mock.GetInnerMockSetups().TryFind(method, out var setup) && setup.ReturnsInnerMock(out innerMock))
+				if (mock.GetInnerMockSetups().TryFind(part, out var setup) && setup.ReturnsInnerMock(out innerMock))
 				{
 					Mock.VerifyRecursive(innerMock, expression, parts, times, failMessage, verifyLast);
 				}
@@ -347,7 +347,7 @@ namespace Moq
 						// In order for an invocation to be "transitive", its return value has to be a
 						// sub-object (inner mock); and that sub-object has to have received at least
 						// one call:
-						var wasTransitiveInvocation = innerMockSetups.TryFind(unverifiedInvocations[i].Method, out var inner)
+						var wasTransitiveInvocation = innerMockSetups.TryFind(unverifiedInvocations[i], out var inner)
 						                              && inner.GetInnerMock().MutableInvocations.Any();
 						if (wasTransitiveInvocation)
 						{
@@ -490,7 +490,7 @@ namespace Moq
 			else
 			{
 				Mock innerMock;
-				if (!(mock.GetInnerMockSetups().TryFind(method, out var setup) && setup.ReturnsInnerMock(out innerMock)))
+				if (!(mock.GetInnerMockSetups().TryFind(part, out var setup) && setup.ReturnsInnerMock(out innerMock)))
 				{
 					var returnValue = mock.GetDefaultValue(method, out innerMock, useAlternateProvider: DefaultValueProvider.Mock);
 					if (innerMock == null)
@@ -612,7 +612,8 @@ namespace Moq
 
 		internal static void RaiseEvent(Mock mock, LambdaExpression expression, Stack<InvocationShape> parts, object[] arguments)
 		{
-			var (_, method, _) = parts.Pop();
+			var part = parts.Pop();
+			var method = part.Method;
 
 			if (parts.Count == 0)
 			{
@@ -640,7 +641,7 @@ namespace Moq
 				}
 
 			}
-			else if (mock.GetInnerMockSetups().TryFind(method, out var innerMockSetup) && innerMockSetup.ReturnsInnerMock(out var innerMock))
+			else if (mock.GetInnerMockSetups().TryFind(part, out var innerMockSetup) && innerMockSetup.ReturnsInnerMock(out var innerMock))
 			{
 				Mock.RaiseEvent(innerMock, expression, parts, arguments);
 			}

--- a/src/Moq/Properties/Resources.Designer.cs
+++ b/src/Moq/Properties/Resources.Designer.cs
@@ -491,7 +491,7 @@ namespace Moq.Properties {
 		}
 		
 		/// <summary>
-		///   Looks up a localized string similar to Performed invocations: {0}.
+		///   Looks up a localized string similar to Performed invocations:.
 		/// </summary>
 		internal static string PerformedInvocations {
 			get {

--- a/src/Moq/Properties/Resources.resx
+++ b/src/Moq/Properties/Resources.resx
@@ -296,7 +296,7 @@ Expected invocation on the mock once, but was {4} times: {1}</value>
 		<value>No setups configured.</value>
 	</data>
 	<data name="PerformedInvocations" xml:space="preserve">
-		<value>Performed invocations: {0}</value>
+		<value>Performed invocations:</value>
 	</data>
 	<data name="UnexpectedTranslationOfMemberAccess" xml:space="preserve">
 		<value>Unexpected translation of a member access: {0}</value>

--- a/src/Moq/ProxyFactories/CastleProxyFactory.cs
+++ b/src/Moq/ProxyFactories/CastleProxyFactory.cs
@@ -220,6 +220,8 @@ namespace Moq
 				Debug.Assert(this.underlying != null);
 				Debug.Assert(this.underlying.Method.ReturnType != typeof(void));
 
+				this.SetReturnValue(value);
+
 				this.underlying.ReturnValue = value;
 				this.underlying = null;
 			}

--- a/src/Moq/ProxyFactories/InterfaceProxy.cs
+++ b/src/Moq/ProxyFactories/InterfaceProxy.cs
@@ -54,8 +54,6 @@ namespace Moq.Internals
 		{
 			private static object[] noArguments = new object[0];
 
-			private object returnValue;
-
 			public Invocation(MethodInfo method, params object[] arguments)
 				: base(method, arguments)
 			{
@@ -66,13 +64,11 @@ namespace Moq.Internals
 			{
 			}
 
-			public object ReturnValue => this.returnValue;
-
 			public override void Return() { }
 
 			public override void Return(object value)
 			{
-				this.returnValue = value;
+				this.SetReturnValue(value);
 			}
 
 			public override void ReturnBase() { }

--- a/tests/Moq.Tests/InvocationsFixture.cs
+++ b/tests/Moq.Tests/InvocationsFixture.cs
@@ -108,5 +108,25 @@ namespace Moq.Tests
 
 			Assert.Throws<IndexOutOfRangeException>(() => mock.Invocations[0]);
 	    }
+
+		[Fact]
+		public void Invocations_record_return_value()
+		{
+			var mock = new Mock<IComparable>();
+			mock.Setup(m => m.CompareTo(It.IsAny<object>())).Returns(42);
+			_ = mock.Object.CompareTo(default);
+			var invocation = mock.MutableInvocations.ToArray()[0];
+			Assert.Equal(42, invocation.ReturnValue);
+		}
+
+		[Fact]
+		public void Invocations_for_object_methods_on_interface_proxy_record_return_value()
+		{
+			var mock = new Mock<IComparable>();
+			mock.Setup(m => m.GetHashCode()).Returns(42);
+			_ = mock.Object.GetHashCode();
+			var invocation = mock.MutableInvocations.ToArray()[0];
+			Assert.Equal(42, invocation.ReturnValue);
+		}
 	}
 }

--- a/tests/Moq.Tests/RecursiveMocksFixture.cs
+++ b/tests/Moq.Tests/RecursiveMocksFixture.cs
@@ -316,6 +316,64 @@ namespace Moq.Tests
 			Assert.Equal(5, fooMock.Object.Bar.GetBaz("foo").Value);
 		}
 
+		public class Verify_can_tell_apart_different_arguments_in_intermediate_part_of_fluent_expressions
+		{
+			[Fact]
+			public void When_set_up_by_DefaultValue_Mock_1()
+			{
+				var mock = new Mock<IBar> { DefaultValue = DefaultValue.Mock };
+				mock.Object.GetBaz("actual").Do();
+				mock.Verify(m => m.GetBaz("something else").Do(), Times.Never);
+			}
+
+			[Fact]
+			public void When_manually_set_up_1()
+			{
+				var mock = new Mock<IBar>();
+				mock.Setup(m => m.GetBaz(It.IsAny<string>()).Do());
+				mock.Object.GetBaz("actual").Do();
+				mock.Verify(m => m.GetBaz("something else").Do(), Times.Never);
+			}
+
+			[Fact]
+			public void When_set_up_by_DefaultValue_Mock_2()
+			{
+				var mock = new Mock<IBar> { DefaultValue = DefaultValue.Mock };
+				mock.Object.GetBaz("first").Do();
+				mock.Object.GetBaz("second").Do();
+				mock.Verify(m => m.GetBaz("first").Do(), Times.Once);
+				mock.Verify(m => m.GetBaz("second").Do(), Times.Once);
+			}
+
+			[Fact]
+			public void When_manually_set_up_2()
+			{
+				var mock = new Mock<IBar> { DefaultValue = DefaultValue.Mock };
+				mock.Object.GetBaz("first").Do();
+				mock.Object.GetBaz("second").Do();
+				mock.Verify(m => m.GetBaz("first").Do(), Times.Once);
+				mock.Verify(m => m.GetBaz("second").Do(), Times.Once);
+			}
+
+			[Fact]
+			public void When_set_up_by_DefaultValue_Mock_3()
+			{
+				var mock = new Mock<IBar> { DefaultValue = DefaultValue.Mock };
+				mock.Object.GetBaz("first").Do();
+				mock.Object.GetBaz("second").Do();
+				mock.Verify(m => m.GetBaz(It.IsAny<string>()).Do(), Times.Exactly(2));
+			}
+
+			[Fact]
+			public void When_manually_set_up_3()
+			{
+				var mock = new Mock<IBar> { DefaultValue = DefaultValue.Mock };
+				mock.Object.GetBaz("first").Do();
+				mock.Object.GetBaz("second").Do();
+				mock.Verify(m => m.GetBaz(It.IsAny<string>()).Do(), Times.Exactly(2));
+			}
+		}
+
 		public class Foo : IFoo
 		{
 

--- a/tests/Moq.Tests/VerifyFixture.cs
+++ b/tests/Moq.Tests/VerifyFixture.cs
@@ -843,11 +843,10 @@ namespace Moq.Tests
 			var mex = Assert.Throws<MockException>(() => mock.Verify(f => f.Execute("pong")));
 
 			Assert.True(mex.Message.ContainsConsecutiveLines(
-				"Performed invocations: ",
-				"IFoo.Execute(\"ping\")",
-				"IFoo.Echo(42)",
-				"IFoo.Submit()",
-				"IFoo.Save([1, 2, \"hello\"])"));
+				"      IFoo.Execute(\"ping\")",
+				"      IFoo.Echo(42)",
+				"      IFoo.Submit()",
+				"      IFoo.Save([1, 2, \"hello\"])"));
 		}
 
 		[Fact]
@@ -867,7 +866,7 @@ namespace Moq.Tests
 
 			MockException mex = Assert.Throws<MockException>(() => mock.Verify(f => f.Execute("pong")));
 
-			Assert.Contains("No invocations performed.", mex.Message);
+			Assert.Contains("   No invocations performed.", mex.Message);
 		}
 
 		[Fact]
@@ -933,8 +932,7 @@ namespace Moq.Tests
 			mock.Object.Method(strings);
 			var mex = Assert.Throws<MockException>(() => mock.Verify(_ => _.Method(null)));
 			Assert.True(mex.Message.ContainsConsecutiveLines(
-				@"Performed invocations: ",
-				@"IArrays.Method([""1"", null, ""3""])"));
+				@"      IArrays.Method([""1"", null, ""3""])"));
 		}
 
 		[Fact]
@@ -945,8 +943,7 @@ namespace Moq.Tests
 			mock.Object.Method(strings);
 			var mex = Assert.Throws<MockException>(() => mock.Verify(_ => _.Method(null)));
 			Assert.True(mex.Message.ContainsConsecutiveLines(
-				@"Performed invocations: ",
-				@"IArrays.Method([""1"", null, ""3"", ""4"", ""5"", ""6"", ""7"", ""8"", ""9"", ""10""])"));
+				@"      IArrays.Method([""1"", null, ""3"", ""4"", ""5"", ""6"", ""7"", ""8"", ""9"", ""10""])"));
 		}
 
 		[Fact]
@@ -957,8 +954,7 @@ namespace Moq.Tests
 			mock.Object.Method(strings);
 			var mex = Assert.Throws<MockException>(() => mock.Verify(_ => _.Method(null)));
 			Assert.True(mex.Message.ContainsConsecutiveLines(
-				@"Performed invocations: ",
-				@"IArrays.Method([""1"", null, ""3"", ""4"", ""5"", ""6"", ""7"", ""8"", ""9"", ""10"", ...])"));
+				@"      IArrays.Method([""1"", null, ""3"", ""4"", ""5"", ""6"", ""7"", ""8"", ""9"", ""10"", ...])"));
 		}
 
 		[Fact]


### PR DESCRIPTION
This improves the accuracy with which Moq matches invocations against recursive / fluent verification expressions when using `mock.Verify(expression)`. Error messages likewise contain more precise & more complete information about which invocations occurred, and on what (inner) mocks.

Here's an example of what call verification error message will look like when this gets merged:

```csharp
public interface IX
{
    void Do();
    void Do(int arg);

    IX Inner { get; }
    IX GetInner(int arg);
}

var mock = new Mock<IX> { DefaultValue = DefaultValue.Mock };

mock.Object.GetInner(1).Do(1);
mock.Object.GetInner(1).Do(2);

var innerTwo = mock.Object.GetInner(2);
innerTwo.Do();
innerTwo.Do(2);

mock.Object.GetInner(3);

mock.Verify(m => m.GetInner(1).Do(It.IsAny<int>()), Times.Exactly(3));
```

```
Expected invocation on the mock once, but was 2 times: m => m.GetInner(It.IsAny<int>()).Do(2)
Performed invocations:

   Mock<IX:00000001> (m):

      IX.GetInner(1)  => Mock<IX:00000002>
      IX.GetInner(1)  => Mock<IX:00000002>
      IX.GetInner(2)  => Mock<IX:00000003>
      IX.GetInner(3)  => Mock<IX:00000004>

   Mock<IX:00000002>:

      IX.Do(1)
      IX.Do(2)

   Mock<IX:00000003>:

      IX.Do()
      IX.Do(2)

   Mock<IX:00000004>:
   No invocations performed.
```