### PR TITLE
Add LINQ to Mocks support for strict mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 #### Added
 
 * New method overload `sequenceSetup.ReturnsAsync(Func<T>)` (@stakx, #841)
+* LINQ to Mocks support for strict mocks, i.e. new method overloads for `Mock.Of`, `Mocks.Of`, `mockRepository.Of`, and `mockRepository.OneOf` that accept a `MockBehavior` parameter. (@stakx, #842)
 
 #### Fixed
 

--- a/src/Moq/Linq/Mock.cs
+++ b/src/Moq/Linq/Mock.cs
@@ -38,7 +38,10 @@ namespace Moq
 			// which involved a lot of avoidable `IQueryable` query provider overhead and lambda compilation.
 			// What it really boils down to is this (much faster) code:
 			var mock = new Mock<T>(behavior);
-			mock.SetupAllProperties();
+			if (behavior != MockBehavior.Strict)
+			{
+				mock.SetupAllProperties();
+			}
 			return mock.Object;
 		}
 

--- a/src/Moq/Linq/Mock.cs
+++ b/src/Moq/Linq/Mock.cs
@@ -26,7 +26,7 @@ namespace Moq
 			//
 			// which involved a lot of avoidable `IQueryable` query provider overhead and lambda compilation.
 			// What it really boils down to is this (much faster) code:
-			var mock = new Mock<T>();
+			var mock = new Mock<T>(MockBehavior.Default);
 			mock.SetupAllProperties();
 			return mock.Object;
 		}
