### PR TITLE
Fix implementation of `Times.Equals`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ This release contains several **minor breaking changes**. Please review your cod
 * Formatting of enumerable object for error message broke EF Core test case (@MichaelSagalovich, #741)
 * `Verify[All]` fails because of lazy (instead of eager) setup argument expression evaluation (@aeslinger, #711)
 * `ArgumentOutOfRangeException` when setup expression contains indexer access (@mosentok, #714)
+* Incorrect implementation of `Times.Equals` (@stakx, #805)
 
 
 ## 4.10.1 (2018-12-03)

--- a/src/Moq/Times.cs
+++ b/src/Moq/Times.cs
@@ -8,7 +8,7 @@ using Moq.Properties;
 namespace Moq
 {
 	/// <include file='Times.xdoc' path='docs/doc[@for="Times"]/*'/>
-	public struct Times
+	public struct Times : IEquatable<Times>
 	{
 		private int from;
 		private int to;
@@ -87,16 +87,23 @@ namespace Moq
 			return new Times(Kind.Once, 1, 1);
 		}
 
+		/// <summary>
+		///   Returns a value indicating whether this instance is equal to a specified <see cref="Times"/> value.
+		/// </summary>
+		/// <param name="other">A <see cref="Times"/> value to compare to this instance.</param>
+		/// <returns>
+		///   <see langword="true"/> if <paramref name="other"/> has the same value as this instance;
+		///   otherwise, <see langword="true"/>.
+		/// </returns>
+		public bool Equals(Times other)
+		{
+			return this.from == other.from && this.to == other.to;
+		}
+
 		/// <include file='Times.xdoc' path='docs/doc[@for="Times.Equals"]/*'/>
 		public override bool Equals(object obj)
 		{
-			if (obj is Times)
-			{
-				var other = (Times)obj;
-				return this.from == other.from && this.to == other.to;
-			}
-
-			return false;
+			return obj is Times other && this.Equals(other);
 		}
 
 		/// <include file='Times.xdoc' path='docs/doc[@for="Times.GetHashCode"]/*'/>

--- a/src/Moq/Times.cs
+++ b/src/Moq/Times.cs
@@ -10,17 +10,15 @@ namespace Moq
 	/// <include file='Times.xdoc' path='docs/doc[@for="Times"]/*'/>
 	public struct Times
 	{
-		private string messageFormat;
 		private int from;
 		private int to;
 		private Kind kind;
 
-		private Times(Kind kind, int from, int to, string messageFormat)
+		private Times(Kind kind, int from, int to)
 		{
-			this.kind = kind;
 			this.from = from;
 			this.to = to;
-			this.messageFormat = messageFormat;
+			this.kind = kind;
 		}
 
 		/// <include file='Times.xdoc' path='docs/doc[@for="Times.AtLeast"]/*'/>
@@ -28,13 +26,13 @@ namespace Moq
 		{
 			Guard.NotOutOfRangeInclusive(callCount, 1, int.MaxValue, nameof(callCount));
 
-			return new Times(Kind.AtLeast, callCount, int.MaxValue, Resources.NoMatchingCallsAtLeast);
+			return new Times(Kind.AtLeast, callCount, int.MaxValue);
 		}
 
 		/// <include file='Times.xdoc' path='docs/doc[@for="Times.AtLeastOnce"]/*'/>
 		public static Times AtLeastOnce()
 		{
-			return new Times(Kind.AtLeastOnce, 1, int.MaxValue, Resources.NoMatchingCallsAtLeastOnce);
+			return new Times(Kind.AtLeastOnce, 1, int.MaxValue);
 		}
 
 		/// <include file='Times.xdoc' path='docs/doc[@for="Times.AtMost"]/*'/>
@@ -42,13 +40,13 @@ namespace Moq
 		{
 			Guard.NotOutOfRangeInclusive(callCount, 0, int.MaxValue, nameof(callCount));
 
-			return new Times(Kind.AtMost, 0, callCount, Resources.NoMatchingCallsAtMost);
+			return new Times(Kind.AtMost, 0, callCount);
 		}
 
 		/// <include file='Times.xdoc' path='docs/doc[@for="Times.AtMostOnce"]/*'/>
 		public static Times AtMostOnce()
 		{
-			return new Times(Kind.AtMostOnce, 0, 1, Resources.NoMatchingCallsAtMostOnce);
+			return new Times(Kind.AtMostOnce, 0, 1);
 		}
 
 		/// <include file='Times.xdoc' path='docs/doc[@for="Times.Between"]/*'/>
@@ -62,19 +60,11 @@ namespace Moq
 					throw new ArgumentOutOfRangeException("callCountTo");
 				}
 
-				return new Times(
-					Kind.BetweenExclusive,
-					callCountFrom + 1,
-					callCountTo - 1,
-					Resources.NoMatchingCallsBetweenExclusive);
+				return new Times(Kind.BetweenExclusive, callCountFrom + 1, callCountTo - 1);
 			}
 
 			Guard.NotOutOfRangeInclusive(callCountFrom, 0, callCountTo, nameof(callCountFrom));
-			return new Times(
-				Kind.BetweenInclusive,
-				callCountFrom,
-				callCountTo,
-				Resources.NoMatchingCallsBetweenInclusive);
+			return new Times(Kind.BetweenInclusive, callCountFrom, callCountTo);
 		}
 
 		/// <include file='Times.xdoc' path='docs/doc[@for="Times.Exactly"]/*'/>
@@ -82,19 +72,19 @@ namespace Moq
 		{
 			Guard.NotOutOfRangeInclusive(callCount, 0, int.MaxValue, nameof(callCount));
 
-			return new Times(Kind.Exactly, callCount, callCount, Resources.NoMatchingCallsExactly);
+			return new Times(Kind.Exactly, callCount, callCount);
 		}
 
 		/// <include file='Times.xdoc' path='docs/doc[@for="Times.Never"]/*'/>
 		public static Times Never()
 		{
-			return new Times(Kind.Never, 0, 0, Resources.NoMatchingCallsNever);
+			return new Times(Kind.Never, 0, 0);
 		}
 
 		/// <include file='Times.xdoc' path='docs/doc[@for="Times.Once"]/*'/>
 		public static Times Once()
 		{
-			return new Times(Kind.Once, 1, 1, Resources.NoMatchingCallsOnce);
+			return new Times(Kind.Once, 1, 1);
 		}
 
 		/// <include file='Times.xdoc' path='docs/doc[@for="Times.Equals"]/*'/>
@@ -132,9 +122,23 @@ namespace Moq
 			var from = this.kind == Kind.BetweenExclusive ? this.from - 1 : this.from;
 			var to   = this.kind == Kind.BetweenExclusive ? this.to   + 1 : this.to;
 
+			string message = null;
+			switch (this.kind)
+			{
+				case Kind.AtLeast:          message = Resources.NoMatchingCallsAtLeast; break;
+				case Kind.AtLeastOnce:      message = Resources.NoMatchingCallsAtLeastOnce; break;
+				case Kind.AtMost:           message = Resources.NoMatchingCallsAtMost; break;
+				case Kind.AtMostOnce:       message = Resources.NoMatchingCallsAtMostOnce; break;
+				case Kind.BetweenExclusive: message = Resources.NoMatchingCallsBetweenExclusive; break;
+				case Kind.BetweenInclusive: message = Resources.NoMatchingCallsBetweenInclusive; break;
+				case Kind.Exactly:          message = Resources.NoMatchingCallsExactly; break;
+				case Kind.Once:             message = Resources.NoMatchingCallsOnce; break;
+				case Kind.Never:            message = Resources.NoMatchingCallsNever; break;
+			}
+
 			return string.Format(
 				CultureInfo.CurrentCulture,
-				this.messageFormat,
+				message,
 				failMessage,
 				expression,
 				from,

--- a/src/Moq/Times.cs
+++ b/src/Moq/Times.cs
@@ -8,11 +8,11 @@ using Moq.Properties;
 namespace Moq
 {
 	/// <include file='Times.xdoc' path='docs/doc[@for="Times"]/*'/>
-	public struct Times : IEquatable<Times>
+	public readonly struct Times : IEquatable<Times>
 	{
-		private int from;
-		private int to;
-		private Kind kind;
+		private readonly int from;
+		private readonly int to;
+		private readonly Kind kind;
 
 		private Times(Kind kind, int from, int to)
 		{

--- a/src/Moq/Times.cs
+++ b/src/Moq/Times.cs
@@ -64,8 +64,8 @@ namespace Moq
 
 				return new Times(
 					Kind.BetweenExclusive,
-					callCountFrom,
-					callCountTo,
+					callCountFrom + 1,
+					callCountTo - 1,
 					Resources.NoMatchingCallsBetweenExclusive);
 			}
 
@@ -129,20 +129,22 @@ namespace Moq
 
 		internal string GetExceptionMessage(string failMessage, string expression, int callCount)
 		{
+			var from = this.kind == Kind.BetweenExclusive ? this.from - 1 : this.from;
+			var to   = this.kind == Kind.BetweenExclusive ? this.to   + 1 : this.to;
+
 			return string.Format(
 				CultureInfo.CurrentCulture,
 				this.messageFormat,
 				failMessage,
 				expression,
-				this.from,
-				this.to,
+				from,
+				to,
 				callCount);
 		}
 
 		internal bool Verify(int callCount)
 		{
-			return this.kind == Kind.BetweenExclusive ? this.from <  callCount && callCount <  this.to
-			                                          : this.from <= callCount && callCount <= this.to;
+			return this.from <= callCount && callCount <= this.to;
 		}
 
 		private enum Kind

--- a/tests/Moq.Tests/TimesFixture.cs
+++ b/tests/Moq.Tests/TimesFixture.cs
@@ -171,5 +171,40 @@ namespace Moq.Tests
 			Assert.True(target.Verify(1));
 			Assert.False(target.Verify(int.MaxValue));
 		}
+
+		public class Equality
+		{
+			[Fact]
+			public void AtMostOnce_equals_Between_0_1_inclusive()
+			{
+				Assert.Equal(Times.AtMostOnce(), Times.Between(0, 1, Range.Inclusive));
+			}
+
+			[Fact]
+			public void Between_1_2_inclusive_equals_Between_0_3_exclusive()
+			{
+				Assert.Equal(Times.Between(2, 3, Range.Inclusive), Times.Between(1, 4, Range.Exclusive));
+			}
+
+			[Fact]
+			public void Once_equals_Once()
+			{
+				Assert.Equal(Times.Once(), Times.Once());
+			}
+
+			[Fact]
+			public void Once_equals_Exactly_1()
+			{
+				Assert.Equal(Times.Once(), Times.Exactly(1));
+			}
+
+			[Fact]
+			public void Between_x_y_inclusive_does_not_equal_Between_x_y_exclusive()
+			{
+				const int x = 1;
+				const int y = 10;
+				Assert.NotEqual(Times.Between(x, y, Range.Inclusive), Times.Between(x, y, Range.Exclusive));
+			}
+		}
 	}
 }


### PR DESCRIPTION
Closes #805 (and applies some minor cleanup refactoring to `Times` while we're at it).