### PR TITLE
Use portable PDB in separate NuGet symbol package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 ## Unreleased
 
+#### Changed
+
+* Debug symbols (`Moq.pdb`) have moved into a separate NuGet symbol package (as per the current official [guideline](https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg)). If you want the Visual Studio debugger to step into Moq's source code, disable Just My Code, enable SourceLink, and configure [NuGet's symbol server](https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg#nugetorg-symbol-server). (@stakx, #789)
+
 #### Fixed
 
 * Regression: Unhelpful exception message when setting up an indexer with `SetupProperty` (@stakx, #823)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,6 @@ deploy:
   - provider: NuGet
     api_key:
       secure: 7MS5+XWaFchMXFqzgneQCqo9U0DlxiPXe/KWWUnbCBDEizVn06EjdQZkWu1gbNOJ
-    artifact: Package
     on:
       appveyor_repo_tag: true
 
@@ -24,5 +23,5 @@ nuget:
   project_feed: true
 
 artifacts:
-  - path: out\*.nupkg
-    name: Package
+  - path: 'out\*.nupkg'
+  - path: 'out\*.snupkg'

--- a/build/SourceLink.props
+++ b/build/SourceLink.props
@@ -2,11 +2,11 @@
 
 	<PropertyGroup>
 		<MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-		<SourceLinkCreate Condition="'$(BuildingInsideVisualStudio)' != 'True'">True</SourceLinkCreate>
+		<PublishRepositoryUrl>True</PublishRepositoryUrl>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="SourceLink.Create.CommandLine" Version="2.7.3" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All"/>
 	</ItemGroup>
 
 </Project>

--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -9,7 +9,7 @@
 		<TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
 		<AssemblyName>Moq</AssemblyName>
 		<DebugSymbols>True</DebugSymbols>
-		<DebugType>full</DebugType>
+		<DebugType>portable</DebugType>
 		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile> 
 		<GenerateDocumentation>true</GenerateDocumentation>
 		<NoWarn>0419</NoWarn>
@@ -33,6 +33,8 @@
 		<PackageOutputPath>$(OutputDirectory)</PackageOutputPath>
 		<PackageTags>moq;tdd;mocking;mocks;unittesting;agile;unittest</PackageTags>
 		<RepositoryUrl>https://github.com/moq/moq4</RepositoryUrl>
+		<IncludeSymbols>True</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -37,7 +37,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Castle.Core" Version="4.4.0" />
-		<PackageReference Include="IFluentInterface" Version="2.1.0" />
+		<PackageReference Include="IFluentInterface" Version="2.1.0" PrivateAssets="All" />
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
 		<PackageReference Include="TypeNameFormatter.Sources" Version="1.0.0" PrivateAssets="All" />
 	</ItemGroup>

--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -50,11 +50,6 @@
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
 		<PackageReference Include="TypeNameFormatter.Sources" Version="1.0.0" PrivateAssets="All" />
 	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Xml" />
-	</ItemGroup>
 
 	<ItemGroup>
 		<EmbeddedResource Update="Properties\Resources.resx">

--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -21,11 +21,18 @@
 
 	<PropertyGroup>
 		<!-- Properties related to NuGet packaging: -->
-		<IncludeBuildOutput>False</IncludeBuildOutput>
+		<IsPackable>True</IsPackable>
+		<PackageId>Moq</PackageId>
+		<Title>Moq: an enjoyable mocking library</Title>
+		<Description>Moq is the most popular and friendly mocking framework for .NET.</Description>
+		<PackageReleaseNotes>A changelog is available at https://github.com/moq/moq4/blob/master/CHANGELOG.md.</PackageReleaseNotes>
+		<Authors>Daniel Cazzulino, kzu</Authors>
+		<PackageLicenseUrl>https://raw.githubusercontent.com/moq/moq4/master/License.txt</PackageLicenseUrl>
+		<PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
 		<NoPackageAnalysis>True</NoPackageAnalysis>
-		<NuspecFile>Moq.nuspec</NuspecFile>
-		<NuspecBasePath>$(MSBuildThisFileDirectory)</NuspecBasePath>
 		<PackageOutputPath>$(OutputDirectory)</PackageOutputPath>
+		<PackageTags>moq;tdd;mocking;mocks;unittesting;agile;unittest</PackageTags>
+		<RepositoryUrl>https://github.com/moq/moq4</RepositoryUrl>
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">


### PR DESCRIPTION
We want to continue publishing SourceLink-ed debug symbols, but using classic Windows PDBs generates a huge package. Using the much smaller portable PDB format would be much better, but some people may still experience problems with those. (See e.g. GitHub issue #428.)

Let's follow the official guidance (see links below) and publish debug symbols in a separate `.snupkg` package to NuGet's symbol server. This means that we can (must, in fact) use portable PDBs as it will be the consumers' choice whether to use the separate symbols or not.

Closes #447.

References:
 * https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg
 * https://github.com/dotnet/SourceLink#alternative-pdb-distribution