### PR TITLE
`ActionObserver` improved support for parameterized base class ctors & additional virtual calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ This release contains several **minor breaking changes**. Please review your cod
 * Incomplete stack trace when raising an event with `mock.Raise` throws (@MutatedTomato, #738)
 * `Mock.Raise` only raises events on root object (@hallipr, #166)
 * Mocking indexer captures `It.IsAny()` as the value, even if given in the indexer argument (@idigra, #696)
+* `VerifySet` fails on non-trivial property setup (@TimothyHayes, #430)
+* Use of `SetupSet` 'forgets' method setup (@TimothyHayes, #432)
 
 ## 4.10.1 (2018-12-03)
 

--- a/src/Moq/ActionObserver.cs
+++ b/src/Moq/ActionObserver.cs
@@ -26,12 +26,12 @@ namespace Moq
 	/// </summary>
 	internal sealed class ActionObserver : ExpressionReconstructor
 	{
-		public override Expression<Action<T>> ReconstructExpression<T>(Action<T> action)
+		public override Expression<Action<T>> ReconstructExpression<T>(Action<T> action, object[] ctorArgs = null)
 		{
 			using (var matcherObserver = MatcherObserver.Activate())
 			{
 				// Create the root recording proxy:
-				var root = (T)CreateProxy(typeof(T), matcherObserver, out var rootRecorder);
+				var root = (T)CreateProxy(typeof(T), ctorArgs, matcherObserver, out var rootRecorder);
 
 				Exception error = null;
 				try
@@ -213,10 +213,10 @@ namespace Moq
 		}
 
 		// Creates a proxy (way more light-weight than a `Mock<T>`!) with an invocation `Recorder` attached to it.
-		private static IProxy CreateProxy(Type type, MatcherObserver matcherObserver, out Recorder recorder)
+		private static IProxy CreateProxy(Type type, object[] ctorArgs, MatcherObserver matcherObserver, out Recorder recorder)
 		{
 			recorder = new Recorder(matcherObserver);
-			return (IProxy)ProxyFactory.Instance.CreateProxy(type, recorder, Type.EmptyTypes, new object[0]);
+			return (IProxy)ProxyFactory.Instance.CreateProxy(type, recorder, Type.EmptyTypes, ctorArgs ?? new object[0]);
 		}
 
 		// Records an invocation, mocks return values, and builds a chain to the return value's recorder.
@@ -270,7 +270,7 @@ namespace Moq
 					}
 					else if (returnType.IsMockeable())
 					{
-						this.returnValue = CreateProxy(returnType, this.matcherObserver, out _);
+						this.returnValue = CreateProxy(returnType, null, this.matcherObserver, out _);
 					}
 					else
 					{

--- a/src/Moq/ActionObserver.cs
+++ b/src/Moq/ActionObserver.cs
@@ -254,12 +254,21 @@ namespace Moq
 			{
 				var returnType = invocation.Method.ReturnType;
 
-#if DEBUG
-				// In theory, each recorder receives exactly one invocation.
-				// We put the following guard here for debugging purposes, since your IDE's
-				// "Watch" window might cause additional calls that normally shouldn't happen.
-				if (this.invocation == null)
-#endif
+				// In theory, each recorder should receive exactly one invocation.
+				// There are some reasons why that may not always be true:
+				//
+				//  1. You may be inspecting a `Recorder` object in your IDE, causing
+				//     additional calls e.g. to `ToString`. In this case, any such
+				//     subsequent calls should be ignored.
+				//
+				//  2. The proxied type may perform virtual calls in its own ctor.
+				//     In this case, *only* the last call is going to be relevant.
+				//
+				// Getting (2) right is more important than getting (1) right, so we
+				// disable the following guard and allow subsequent calls to override
+				// earlier ones:
+
+				//if (this.invocation == null)
 				{
 					this.invocation = invocation;
 					this.invocationTimestamp = this.matcherObserver.GetNextTimestamp();

--- a/src/Moq/AsInterface.cs
+++ b/src/Moq/AsInterface.cs
@@ -21,6 +21,8 @@ namespace Moq
 
 		internal override Dictionary<Type, object> ConfiguredDefaultValues => this.owner.ConfiguredDefaultValues;
 
+		internal override object[] ConstructorArguments => this.owner.ConstructorArguments;
+
 		internal override InvocationCollection MutableInvocations => this.owner.MutableInvocations;
 
 		internal override bool IsObjectInitialized => this.owner.IsObjectInitialized;

--- a/src/Moq/ExpressionReconstructor.cs
+++ b/src/Moq/ExpressionReconstructor.cs
@@ -28,6 +28,7 @@ namespace Moq
 		///   Reconstructs a <see cref="LambdaExpression"/> from the given <see cref="Action{T}"/> delegate.
 		/// </summary>
 		/// <param name="action">The <see cref="Action"/> delegate for which to reconstruct a LINQ expression tree.</param>
-		public abstract Expression<Action<T>> ReconstructExpression<T>(Action<T> action);
+		/// <param name="ctorArgs">Arguments to pass to a parameterized constructor of <typeparamref name="T"/>. (Optional.)</param>
+		public abstract Expression<Action<T>> ReconstructExpression<T>(Action<T> action, object[] ctorArgs = null);
 	}
 }

--- a/src/Moq/Language/Flow/WhenPhrase.cs
+++ b/src/Moq/Language/Flow/WhenPhrase.cs
@@ -39,7 +39,7 @@ namespace Moq.Language.Flow
 		public ISetupSetter<T, TProperty> SetupSet<TProperty>(Action<T> setterExpression)
 		{
 			Guard.NotNull(setterExpression, nameof(setterExpression));
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression, this.mock.ConstructorArguments);
 
 			var setup = Mock.SetupSet(mock, expression, this.condition);
 			return new SetterSetupPhrase<T, TProperty>(setup);
@@ -48,7 +48,7 @@ namespace Moq.Language.Flow
 		public ISetup<T> SetupSet(Action<T> setterExpression)
 		{
 			Guard.NotNull(setterExpression, nameof(setterExpression));
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression, this.mock.ConstructorArguments);
 
 			var setup = Mock.SetupSet(mock, expression, this.condition);
 			return new VoidSetupPhrase<T>(setup);

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -192,7 +192,7 @@ namespace Moq
 		{
 			Guard.NotNull(eventExpression, nameof(eventExpression));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(eventExpression);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(eventExpression, this.mock.ConstructorArguments);
 
 			// TODO: validate that expression is for event subscription or unsubscription
 
@@ -204,7 +204,7 @@ namespace Moq
 		{
 			Guard.NotNull(eventExpression, nameof(eventExpression));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(eventExpression);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(eventExpression, this.mock.ConstructorArguments);
 
 			// TODO: validate that expression is for event subscription or unsubscription
 

--- a/src/Moq/Mock.Generic.cs
+++ b/src/Moq/Mock.Generic.cs
@@ -176,6 +176,8 @@ namespace Moq
 			}
 		}
 
+		internal override object[] ConstructorArguments => this.constructorArguments;
+
 		internal override Dictionary<Type, object> ConfiguredDefaultValues => this.configuredDefaultValues;
 
 		/// <summary>
@@ -326,7 +328,7 @@ namespace Moq
 		public ISetupSetter<T, TProperty> SetupSet<TProperty>(Action<T> setterExpression)
 		{
 			Guard.NotNull(setterExpression, nameof(setterExpression));
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression, this.ConstructorArguments);
 
 			var setup = Mock.SetupSet(this, expression, condition: null);
 			return new SetterSetupPhrase<T, TProperty>(setup);
@@ -336,7 +338,7 @@ namespace Moq
 		public ISetup<T> SetupSet(Action<T> setterExpression)
 		{
 			Guard.NotNull(setterExpression, nameof(setterExpression));
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression, this.ConstructorArguments);
 
 			var setup = Mock.SetupSet(this, expression, condition: null);
 			return new VoidSetupPhrase<T>(setup);
@@ -528,7 +530,7 @@ namespace Moq
 		{
 			Guard.NotNull(setterExpression, nameof(setterExpression));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression, this.ConstructorArguments);
 			Mock.VerifySet(this, expression, Times.AtLeastOnce(), null);
 		}
 
@@ -537,7 +539,7 @@ namespace Moq
 		{
 			Guard.NotNull(setterExpression, nameof(setterExpression));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression, this.ConstructorArguments);
 			Mock.VerifySet(this, expression, times, null);
 		}
 
@@ -546,7 +548,7 @@ namespace Moq
 		{
 			Guard.NotNull(setterExpression, nameof(setterExpression));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression, this.ConstructorArguments);
 			Mock.VerifySet(this, expression, times(), null);
 		}
 
@@ -555,7 +557,7 @@ namespace Moq
 		{
 			Guard.NotNull(setterExpression, nameof(setterExpression));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression, this.ConstructorArguments);
 			Mock.VerifySet(this, expression, Times.AtLeastOnce(), failMessage);
 		}
 
@@ -564,7 +566,7 @@ namespace Moq
 		{
 			Guard.NotNull(setterExpression, nameof(setterExpression));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression, this.ConstructorArguments);
 			Mock.VerifySet(this, expression, times, failMessage);
 		}
 
@@ -573,7 +575,7 @@ namespace Moq
 		{
 			Guard.NotNull(setterExpression, nameof(setterExpression));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression, this.ConstructorArguments);
 			Mock.VerifySet(this, expression , times(), failMessage);
 		}
 

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -113,6 +113,8 @@ namespace Moq
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.CallBase"]/*'/>
 		public abstract bool CallBase { get; set; }
 
+		internal abstract object[] ConstructorArguments { get; }
+
 		/// <include file='Mock.xdoc' path='docs/doc[@for="Mock.DefaultValue"]/*'/>
 		public DefaultValue DefaultValue
 		{
@@ -609,7 +611,7 @@ namespace Moq
 		{
 			Guard.NotNull(action, nameof(action));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(action);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(action, mock.ConstructorArguments);
 			var parts = expression.Split();
 			Mock.RaiseEvent(mock, expression, parts, arguments);
 		}

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -1505,6 +1505,90 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 430
+
+		public class Issue430
+		{
+			[Fact]
+			public void Antlers_NoSetup()
+			{
+				// Arrange
+
+				// create mock of class under test
+				var sut = new Mock<Vixen>(args: true) { CallBase = true };
+
+				// Act
+				sut.Object.Antlers = true;
+
+				// Assert
+				sut.VerifySet(x => x.Antlers = true);
+			}
+
+			[Fact]
+			public void Antlers_SetupProperty()
+			{
+				// Arrange
+
+				// create mock of class under test
+				var sut = new Mock<Vixen>(args: true) { CallBase = true };
+				sut.SetupProperty(x => x.Antlers, false);
+
+				// Act
+				sut.Object.Antlers = true;
+
+				// Assert
+				sut.VerifySet(x => x.Antlers = true);
+			}
+
+			[Fact]
+			public void Antlers_SetupSet()
+			{
+				// Arrange
+
+				// create mock of class under test
+				var sut = new Mock<Vixen>(args: true) { CallBase = true };
+				sut.SetupSet(x => x.Antlers = true);
+
+				// Act
+				sut.Object.Antlers = true;
+
+				// Assert
+				sut.VerifySet(x => x.Antlers = true);
+			}
+
+			public class Vixen
+			{
+
+				public Vixen(bool pIsMale)
+				{
+					IsMale = pIsMale;
+				}
+
+				private bool _IsMale;
+				public virtual bool IsMale
+				{
+					get { return this._IsMale; }
+					private set { this._IsMale = value; }
+				}
+
+				private bool _Antlers;
+				public virtual bool Antlers
+				{
+					get { return this._Antlers; }
+					set
+					{
+						// females cannot have antlers
+						if (IsMale)
+							this._Antlers = value;
+						else
+							this._Antlers = false;
+					}
+				}
+			}
+		}
+
+		#endregion
+
 		#region 438
 
 		public class Issue438

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -1589,6 +1589,100 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 432
+
+		public class Issue432
+		{
+			[Fact]
+			public void Antlers_NoSetup()
+			{
+				// Arrange
+				int temp = 0;
+
+				// create mock of class under test
+				var sut = new Mock<Prancer>(args: true) { CallBase = true };
+				sut.Setup(x => x.ExecuteMe()).Callback(() => temp = 1); // nullify
+
+				// Act
+				sut.Object.Antlers = true;
+
+				// Assert
+				sut.VerifySet(x => x.Antlers = true);
+				Assert.Equal(1, temp);
+			}
+
+			[Fact]
+			public void Antlers_SetupProperty()
+			{
+				// Arrange
+				int temp = 0;
+
+				// create mock of class under test
+				var sut = new Mock<Prancer>(args: true) { CallBase = true };
+				sut.SetupProperty(x => x.Antlers, false);
+				sut.Setup(x => x.ExecuteMe()).Callback(() => temp = 2); // nullify
+
+				// Act
+				sut.Object.Antlers = true;
+
+				// Assert
+				sut.VerifySet(x => x.Antlers = true);
+				Assert.Equal(2, temp);
+			}
+
+			[Fact]
+			public void Antlers_SetupSet()
+			{
+				// Arrange
+				int temp = 0;
+
+				// create mock of class under test
+				var sut = new Mock<Prancer>(args: true) { CallBase = true };
+				sut.Setup(x => x.ExecuteMe()).Callback(() => temp = 3); // nullify
+				sut.SetupSet(x => x.Antlers = true);
+
+				// Act
+				sut.Object.Antlers = true;
+
+				// Assert
+				sut.VerifySet(x => x.Antlers = true);
+				Assert.Equal(3, temp);
+			}
+
+			public class Prancer
+			{
+				public Prancer(bool pIsMale)
+				{
+					IsMale = pIsMale;
+					ExecuteMe();
+				}
+
+				private bool _IsMale;
+				public virtual bool IsMale
+				{
+					get { return this._IsMale; }
+					private set { this._IsMale = value; }
+				}
+
+				private bool _Antlers;
+				public virtual bool Antlers
+				{
+					get { return this._Antlers; }
+					set
+					{
+						this._Antlers = value;
+					}
+				}
+
+				public virtual void ExecuteMe()
+				{
+					throw new Exception("Why am I here?");
+				}
+			}
+		}
+
+		#endregion
+
 		#region 438
 
 		public class Issue438


### PR DESCRIPTION
This adds test cases from two old issues, #430 and #432, which reveal some deficiencies in the current implementation of `ActionObserver`:

 * It cannot deal with proxyable types that do not have a parameterless ctor.
 * It trips up in debug mode when a base class ctor triggers virtual method calls.

This should fix both of those. Closes #430, closes #432.