### PR TITLE
Handle write-only properties in SetupAllProperties for strict mocks (fix #835)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 * Improved performance for `Mock.Of<T>` and `mock.SetupAllProperties()` as the latter now performs property setups just-in-time, instead of as an ahead-of-time batch operation. (@vanashimko, #826)
 
+#### Fixed
+
+* `mock.SetupAllProperties()` now setups write-only properties for strict mocks, so that accessing such properties will not throw anymore. (@vanashimko, #836)
+
 
 ## 4.11.0 (2019-05-28)
 

--- a/src/Moq/Interception/InterceptionAspects.cs
+++ b/src/Moq/Interception/InterceptionAspects.cs
@@ -351,20 +351,18 @@ namespace Moq
 					return false;
 				}
 
-				// Should ignore write-only properties, as they will be handled by Return aspect
-				// unless if the mock is strict; for those, interception terminates by FailForStrictMock aspect.
-				if (invocationMethod.IsPropertySetter() && !property.CanRead)
-				{
-					return false;
-				}
-
-				var getter = property.GetGetMethod(true);
 				var expression = GetPropertyExpression(invocationMethod.DeclaringType, property);
 
-				object propertyValue = CreateInitialPropertyValue(mock, getter);
+				object propertyValue;
 
-				Setup getterSetup = new AutoImplementedPropertyGetterSetup(expression, getter, () => propertyValue);
-				mock.Setups.Add(getterSetup);
+				Setup getterSetup = null;
+				if (property.CanRead)
+				{
+					var getter = property.GetGetMethod(true);
+					propertyValue = CreateInitialPropertyValue(mock, getter);
+					getterSetup = new AutoImplementedPropertyGetterSetup(expression, getter, () => propertyValue);
+					mock.Setups.Add(getterSetup);
+				}
 
 				Setup setterSetup = null;
 				if (property.CanWrite)

--- a/tests/Moq.Tests/StubExtensionsFixture.cs
+++ b/tests/Moq.Tests/StubExtensionsFixture.cs
@@ -185,10 +185,12 @@ namespace Moq.Tests
 			public abstract string Test { set; }
 		}
 
-		[Fact]
-		public void Write_only_property_should_be_ignored_by_SetupAllProperties()
+		[Theory]
+		[InlineData(MockBehavior.Strict)]
+		[InlineData(MockBehavior.Loose)]
+		public void SetupAllProperties_should_setup_write_only_properties(MockBehavior mockBehavior)
 		{
-			var mock = new Mock<WriteOnlyProperty>();
+			var mock = new Mock<WriteOnlyProperty>(mockBehavior);
 			mock.SetupAllProperties();
 			
 			mock.Object.Test = "test";


### PR DESCRIPTION
Fix #835.

Was not sure, if such a minor change should be included in a changelog, but included just in case.