### PR TITLE
Correct error message when attempting to set up an indexer with `SetupProperty`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
+## Unreleased
+
+#### Fixed
+
+* Regression: Unhelpful exception message when setting up an indexer with `SetupProperty` (@stakx, #823)
+
+
 ## 4.11.0-rc1 (2019-04-19)
 
 This is a pre-release version.

--- a/src/Moq/Mock.Generic.cs
+++ b/src/Moq/Mock.Generic.cs
@@ -314,6 +314,10 @@ namespace Moq
 		{
 			Guard.NotNull(property, nameof(property));
 
+			var pi = property.ToPropertyInfo();
+			Guard.CanRead(pi);
+			Guard.CanWrite(pi);
+
 			TProperty value = initialValue;
 			this.SetupGet(property).Returns(() => value);
 			Mock.SetupSet(this, property.AssignItIsAny(), condition: null).SetCallbackResponse(new Action<TProperty>(p => value = p));

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2545,6 +2545,32 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 823
+
+		public class Issue823
+		{
+			public interface IX
+			{
+				string this[int index] { get;set; }
+			}
+
+			[Fact]
+			public void Setting_up_indexer_with_SetupProperty_throws_with_error_message_pointing_at_the_problem()
+			{
+				var mock = new Mock<IX>();
+				var ex = Assert.Throws<ArgumentException>(() => mock.SetupProperty(m => m[1]));
+				if (!string.IsNullOrEmpty(ex.ParamName))
+				{
+					Assert.Equal("property", ex.ParamName);
+				}
+				Assert.Contains("not a property", ex.Message);
+				// ^ To add some context for these tests, at one point the exception thrown read:
+				//   "Expression must be writeable", referring to a parameter "left".
+			}
+		}
+
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47


### PR DESCRIPTION
Fixes #823.