### PR TITLE
add It.Ignore for AnyMatcher

### DIFF
--- a/src/Moq/It.cs
+++ b/src/Moq/It.cs
@@ -51,6 +51,12 @@ namespace Moq
 			return Expression.Call(It.isAnyMethod.MakeGenericMethod(genericArgument));
 		}
 
+		/// <include file='It.xdoc' path='docs/doc[@for="It.Ignore"]/*'/>
+		public static TValue Ignore<TValue>()
+		{
+			return Match<TValue>.Create<TValue>(null, () => It.Ignore<TValue>());
+		}
+
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsNotNull"]/*'/>
 		public static TValue IsNotNull<TValue>()
 		{

--- a/src/Moq/It.xdoc
+++ b/src/Moq/It.xdoc
@@ -28,6 +28,22 @@
 		</example>
 		<typeparam name="TValue">Type of the value.</typeparam>
 	</doc>
+	<doc for="It.Ignore">
+		<summary>
+			Ignores any type or value.
+		</summary>
+		<remarks>
+			Typically used when the actual argument type for the method is 
+			internal or private.
+		</remarks>
+		<example>
+			<code>
+				// Verifies that a call to the logger was made for severity Warning, regardless of the actual log formatter.
+				mock.Verify(x => x.Log(LogLevel.Warning, It.IsAny&lt;EventId&gt;(), It.IsAny&lt;object&gt;(), It.IsAny&lt;Exception&gt;(), It.Ignore&lt;Func&lt;object, Exception, string&gt;&gt;()));
+			</code>
+		</example>
+		<typeparam name="TValue">Type of the value.</typeparam>
+	</doc>
 	<doc for="It.IsNotNull">
 		<summary>
 			Matches any value of the given <typeparamref name="TValue"/> type, except null.

--- a/src/Moq/MatcherFactory.cs
+++ b/src/Moq/MatcherFactory.cs
@@ -32,6 +32,14 @@ namespace Moq
 
 		public static IMatcher CreateMatcher(Expression argument, ParameterInfo parameter)
 		{
+			if (argument is MethodCallExpression methodCallExpression)
+			{
+				if (methodCallExpression.Method.Name == nameof(It.Ignore))
+				{
+					return AnyMatcher.Instance;
+				}
+			}
+
 			if (parameter.ParameterType.IsByRef)
 			{
 				if ((parameter.Attributes & (ParameterAttributes.In | ParameterAttributes.Out)) == ParameterAttributes.Out)


### PR DESCRIPTION
While experimenting with .NET Core 3.0 preview I ran into a problem where they were no longer boxing an internal class to `object` to the `ILogger.Log<TState>` abstraction. This means that I can no longer `Setup` or `Verify` against that abstraction, since `It.IsAny<>()` has to exactly match the invocation types. See https://github.com/aspnet/Extensions/issues/1319 for the details on this. And really, as we discover more changes in 3.0 Preview I expect to see more of these decisions impacting us.

The only solution I can think of is to have a way to completely short-circuit on specific parameters (who's types you cannot see) by explicitly choosing to do so via a new `It.Ignore<>()` method.

I don't expect you to merge this in to 4.0 at all, but rather to see it as a feature request for 5.0 via implementation. However if 3.0 is finalized and lands before Moq 5.0 ships I expect a few projects will be broken when they upgrade. At least then you'll have this to decide to include or not.