@@ -40,7 +40,7 @@ namespace Moq
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By Design")]
 		public static T Of<T>(Expression<Func<T, bool>> predicate) where T : class
 		{
-			var mocked = Mocks.CreateMockQuery<T>().First<T>(predicate);
+			var mocked = Mocks.CreateMockQuery<T>(MockBehavior.Default).First(predicate);
 
 			// The current implementation of LINQ to Mocks creates mocks that already have recorded invocations.
 			// Because this interferes with `VerifyNoOtherCalls`, we recursively clear all invocations before

--- a/src/Moq/Linq/Mock.cs
+++ b/src/Moq/Linq/Mock.cs
@@ -20,13 +20,24 @@ namespace Moq
 		/// <returns>The mocked object created.</returns>
 		public static T Of<T>() where T : class
 		{
+			return Mock.Of<T>(MockBehavior.Default);
+		}
+
+		/// <summary>
+		/// Creates an mock object of the indicated type.
+		/// </summary>
+		/// <param name="behavior">Behavior of the mock.</param>
+		/// <typeparam name="T">The type of the mocked object.</typeparam>
+		/// <returns>The mocked object created.</returns>
+		public static T Of<T>(MockBehavior behavior) where T : class
+		{
 			// This method was originally implemented as follows:
 			//
 			// return Mocks.CreateMockQuery<T>().First<T>();
 			//
 			// which involved a lot of avoidable `IQueryable` query provider overhead and lambda compilation.
 			// What it really boils down to is this (much faster) code:
-			var mock = new Mock<T>(MockBehavior.Default);
+			var mock = new Mock<T>(behavior);
 			mock.SetupAllProperties();
 			return mock.Object;
 		}
@@ -40,7 +51,20 @@ namespace Moq
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By Design")]
 		public static T Of<T>(Expression<Func<T, bool>> predicate) where T : class
 		{
-			var mocked = Mocks.CreateMockQuery<T>(MockBehavior.Default).First(predicate);
+			return Mock.Of<T>(predicate, MockBehavior.Default);
+		}
+
+		/// <summary>
+		/// Creates an mock object of the indicated type.
+		/// </summary>
+		/// <param name="predicate">The predicate with the specification of how the mocked object should behave.</param>
+		/// <param name="behavior">Behavior of the mock.</param>
+		/// <typeparam name="T">The type of the mocked object.</typeparam>
+		/// <returns>The mocked object created.</returns>
+		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By Design")]
+		public static T Of<T>(Expression<Func<T, bool>> predicate, MockBehavior behavior) where T : class
+		{
+			var mocked = Mocks.CreateMockQuery<T>(behavior).First(predicate);
 
 			// The current implementation of LINQ to Mocks creates mocks that already have recorded invocations.
 			// Because this interferes with `VerifyNoOtherCalls`, we recursively clear all invocations before

--- a/src/Moq/Linq/MockRepository.cs
+++ b/src/Moq/Linq/MockRepository.cs
@@ -141,7 +141,10 @@ namespace Moq
 			do
 			{
 				var mock = this.Create<T>(behavior);
-				mock.SetupAllProperties();
+				if (behavior != MockBehavior.Strict)
+				{
+					mock.SetupAllProperties();
+				}
 
 				yield return mock.Object;
 			}

--- a/src/Moq/Linq/MockRepository.cs
+++ b/src/Moq/Linq/MockRepository.cs
@@ -25,7 +25,18 @@ namespace Moq
 		/// <typeparam name="T">The type of the mocked object to query.</typeparam>
 		public IQueryable<T> Of<T>() where T : class
 		{
-			return this.CreateMockQuery<T>(this.Behavior);
+			return this.Of<T>(this.Behavior);
+		}
+
+		/// <summary>
+		/// Access the universe of mocks of the given type, to retrieve those
+		/// that behave according to the LINQ query specification.
+		/// </summary>
+		/// <param name="behavior">Behavior of the mocks.</param>
+		/// <typeparam name="T">The type of the mocked object to query.</typeparam>
+		public IQueryable<T> Of<T>(MockBehavior behavior) where T : class
+		{
+			return this.CreateMockQuery<T>(behavior);
 		}
 
 		/// <summary>
@@ -37,7 +48,20 @@ namespace Moq
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public IQueryable<T> Of<T>(Expression<Func<T, bool>> specification) where T : class
 		{
-			return this.CreateMockQuery<T>(this.Behavior).Where(specification);
+			return this.Of<T>(specification, this.Behavior);
+		}
+
+		/// <summary>
+		/// Access the universe of mocks of the given type, to retrieve those
+		/// that behave according to the LINQ query specification.
+		/// </summary>
+		/// <param name="specification">The predicate with the setup expressions.</param>
+		/// <param name="behavior">Behavior of the mocks.</param>
+		/// <typeparam name="T">The type of the mocked object to query.</typeparam>
+		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+		public IQueryable<T> Of<T>(Expression<Func<T, bool>> specification, MockBehavior behavior) where T : class
+		{
+			return this.CreateMockQuery<T>(behavior).Where(specification);
 		}
 
 		/// <summary>
@@ -48,7 +72,19 @@ namespace Moq
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public T OneOf<T>() where T : class
 		{
-			return this.CreateMockQuery<T>(this.Behavior).First();
+			return this.OneOf<T>(this.Behavior);
+		}
+
+		/// <summary>
+		/// Creates an mock object of the indicated type.
+		/// </summary>
+		/// <param name="behavior">Behavior of the mock.</param>
+		/// <typeparam name="T">The type of the mocked object.</typeparam>
+		/// <returns>The mocked object created.</returns>
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public T OneOf<T>(MockBehavior behavior) where T : class
+		{
+			return this.CreateMockQuery<T>(behavior).First();
 		}
 
 		/// <summary>
@@ -61,7 +97,21 @@ namespace Moq
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public T OneOf<T>(Expression<Func<T, bool>> specification) where T : class
 		{
-			return this.CreateMockQuery<T>(this.Behavior).First(specification);
+			return this.OneOf<T>(specification, this.Behavior);
+		}
+
+		/// <summary>
+		/// Creates an mock object of the indicated type.
+		/// </summary>
+		/// <param name="specification">The predicate with the setup expressions.</param>
+		/// <param name="behavior">Behavior of the mock.</param>
+		/// <typeparam name="T">The type of the mocked object.</typeparam>
+		/// <returns>The mocked object created.</returns>
+		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By Design")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public T OneOf<T>(Expression<Func<T, bool>> specification, MockBehavior behavior) where T : class
+		{
+			return this.CreateMockQuery<T>(behavior).First(specification);
 		}
 
 		/// <summary>

--- a/src/Moq/Linq/MockSetupsBuilder.cs
+++ b/src/Moq/Linq/MockSetupsBuilder.cs
@@ -217,9 +217,11 @@ namespace Moq.Linq
 			var mockExpression = propertyCall.Object;
 			var propertyExpression = propertyCall.Arguments.First().StripQuotes();
 
-			// Because Mocks.CreateMocks (the underlying implementation of the IQueryable provider
-			// already sets up all properties as stubs, we can safely just set the value here, 
-			// which also allows the use of this querying capability against plain DTO even 
+			// We can safely just set the value here since `SetProperty` will temporarily enable auto-stubbing
+			// if the underlying `IQueryable` provider implementation hasn't already enabled it permanently by
+			// calling `SetupAllProperties`.
+			//
+			// This method also enables the use of this querying capability against plain DTO even
 			// if their properties are not virtual.
 			var setPropertyMethod = typeof(Mocks)
 				.GetMethod("SetProperty", BindingFlags.Static | BindingFlags.NonPublic)

--- a/src/Moq/Linq/Mocks.cs
+++ b/src/Moq/Linq/Mocks.cs
@@ -26,7 +26,18 @@ namespace Moq
 		/// <typeparam name="T">The type of the mocked object to query.</typeparam>
 		public static IQueryable<T> Of<T>() where T : class
 		{
-			return Mocks.CreateMockQuery<T>(MockBehavior.Default);
+			return Mocks.Of<T>(MockBehavior.Default);
+		}
+
+		/// <summary>
+		/// Access the universe of mocks of the given type, to retrieve those
+		/// that behave according to the LINQ query specification.
+		/// </summary>
+		/// <param name="behavior">Behavior of the mocks.</param>
+		/// <typeparam name="T">The type of the mocked object to query.</typeparam>
+		public static IQueryable<T> Of<T>(MockBehavior behavior) where T : class
+		{
+			return Mocks.CreateMockQuery<T>(behavior);
 		}
 
 		/// <summary>
@@ -38,7 +49,20 @@ namespace Moq
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
 		public static IQueryable<T> Of<T>(Expression<Func<T, bool>> specification) where T : class
 		{
-			return Mocks.CreateMockQuery<T>(MockBehavior.Default).Where(specification);
+			return Mocks.Of<T>(specification, MockBehavior.Default);
+		}
+
+		/// <summary>
+		/// Access the universe of mocks of the given type, to retrieve those
+		/// that behave according to the LINQ query specification.
+		/// </summary>
+		/// <param name="specification">The predicate with the setup expressions.</param>
+		/// <param name="behavior">Behavior of the mocks.</param>
+		/// <typeparam name="T">The type of the mocked object to query.</typeparam>
+		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By design")]
+		public static IQueryable<T> Of<T>(Expression<Func<T, bool>> specification, MockBehavior behavior) where T : class
+		{
+			return Mocks.CreateMockQuery<T>(behavior).Where(specification);
 		}
 
 		/// <summary>

--- a/src/Moq/Obsolete/MockFactory.cs
+++ b/src/Moq/Obsolete/MockFactory.cs
@@ -119,6 +119,11 @@ namespace Moq
 		}
 
 		/// <summary>
+		///   Gets the default <see cref="MockBehavior"/> of mocks created by this repository.
+		/// </summary>
+		internal MockBehavior Behavior => this.defaultBehavior;
+
+		/// <summary>
 		/// Whether the base member virtual implementation will be called 
 		/// for mocked classes if no setup is matched. Defaults to <see langword="false"/>.
 		/// </summary>

--- a/tests/Moq.Tests/Linq/MockRepositoryQuerying.cs
+++ b/tests/Moq.Tests/Linq/MockRepositoryQuerying.cs
@@ -57,11 +57,60 @@ namespace Moq.Tests.Linq
 
 				Assert.Equal("1", foo.Id);
 			}
