### PR TITLE
Make `stringBuilder.AppendValueOf` safer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This release contains several **minor breaking changes**. Please review your cod
 * Use of `SetupSet` 'forgets' method setup (@TimothyHayes, #432)
 * Recursive mocks don't work with argument matching (@thalesmello, #142)
 * Recursive property setup overrides previous setups (@jamesfoster, #110)
+* Formatting of enumerable object for error message broke EF Core test case (@MichaelSagalovich, #741)
 
 
 ## 4.10.1 (2018-12-03)


### PR DESCRIPTION
...by only showing the first 10 items of enumerables for certain safe collection types (arrays and `List<T>`). It cannot be generally assumed that `IEnumerable` actually work.

I cannot easily add the test case provided in #741 to the regression test suite as it relies on EF Core, and the test project already uses EF, so we'd likely have type conflicts if both of them are referenced.

Closes #741.