### PR TITLE
Add ToString() for fluent setup API objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ This release contains several **minor breaking changes**. Please review your cod
 * `Verify[All]` fails because of lazy (instead of eager) setup argument expression evaluation (@aeslinger, #711)
 * `ArgumentOutOfRangeException` when setup expression contains indexer access (@mosentok, #714)
 * Incorrect implementation of `Times.Equals` (@stakx, #805)
-
+* Calling `ToString()` on `SetupPhrase` does not return expression (@jacob-ewald, #810)
 
 ## 4.10.1 (2018-12-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ This release contains several **minor breaking changes**. Please review your cod
 * `Verify[All]` fails because of lazy (instead of eager) setup argument expression evaluation (@aeslinger, #711)
 * `ArgumentOutOfRangeException` when setup expression contains indexer access (@mosentok, #714)
 * Incorrect implementation of `Times.Equals` (@stakx, #805)
-* Calling `ToString()` on `SetupPhrase` does not return expression (@jacob-ewald, #810)
+
 
 ## 4.10.1 (2018-12-03)
 

--- a/src/Moq/Language/Flow/SetupPhrase.cs
+++ b/src/Moq/Language/Flow/SetupPhrase.cs
@@ -162,5 +162,10 @@ namespace Moq.Language.Flow
 		{
 			this.setup.Verifiable(failMessage);
 		}
+
+		public override string ToString()
+		{
+			return setup.Expression.ToStringFixed();
+		}
 	}
 }

--- a/src/Moq/Language/Flow/SetupSequencePhrase.cs
+++ b/src/Moq/Language/Flow/SetupSequencePhrase.cs
@@ -37,6 +37,11 @@ namespace Moq.Language.Flow
 			this.setup.AddThrows(exception);
 			return this;
 		}
+
+		public override string ToString()
+		{
+			return setup.Expression.ToStringFixed();
+		}
 	}
 
 	internal sealed class SetupSequencePhrase<TResult> : ISetupSequentialResult<TResult>
@@ -86,5 +91,10 @@ namespace Moq.Language.Flow
 		public ISetupSequentialResult<TResult> Throws<TException>()
 			where TException : Exception, new()
 			=> this.Throws(new TException());
+
+		public override string ToString()
+		{
+			return setup.Expression.ToStringFixed();
+		}
 	}
 }

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2475,35 +2475,35 @@ namespace Moq.Tests.Regressions
 			[Fact]
 			public void VoidSetupPhraseConvertsExpressionToDescriptiveString()
 			{
-				var voidSetupPhrase = new Mock<IFoo>().Setup(x => x.DoThings(null));
+				var voidSetup = new Mock<IFoo>().Setup(x => x.DoThings(null));
 
-				Assert.Equal("x => x.DoThings(null)", voidSetupPhrase.ToString());
+				Assert.Equal("x => x.DoThings(null)", voidSetup.ToString());
 			}
 
 			[Fact]
 			public void NonVoidSetupPhraseConvertsExpressionToDescriptiveString()
 			{
-				var nonVoidSetupPhrase = new Mock<IFoo>().Setup(x => x.Property1);
+				var nonVoidSetup = new Mock<IFoo>().Setup(x => x.Property1);
 
-				Assert.Equal("x => x.Property1", nonVoidSetupPhrase.ToString());
+				Assert.Equal("x => x.Property1", nonVoidSetup.ToString());
 			}
 
 			[Fact]
 			public void SetterSetupPhraseConvertsExpressionToDescriptiveString()
 			{
-				var setterSetupPhrase = new Mock<IFoo>().SetupSet<object>(x => x.Property1 = null);
+				var setterSetup = new Mock<IFoo>().SetupSet<object>(x => x.Property1 = null);
 
-				Assert.Equal("x => x.Property1 = null", setterSetupPhrase.ToString());
+				Assert.Equal("x => x.Property1 = null", setterSetup.ToString());
 			}
 
 			[Fact]
 			public void SetupSequencePhraseConvertsExpressionToDescriptiveString()
 			{
-				var setupSequencePhrase = new Mock<IFoo>().SetupSequence(x => x.DoThings(null));
-				var setupGenericSequencePhrase = new Mock<IFoo>().SetupSequence(x => x.DoThings<object>(null));
+				var setupSequence = new Mock<IFoo>().SetupSequence(x => x.DoThings(null));
+				var setupGenericSequence = new Mock<IFoo>().SetupSequence(x => x.DoThings<object>(null));
 
-				Assert.Equal("x => x.DoThings(null)", setupSequencePhrase.ToString());
-				Assert.Equal("x => x.DoThings<object>(null)", setupGenericSequencePhrase.ToString());
+				Assert.Equal("x => x.DoThings(null)", setupSequence.ToString());
+				Assert.Equal("x => x.DoThings<object>(null)", setupGenericSequence.ToString());
 			}
 		}
 

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2467,6 +2467,21 @@ namespace Moq.Tests.Regressions
 		}
 
 		#endregion