+
+			[Fact]
+			public void Can_override_behavior_and_create_loose_mock()
+			{
+				var foo = this.repository.OneOf<IFoo>(MockBehavior.Loose);
+				Assert.Equal(MockBehavior.Loose, Mock.Get(foo).Behavior);
+				_ = foo.Id;
+			}
+		}
+
+		public class Strict_mocks
+		{
+			private MockRepository repository;
+
+			public Strict_mocks()
+			{
+				this.repository = new MockRepository(MockBehavior.Default);
+			}
+
+			[Fact]
+			public void Strict_Of_will_throw_for_non_setup_property()
+			{
+				var foo = this.repository.Of<IFoo>(MockBehavior.Strict).First();
+				Assert.Throws<MockException>(() => _ = foo.Name);
+			}
+
+			[Fact]
+			public void Strict_Of_with_expression_will_throw_for_non_setup_property()
+			{
+				var foo = this.repository.Of<IFoo>(f => f.Id == default, MockBehavior.Strict).First();
+				_ = foo.Id;
+				Assert.Throws<MockException>(() => _ = foo.Name);
+			}
+
+			[Fact]
+			public void Strict_OneOf_will_throw_for_non_setup_property()
+			{
+				var foo = this.repository.OneOf<IFoo>(MockBehavior.Strict);
+				Assert.Throws<MockException>(() => _ = foo.Name);
+			}
+
+			[Fact]
+			public void Strict_OneOf_with_expression_will_throw_for_non_setup_property()
+			{
+				var foo = this.repository.OneOf<IFoo>(f => f.Id == default, MockBehavior.Strict);
+				_ = foo.Id;
+				Assert.Throws<MockException>(() => _ = foo.Name);
+			}
 		}
 
 		public interface IFoo
 		{
 			string Id { get; set; }
+			string Name { get; set; }
 			bool Do();
 		}
 	}

