### PR TITLE
Unskip unit tests regarding indexers & matchers

### DIFF
--- a/tests/Moq.Tests/PropertiesFixture.cs
+++ b/tests/Moq.Tests/PropertiesFixture.cs
@@ -72,25 +72,21 @@ namespace Moq.Tests
 			foo.Object[0] = "foo";
 		}
 
-		//[Fact(Skip = "Not supported for now")]
-		//public void ShouldSetIndexerWithIndexMatcher()
-		//{
-		//	var foo = new Mock<IIndexedFoo>(MockBehavior.Strict);
-		//
-		//	foo.SetupSet(f => f[It.IsAny<int>()] = "foo");
-		//
-		//	foo.Object[18] = "foo";
-		//}
+		[Fact]
+		public void ShouldSetIndexerWithIndexMatcher()
+		{
+			var foo = new Mock<IIndexedFoo>(MockBehavior.Strict);
+			foo.SetupSet(f => f[It.IsAny<int>()] = "foo");
+			foo.Object[18] = "foo";
+		}
 
-		//[Fact(Skip = "Not supported for now")]
-		//public void ShouldSetIndexerWithBothMatcher()
-		//{
-		//	var foo = new Mock<IIndexedFoo>(MockBehavior.Strict);
-		//
-		//	foo.SetupSet(f => f[It.IsAny<int>()] = It.IsAny<string>());
-		//
-		//	foo.Object[18] = "foo";
-		//}
+		[Fact]
+		public void ShouldSetIndexerWithBothMatcher()
+		{
+			var foo = new Mock<IIndexedFoo>(MockBehavior.Strict);
+			foo.SetupSet(f => f[It.IsAny<int>()] = It.IsAny<string>());
+			foo.Object[18] = "foo";
+		}
 
 		[Fact]
 		public void Can_Setup_virtual_property()


### PR DESCRIPTION
These have been made to work with the rewrites that went into 4.11.0.