### PR TITLE
Match indexers used as arguments in setup expression eagerly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This release contains several **minor breaking changes**. Please review your cod
 * `mock.Verify` no longer creates setups, nor will it override existing setups, as a side-effect of using a recursive expression. (@stakx, #765)
 * More accurate detection of argument matchers with `SetupSet` and `VerifySet`, especially when used in fluent setup expressions or with indexers (@stakx, #767)
 * `mock.Verify(expression)` error messages now contain a full listing of all invocations that occurred across all involved mocks. Setups are no longer listed, since they are completely irrelevant in the context of call verification. (@stakx, #779, #780)
+* Indexers used as arguments in setup expressions are now eagerly evaluated, like all other properties already are (except when they refer to matchers) (@stakx, #794)
 
 #### Added
 
@@ -44,6 +45,7 @@ This release contains several **minor breaking changes**. Please review your cod
 * Recursive property setup overrides previous setups (@jamesfoster, #110)
 * Formatting of enumerable object for error message broke EF Core test case (@MichaelSagalovich, #741)
 * `Verify[All]` fails because of lazy (instead of eager) setup argument expression evaluation (@aeslinger, #711)
+* `ArgumentOutOfRangeException` when setup expression contains indexer access (@mosentok, #714)
 
 
 ## 4.10.1 (2018-12-03)

--- a/src/Moq/MatcherFactory.cs
+++ b/src/Moq/MatcherFactory.cs
@@ -132,9 +132,13 @@ namespace Moq
 				}
 #pragma warning restore 618
 
-				return new Pair<IMatcher, Expression>(new LazyEvalMatcher(originalExpression), originalExpression);
+				var method = call.Method;
+				if (!method.IsPropertyGetter() && !method.IsPropertyIndexerGetter())
+				{
+					return new Pair<IMatcher, Expression>(new LazyEvalMatcher(originalExpression), originalExpression);
+				}
 			}
-			else if (expression is MemberExpression memberAccess)
+			else if (expression is MemberExpression || expression is IndexExpression)
 			{
 				if (expression.IsMatch(out var match))
 				{

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2371,6 +2371,31 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 714
+
+		public class Issue714
+		{
+			[Fact]
+			public void Setup_argument_using_indexer_should_be_evaluated_eagerly()
+			{
+				Mock<IMockable> mock = new Mock<IMockable>();
+				var args = new List<object> { new object() };
+				for (var i = 0; i < args.Count; i++)
+				{
+					mock.Setup(m => m.Method(args[i]));
+				}
+
+				mock.Object.Method(args[0]);
+			}
+
+			public interface IMockable
+			{
+				void Method(object arg);
+			}
+		}
+
+		#endregion
+
 		#region 725
 
 		public sealed class Issue725


### PR DESCRIPTION
This resolves #714.

It doesn't make sense for indexers to be matched lazily when other properties are being matched eagerly, so this will make Moq a little more consistent.

(While technically a small breaking change, making it anyway seems permissible because Moq has neglected indexers far too long and essentially left its behavior regarding them semi-unspecified.)