--- a/tests/Moq.Tests/Linq/QueryableMocksFixture.cs
+++ b/tests/Moq.Tests/Linq/QueryableMocksFixture.cs
@@ -182,6 +182,36 @@ namespace Moq.Tests
 			Assert.Equal("foo", target.Value);
 		}
 
+		[Fact]
+		public void Strict_Mock_Of_will_throw_for_non_setup_property()
+		{
+			var foo = Mock.Of<IFoo>(MockBehavior.Strict);
+			Assert.Throws<MockException>(() => _ = foo.Name);
+		}
+
+		[Fact]
+		public void Strict_Mock_Of_with_specification_expression_will_throw_for_non_setup_property()
+		{
+			var foo = Mock.Of<IFoo>(f => f.Targets == default, MockBehavior.Strict);
+			_ = foo.Targets;
+			Assert.Throws<MockException>(() => _ = foo.Name);
+		}
+
+		[Fact]
+		public void Strict_Mocks_Of_will_throw_for_non_setup_property()
+		{
+			var foo = Mocks.Of<IFoo>(MockBehavior.Strict).First();
+			Assert.Throws<MockException>(() => _ = foo.Name);
+		}
+
+		[Fact]
+		public void Strict_Mocks_Of_with_specification_expression_will_throw_for_non_setup_property()
+		{
+			var foo = Mocks.Of<IFoo>(f => f.Targets == default, MockBehavior.Strict).First();
+			_ = foo.Targets;
+			Assert.Throws<MockException>(() => _ = foo.Name);
+		}
+
 		public class Dto
 		{
 			public string Value { get; set; }


### PR DESCRIPTION
This closes #740.