### PR TITLE
Keep `InvocationShape` argument matchers & expressions in sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ This release contains several **minor breaking changes**. Please review your cod
 * Recursive mocks don't work with argument matching (@thalesmello, #142)
 * Recursive property setup overrides previous setups (@jamesfoster, #110)
 * Formatting of enumerable object for error message broke EF Core test case (@MichaelSagalovich, #741)
+* `Verify[All]` fails because of lazy (instead of eager) setup argument expression evaluation (@aeslinger, #711)
 
 
 ## 4.10.1 (2018-12-03)

--- a/src/Moq/InvocationShape.cs
+++ b/src/Moq/InvocationShape.cs
@@ -40,10 +40,15 @@ namespace Moq
 
 			this.Expression = expression;
 			this.Method = method;
-			this.Arguments = arguments ?? noArguments;
-
-			this.argumentMatchers = arguments != null ? MatcherFactory.CreateMatchers(arguments, method.GetParameters())
-			                                          : noArgumentMatchers;
+			if (arguments != null)
+			{
+				(this.argumentMatchers, this.Arguments) = MatcherFactory.CreateMatchers(arguments, method.GetParameters());
+			}
+			else
+			{
+				this.argumentMatchers = noArgumentMatchers;
+				this.Arguments = noArguments;
+			}
 		}
 
 		public void Deconstruct(out LambdaExpression expression, out MethodInfo method, out IReadOnlyList<Expression> arguments)

--- a/src/Moq/Matchers/ParamArrayMatcher.cs
+++ b/src/Moq/Matchers/ParamArrayMatcher.cs
@@ -16,7 +16,7 @@ namespace Moq.Matchers
 			if (expression != null)
 			{
 				this.matchers = expression.Expressions
-					.Select(e => MatcherFactory.CreateMatcher(e)).ToArray();
+					.Select(e => MatcherFactory.CreateMatcher(e).Item1).ToArray();
 			}
 			else
 			{

--- a/src/Moq/Matchers/ParamArrayMatcher.cs
+++ b/src/Moq/Matchers/ParamArrayMatcher.cs
@@ -2,8 +2,7 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
+using System.Diagnostics;
 
 namespace Moq.Matchers
 {
@@ -11,17 +10,11 @@ namespace Moq.Matchers
 	{
 		private IMatcher[] matchers;
 
-		public ParamArrayMatcher(NewArrayExpression expression)
+		public ParamArrayMatcher(IMatcher[] matchers)
 		{
-			if (expression != null)
-			{
-				this.matchers = expression.Expressions
-					.Select(e => MatcherFactory.CreateMatcher(e).Item1).ToArray();
-			}
-			else
-			{
-				this.matchers = new IMatcher[0];
-			}
+			Debug.Assert(matchers != null);
+
+			this.matchers = matchers;
 		}
 
 		public bool Matches(object value)

--- a/src/Moq/Pair.cs
+++ b/src/Moq/Pair.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+namespace Moq
+{
+	internal readonly struct Pair<T1, T2>
+	{
+		public readonly T1 Item1;
+		public readonly T2 Item2;
+
+		public Pair(T1 item1, T2 item2)
+		{
+			this.Item1 = item1;
+			this.Item2 = item2;
+		}
+
+		public void Deconstruct(out T1 item1, out T2 item2)
+		{
+			item1 = this.Item1;
+			item2 = this.Item2;
+		}
+	}
+}

--- a/tests/Moq.Tests/MatchExpressionFixture.cs
+++ b/tests/Moq.Tests/MatchExpressionFixture.cs
@@ -95,7 +95,7 @@ namespace Moq.Tests
 			var expression = GetExpression();
 			var matchExpression = FindMatchExpression(expression);
 			Debug.Assert(matchExpression != null);
-			var matcher = MatcherFactory.CreateMatcher(matchExpression);
+			var (matcher, _) = MatcherFactory.CreateMatcher(matchExpression);
 			Assert.IsType<Match<int>>(matcher);
 		}
 

--- a/tests/Moq.Tests/Matchers/AnyMatcherFixture.cs
+++ b/tests/Moq.Tests/Matchers/AnyMatcherFixture.cs
@@ -15,7 +15,7 @@ namespace Moq.Tests.Matchers
 		{
 			var expr = ToExpression<object>(() => It.IsAny<object>()).Body;
 
-			var matcher = MatcherFactory.CreateMatcher(expr);
+			var (matcher, _) = MatcherFactory.CreateMatcher(expr);
 
 			Assert.True(matcher.Matches(null));
 		}
@@ -25,7 +25,7 @@ namespace Moq.Tests.Matchers
 		{
 			var expr = ToExpression<object>(() => It.IsAny<object>()).Body;
 
-			var matcher = MatcherFactory.CreateMatcher(expr);
+			var (matcher, _) = MatcherFactory.CreateMatcher(expr);
 
 			Assert.True(matcher.Matches("foo"));
 		}
@@ -35,7 +35,7 @@ namespace Moq.Tests.Matchers
 		{
 			var expr = ToExpression<IDisposable>(() => It.IsAny<IDisposable>()).Body;
 
-			var matcher = MatcherFactory.CreateMatcher(expr);
+			var (matcher, _) = MatcherFactory.CreateMatcher(expr);
 
 			Assert.True(matcher.Matches(new Disposable()));
 		}
@@ -45,7 +45,7 @@ namespace Moq.Tests.Matchers
 		{
 			var expr = ToExpression<IFormatProvider>(() => It.IsAny<IFormatProvider>()).Body;
 
-			var matcher = MatcherFactory.CreateMatcher(expr);
+			var (matcher, _) = MatcherFactory.CreateMatcher(expr);
 
 			Assert.False(matcher.Matches("foo"));
 		}

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2339,6 +2339,38 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 711
+
+		public class Issue711
+		{
+			[Fact]
+			public void Argument_expression_does_not_get_reevaluated_by_VerifyAll()
+			{
+				int? x = 1;
+				var mock = new Mock<Action<int?>>();
+				mock.Setup(m => m(x.Value));
+				mock.Object(1);
+				x = null; // if the argument expression `x.Value` got reevaluated by VerifyAll,
+				          // we'd expect to see a `NullReferenceException`.
+				mock.VerifyAll();
+			}
+
+			[Fact]
+			public void Argument_expression_of_overriding_setup_does_not_get_reevaluated_by_VerifyAll()
+			{
+				int? x = 1;
+				var mock = new Mock<Action<int?>>();
+				mock.Setup(m => m(1));  // only difference to the above test, and one would
+				                        // think that this won't change anything.
+				mock.Setup(m => m(x.Value));
+				mock.Object(1);
+				x = null;
+				mock.VerifyAll();
+			}
+		}
+
+		#endregion
+
 		#region 725
 
 		public sealed class Issue725


### PR DESCRIPTION
Fixes #711. See explanation in https://github.com/moq/moq4/issues/711#issuecomment-433386423 as well as in commit messages for details.