+		
+		#region #810
+
+		public class _810
+		{
+			[Fact]
+			public void SetupPhraseConvertsExpressionToDescriptiveString()
+			{
+				var setupPhrase = new Mock<IFoo>().Setup(x => x.DoThings(null));
+
+				Assert.Equal("x => x.DoThings(null)", setupPhrase.ToString());
+			}
+		}
+		
+		#endregion
 
 		// Old @ Google Code
 

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2473,14 +2473,40 @@ namespace Moq.Tests.Regressions
 		public class _810
 		{
 			[Fact]
-			public void SetupPhraseConvertsExpressionToDescriptiveString()
+			public void VoidSetupPhraseConvertsExpressionToDescriptiveString()
 			{
-				var setupPhrase = new Mock<IFoo>().Setup(x => x.DoThings(null));
+				var voidSetupPhrase = new Mock<IFoo>().Setup(x => x.DoThings(null));
 
-				Assert.Equal("x => x.DoThings(null)", setupPhrase.ToString());
+				Assert.Equal("x => x.DoThings(null)", voidSetupPhrase.ToString());
+			}
+
+			[Fact]
+			public void NonVoidSetupPhraseConvertsExpressionToDescriptiveString()
+			{
+				var nonVoidSetupPhrase = new Mock<IFoo>().Setup(x => x.Property1);
+
+				Assert.Equal("x => x.Property1", nonVoidSetupPhrase.ToString());
+			}
+
+			[Fact]
+			public void SetterSetupPhraseConvertsExpressionToDescriptiveString()
+			{
+				var setterSetupPhrase = new Mock<IFoo>().SetupSet<object>(x => x.Property1 = null);
+
+				Assert.Equal("x => x.Property1 = null", setterSetupPhrase.ToString());
+			}
+
+			[Fact]
+			public void SetupSequencePhraseConvertsExpressionToDescriptiveString()
+			{
+				var setupSequencePhrase = new Mock<IFoo>().SetupSequence(x => x.DoThings(null));
+				var setupGenericSequencePhrase = new Mock<IFoo>().SetupSequence(x => x.DoThings<object>(null));
+
+				Assert.Equal("x => x.DoThings(null)", setupSequencePhrase.ToString());
+				Assert.Equal("x => x.DoThings<object>(null)", setupGenericSequencePhrase.ToString());
 			}
 		}
-		
+
 		#endregion
 
 		// Old @ Google Code
@@ -2581,6 +2607,8 @@ namespace Moq.Tests.Regressions
 		public interface IFoo
 		{
 			void DoThings(object arg);
+			T DoThings<T>(object arg);
+			object Property1 { get; set; }
 		}
 
 		[Fact]


### PR DESCRIPTION
When a `Setup` fails verification, it's helpful to have the exact expression that failed, rather than the default `ToString()` representation of the `Setup` class. To illustrate:

What I'd like to see in the output message:
```C#
x => x.DoThings(null)
```
What I actually get:
```C#
Moq.Language.Flow.VoidSetupPhrase`1[Moq.Tests.Regressions.IssueReportsFixture+IFoo]
```

This PR fixes that by overriding the `ToString()` methods and calling `ToStringFixed()` on the expression that is being used. This allows for a nicely formatted string representation of the expression to be returned.

Closes #810.