### PR TITLE
Fix SetupAllProperties to override pre-existing property setups (#837)

### DIFF
--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -506,6 +506,10 @@ namespace Moq
 
 		internal static void SetupAllProperties(Mock mock, DefaultValueProvider defaultValueProvider)
 		{
+			mock.Setups.RemoveAll(x => x.Method.IsPropertyAccessor());
+			// Removing all the previous properties setups to keep the behaviour of overriding
+			// existing setups in `SetupAllProperties`.
+			
 			mock.AutoSetupPropertiesDefaultValueProvider = defaultValueProvider;
 			// `SetupAllProperties` no longer performs properties setup like in previous versions.
 			// Instead it just enables a switch to setup properties on-demand at the moment of first access.

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -34,6 +34,21 @@ namespace Moq
 			}
 		}
 
+		public void RemoveAll(Func<Setup, bool> predicate)
+		{
+			// Fast path (no `lock`) when there are no setups:
+			if (this.setups.Count == 0)
+			{
+				return;
+			}
+
+			lock (this.setups)
+			{
+				this.setups.RemoveAll(x => predicate(x));
+				this.overridden = 0U;
+			}
+		}
+
 		public void Clear()
 		{
 			lock (this.setups)

--- a/tests/Moq.Tests/StubExtensionsFixture.cs
+++ b/tests/Moq.Tests/StubExtensionsFixture.cs
@@ -232,6 +232,32 @@ namespace Moq.Tests
 			Assert.Equal("test", asReimplementedInterface.WriteAccessInDerived);
 		}
 
+		[Fact]
+		public void SetupAllProperties_should_override_previous_SetupAllProperties()
+		{
+			var mock = new Mock<IBar>();
+
+			mock.SetReturnsDefault(1);
+			mock.SetupAllProperties();
+			Assert.Equal(1, mock.Object.Value);
+
+			mock.Object.Value = 2;
+
+			mock.SetupAllProperties();
+			Assert.Equal(1, mock.Object.Value);
+		}
+		
+		[Fact]
+		public void SetupAllProperties_should_override_regular_setups()
+		{
+			var mock = new Mock<IBar>();
+			mock.Setup(x => x.Value).Returns(1);
+
+			mock.SetupAllProperties();
+			
+			Assert.Equal(0, mock.Object.Value);
+		}
+
 		private object GetValue() { return new object(); }
 
 		public interface IFoo


### PR DESCRIPTION
Fix #837.

No changelog entry here, because the fix is not against existing version, but against unreleased one.