### PR TITLE
Re-deprecate `MatcherAttribute`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 This release contains several **minor breaking changes**. Please review your code with respect to the following:
 
-* All custom argument matcher methods (including those using `Match.Create<T>`) must now be marked with the `[Matcher]` attribute. For this reason, `MatcherAttribute` is no longer marked obsolete (@stakx, #732)
 * Method overload resolution for `mock.Protected().Setup("VoidMethod", ...)`, `mock.Protected().Verify("VoidMethod", ...)` and `mock.Protected().Verify<TResult>("NonVoidMethod", ...)` may change due to a new overloads: If the first argument is a `bool`, make sure that argument gets interpreted as part of `args`, not as `exactParameterMatch` (see also *Added* section below). (@stakx & @Shereef, #751, #753)
 * `mock.Verify[All]` now performs a more thorough error aggregation. Error messages of inner/recursive mocks are included in the error message using indentation to show the relationship between mocks. (@stakx, #762)
 * `mock.Verify` no longer creates setups, nor will it override existing setups, as a side-effect of using a recursive expression. (@stakx, #765)

--- a/src/Moq/Capture.cs
+++ b/src/Moq/Capture.cs
@@ -28,7 +28,6 @@ namespace Moq
 		/// Assert.Equal("Hello!", parameters.Single());
 		/// </code>
 		/// </example>
-		[Matcher]
 		public static T In<T>(ICollection<T> collection)
 		{
 			var match = new CaptureMatch<T>(collection.Add);
@@ -52,7 +51,6 @@ namespace Moq
 		/// Assert.Equal("Hello!", parameters.Single());
 		/// </code>
 		/// </example>
-		[Matcher]
 		public static T In<T>(IList<T> collection, Expression<Func<T, bool>> predicate)
 		{
 			var match = new CaptureMatch<T>(collection.Add, predicate);
@@ -75,7 +73,6 @@ namespace Moq
 		/// Assert.Equal("Hello!", capturedValue);
 		/// </code>
 		/// </example>
-		[Matcher]
 		public static T With<T>(CaptureMatch<T> match)
 		{
 			return Match.Create(match);

--- a/src/Moq/ExpressionExtensions.cs
+++ b/src/Moq/ExpressionExtensions.cs
@@ -367,11 +367,14 @@ namespace Moq
 				case ExpressionType.Extension:
 					return !(expression is MatchExpression);
 
+#pragma warning disable 618
 				case ExpressionType.Call:
-					return !((MethodCallExpression)expression).Method.IsDefined(typeof(MatcherAttribute), true);
+					return !((MethodCallExpression)expression).Method.IsDefined(typeof(MatcherAttribute), true)
+						&& !expression.IsMatch(out _);
+#pragma warning restore 618
 
 				case ExpressionType.MemberAccess:
-					return !((MemberExpression)expression).Member.IsDefined(typeof(MatcherAttribute), true);
+					return !expression.IsMatch(out _);
 
 				default:
 					return true;

--- a/src/Moq/It.cs
+++ b/src/Moq/It.cs
@@ -32,7 +32,6 @@ namespace Moq
 		}
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsAny"]/*'/>
-		[Matcher]
 		public static TValue IsAny<TValue>()
 		{
 			return Match<TValue>.Create(
@@ -53,7 +52,6 @@ namespace Moq
 		}
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsNotNull"]/*'/>
-		[Matcher]
 		public static TValue IsNotNull<TValue>()
 		{
 			return Match<TValue>.Create(
@@ -68,7 +66,6 @@ namespace Moq
 
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.Is"]/*'/>
-		[Matcher]
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
 		public static TValue Is<TValue>(Expression<Func<TValue, bool>> match)
 		{
@@ -78,7 +75,6 @@ namespace Moq
 		}
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsInRange"]/*'/>
-		[Matcher]
 		public static TValue IsInRange<TValue>(TValue from, TValue to, Range rangeKind)
 			where TValue : IComparable
 		{
@@ -100,35 +96,30 @@ namespace Moq
 		}
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsIn(enumerable)"]/*'/>
-		[Matcher]
 		public static TValue IsIn<TValue>(IEnumerable<TValue> items)
 		{
 			return Match<TValue>.Create(value => items.Contains(value), () => It.IsIn(items));
 		}
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsIn(params)"]/*'/>
-		[Matcher]
 		public static TValue IsIn<TValue>(params TValue[] items)
 		{
 			return Match<TValue>.Create(value => items.Contains(value), () => It.IsIn(items));
 		}
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsNotIn(enumerable)"]/*'/>
-		[Matcher]
 		public static TValue IsNotIn<TValue>(IEnumerable<TValue> items)
 		{
 			return Match<TValue>.Create(value => !items.Contains(value), () => It.IsNotIn(items));
 		}
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsNotIn(params)"]/*'/>
-		[Matcher]
 		public static TValue IsNotIn<TValue>(params TValue[] items)
 		{
 			return Match<TValue>.Create(value => !items.Contains(value), () => It.IsNotIn(items));
 		}
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsRegex(regex)"]/*'/>
-		[Matcher]
 		public static string IsRegex(string regex)
 		{
 			Guard.NotNull(regex, nameof(regex));
@@ -141,7 +132,6 @@ namespace Moq
 		}
 
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsRegex(regex,options)"]/*'/>
-		[Matcher]
 		public static string IsRegex(string regex, RegexOptions options)
 		{
 			Guard.NotNull(regex, nameof(regex));

--- a/src/Moq/Match.cs
+++ b/src/Moq/Match.cs
@@ -17,7 +17,6 @@ namespace Moq
 		/// Provided for the sole purpose of rendering the delegate passed to the 
 		/// matcher constructor if no friendly render lambda is provided.
 		/// </devdoc>
-		[Matcher]
 		internal static TValue Matcher<TValue>()
 		{
 			return default(TValue);

--- a/src/Moq/Match.xdoc
+++ b/src/Moq/Match.xdoc
@@ -27,10 +27,9 @@
 			that returns a value from a call to <see cref="Match.Create{T}(Predicate{T})"/> with 
 			your matching condition and optional friendly render expression:
 			<code>
-				[Matcher]
 				public Order IsBigOrder()
 				{
-					return Match&lt;Order&gt;.Create(
+					return Match.Create&lt;Order&gt;(
 						o => o.GrandTotal &gt;= 5000, 
 						/* a friendly expression to render on failures */
 						() => IsBigOrder());
@@ -40,8 +39,7 @@
 			<code>
 				mock.Setup(m => m.Submit(IsBigOrder()).Throws&lt;UnauthorizedAccessException&gt;();
 			</code>
-			At runtime, Moq knows that the return value was a matcher (note that the method MUST be 
-			annotated with the [Matcher] attribute in order to determine this) and
+			At runtime, Moq knows that the return value was a matcher and
 			evaluates your predicate with the actual value passed into your predicate.
 			<para>
 				Another example might be a case where you want to match a lists of orders
@@ -50,10 +48,9 @@
 			<code>
 				public static class Orders
 				{
-					[Matcher]
 					public static IEnumerable&lt;Order&gt; Contains(Order order)
 					{
-						return Match&lt;IEnumerable&lt;Order&gt;&gt;.Create(orders => orders.Contains(order));
+						return Match.Create&lt;IEnumerable&lt;Order&gt;&gt;(orders => orders.Contains(order));
 					}
 				}
 			</code>

--- a/src/Moq/MatcherFactory.cs
+++ b/src/Moq/MatcherFactory.cs
@@ -105,26 +105,25 @@ namespace Moq
 
 			if (expression is MethodCallExpression call)
 			{
+				if (expression.IsMatch(out var match))
+				{
+					return match;
+				}
+
+#pragma warning disable 618
 				if (call.Method.IsDefined(typeof(MatcherAttribute), true))
 				{
-					if (expression.IsMatch(out var match))
-					{
-						return match;
-					}
-
 					return new MatcherAttributeMatcher(call);
 				}
+#pragma warning restore 618
 
 				return new LazyEvalMatcher(originalExpression);
 			}
 			else if (expression is MemberExpression memberAccess)
 			{
-				if (memberAccess.Member.IsDefined(typeof(MatcherAttribute), true))
+				if (expression.IsMatch(out var match))
 				{
-					if (expression.IsMatch(out var match))
-					{
-						return match;
-					}
+					return match;
 				}
 			}
 

--- a/src/Moq/Obsolete/MatcherAttribute.cs
+++ b/src/Moq/Obsolete/MatcherAttribute.cs
@@ -2,6 +2,7 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
+using System.ComponentModel;
 
 namespace Moq
 {
@@ -12,8 +13,9 @@ namespace Moq
 	/// </summary>
 	/// <remarks>
 	/// <para>
-	/// This attribute may be used in conjunction with <see cref="Match.Create{T}"/>,
-	/// or with the older mechanism described below.
+	/// <b>This feature has been deprecated in favor of the new 
+	/// and simpler <see cref="Match{T}"/>.
+	/// </b>
 	/// </para>
 	/// <para>
 	/// The argument matching is used to determine whether a concrete 
@@ -119,7 +121,9 @@ namespace Moq
 	/// // use mock, invoke Save, and have the matcher filter.
 	/// </code>
 	/// </example>
-	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = true)]
+	[AttributeUsage(AttributeTargets.Method, Inherited = true)]
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	[Obsolete("This feature has been deprecated in favor of `Match.Create`.")]
 	public sealed class MatcherAttribute : Attribute
 	{
 	}

--- a/tests/Moq.Tests/CustomMatcherFixture.cs
+++ b/tests/Moq.Tests/CustomMatcherFixture.cs
@@ -31,13 +31,11 @@ namespace Moq.Tests
 			Assert.True(mock.Object.Do(5));
 		}
 
-		[Matcher]
 		public TValue Any<TValue>()
 		{
 			return Match.Create<TValue>(v => true);
 		}
 
-		[Matcher]
 		public TValue Between<TValue>(TValue from, TValue to, Range rangeKind)
 			where TValue : IComparable
 		{
@@ -92,10 +90,8 @@ namespace Moq.Tests
 
 		public class Toy
 		{
-			[Matcher]
 			public static Toy IsRed => Match.Create((Toy toy) => toy.Color == "red");
 
-			[Matcher]
 			public static Toy IsGreen() => Match.Create((Toy toy) => toy.Color == "green");
 
 			public string Color { get; set; }

--- a/tests/Moq.Tests/ExtensibilityFixture.cs
+++ b/tests/Moq.Tests/ExtensibilityFixture.cs
@@ -91,7 +91,6 @@ namespace Moq.Tests
 
 	public static class Orders
 	{
-		[Matcher]
 		public static IEnumerable<Order> Contains(Order order)
 		{
 			return Match.Create<IEnumerable<Order>>(orders => orders.Contains(order));
@@ -110,14 +109,11 @@ namespace Moq.Tests
 	{
 		public int Amount { get; set; }
 
-		[Matcher]
 		public static Order IsBig()
 		{
 			return Match.Create<Order>(o => o.Amount >= 1000, () => Order.IsBig());
 		}
 
-
-		[Matcher]
 		public static Order IsSmall => Match.Create<Order>(o => o.Amount <= 1000);
 	}
 }

--- a/tests/Moq.Tests/Linq/SupportedQuerying.cs
+++ b/tests/Moq.Tests/Linq/SupportedQuerying.cs
@@ -237,7 +237,6 @@ namespace Moq.Tests.Linq
 				Assert.Equal("foo", foo.Do(5));
 			}
 
-			[Matcher]
 			public TValue Any<TValue>()
 			{
 				return Match.Create<TValue>(v => true);

--- a/tests/Moq.Tests/MatcherAttributeFixture.cs
+++ b/tests/Moq.Tests/MatcherAttributeFixture.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace Moq.Tests
 {
+	[Obsolete("This fixture contains tests related to `" + nameof(MatcherAttribute) + "`, which is obsolete.")]
 	public class MatcherAttributeFixture
 	{
 		public interface IFoo

--- a/tests/Moq.Tests/MockFixture.cs
+++ b/tests/Moq.Tests/MockFixture.cs
@@ -704,7 +704,6 @@ namespace Moq.Tests
 			Assert.Equal(3, mock.Object.Echo(3));
 		}
 
-		[Matcher]
 		private int IsMultipleOf(int value)
 		{
 			return Match.Create<int>(i => i % value == 0);

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2558,6 +2558,9 @@ namespace Moq.Tests.Regressions
 		#region #49
 
 		[Fact]
+#pragma warning disable 618
+		[Obsolete("This test is related to `" + nameof(MatcherAttribute) + "`, which is obsolete.")]
+#pragma warning restore 618
 		public void UsesCustomMatchersWithGenerics()
 		{
 			var mock = new Mock<IEvaluateLatest>();
@@ -2569,6 +2572,7 @@ namespace Moq.Tests.Regressions
 			Assert.Equal(2, mock.Object.Method(6));
 		}
 
+		[Obsolete("This class contains matchers using `" + nameof(MatcherAttribute) + "`, which is obsolete.")]
 		public static class IsEqual
 		{
 			[Matcher]


### PR DESCRIPTION
As announced in #770, this is a partial revert of #732 in order to reduce the amount of breaking changes in the next release.

Making the `[Matcher]` attribute mandatory on *all* matchers is no longer necessary to fix #725. This is because `MatcherObserver` (which used to be `AmbientObserver`) is no longer tied into the mock interception pipeline and therefore doesn't affect their behavior, and it has been made reentrant in #769.

Closes #770.