### PR TITLE
Optimize `SetupCollection` (esp. `ToArrayLive`) for better performance

### DIFF
--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -4,27 +4,23 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
-using System.Reflection;
 
 namespace Moq
 {
 	internal sealed class SetupCollection
 	{
-		// Using a stack has the advantage that enumeration returns the items in reverse order (last added to first added).
-		// This helps in implementing the rule that "given two matching setups, the last one wins."
-		private Stack<Setup> setups;
+		private List<Setup> setups;
 
 		public SetupCollection()
 		{
-			this.setups = new Stack<Setup>();
+			this.setups = new List<Setup>();
 		}
 
 		public void Add(Setup setup)
 		{
 			lock (this.setups)
 			{
-				this.setups.Push(setup);
+				this.setups.Add(setup);
 			}
 		}
 
@@ -56,8 +52,11 @@ namespace Moq
 
 			lock (this.setups)
 			{
-				foreach (var setup in this.setups)
+				// Iterating in reverse order because newer setups are more relevant than (i.e. override) older ones
+				for (int i = this.setups.Count - 1; i >= 0; --i)
 				{
+					var setup = this.setups[i];
+
 					// the following conditions are repetitive, but were written that way to avoid
 					// unnecessary expensive calls to `setup.Matches`; cheap tests are run first.
 					if (matchingSetup == null && setup.Matches(invocation))
@@ -91,8 +90,11 @@ namespace Moq
 
 			lock (this.setups)
 			{
-				foreach (var setup in this.setups)
+				// Iterating in reverse order because newer setups are more relevant than (i.e. override) older ones
+				for (int i = this.setups.Count - 1; i >= 0; --i)
 				{
+					var setup = this.setups[i];
+
 					if (setup.Condition != null)
 					{
 						continue;

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -10,10 +10,12 @@ namespace Moq
 	internal sealed class SetupCollection
 	{
 		private List<Setup> setups;
+		private uint overridden;  // bit mask for the first 32 setups flagging those known to be overridden
 
 		public SetupCollection()
 		{
 			this.setups = new List<Setup>();
+			this.overridden = 0U;
 		}
 
 		public void Add(Setup setup)
@@ -37,6 +39,7 @@ namespace Moq
 			lock (this.setups)
 			{
 				this.setups.Clear();
+				this.overridden = 0U;
 			}
 		}
 
@@ -55,6 +58,8 @@ namespace Moq
 				// Iterating in reverse order because newer setups are more relevant than (i.e. override) older ones
 				for (int i = this.setups.Count - 1; i >= 0; --i)
 				{
+					if (i < 32 && (this.overridden & (1U << i)) != 0) continue;
+
 					var setup = this.setups[i];
 
 					// the following conditions are repetitive, but were written that way to avoid
@@ -93,6 +98,8 @@ namespace Moq
 				// Iterating in reverse order because newer setups are more relevant than (i.e. override) older ones
 				for (int i = this.setups.Count - 1; i >= 0; --i)
 				{
+					if (i < 32 && (this.overridden & (1U << i)) != 0) continue;
+
 					var setup = this.setups[i];
 
 					if (setup.Condition != null)
@@ -104,6 +111,7 @@ namespace Moq
 					{
 						// A setup with the same expression has already been iterated over,
 						// meaning that this older setup is an overridden one.
+						if (i < 32) this.overridden |= 1U << i;
 						continue;
 					}
 


### PR DESCRIPTION
`SetupCollection.ToArrayLive` is a fairly expensive operation and gets called more often (esp. during verification) now that inner mocks are represented as regular setups. This applies some optimizations that can easily double the speed of that operation, esp. when any overridden setups are present.