### PR TITLE
Proposal: Prevent capturing arguments on match failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * `mock.SetupAllProperties()` now setups write-only properties for strict mocks, so that accessing such properties will not throw anymore. (@vanashimko, #836)
 * Regression: `mock.SetupAllProperties()` and `Mock.Of<T>` fail due to inaccessible property accessors (@Mexe13, #845)
 * Regression: `VerifyNoOtherCalls` causes stack overflow when mock setup returns the mocked object (@bash, #846)
+* `Capture.In()` no longer captures arguments when other setup arguments do not match (@ocoanet, #844).
+* `CaptureMatch` no longer invokes the capture callback when other setup arguments do not match (@ocoanet, #844).
 
 
 ## 4.11.0 (2019-05-28)

--- a/src/Moq/Capture.cs
+++ b/src/Moq/Capture.cs
@@ -30,7 +30,7 @@ namespace Moq
 		/// </example>
 		public static T In<T>(ICollection<T> collection)
 		{
-			var match = new CaptureMatch<T>(collection.Add);
+			var match = new CaptureMatch<T>(collection.Add, captureOnSuccessOnly: true);
 			return With(match);
 		}
 
@@ -53,7 +53,7 @@ namespace Moq
 		/// </example>
 		public static T In<T>(IList<T> collection, Expression<Func<T, bool>> predicate)
 		{
-			var match = new CaptureMatch<T>(collection.Add, predicate);
+			var match = new CaptureMatch<T>(collection.Add, predicate, captureOnSuccessOnly: true);
 			return With(match);
 		}
 

--- a/src/Moq/Capture.cs
+++ b/src/Moq/Capture.cs
@@ -30,7 +30,7 @@ namespace Moq
 		/// </example>
 		public static T In<T>(ICollection<T> collection)
 		{
-			var match = new CaptureMatch<T>(collection.Add, captureOnSuccessOnly: true);
+			var match = new CaptureMatch<T>(collection.Add);
 			return With(match);
 		}
 
@@ -53,7 +53,7 @@ namespace Moq
 		/// </example>
 		public static T In<T>(IList<T> collection, Expression<Func<T, bool>> predicate)
 		{
-			var match = new CaptureMatch<T>(collection.Add, predicate, captureOnSuccessOnly: true);
+			var match = new CaptureMatch<T>(collection.Add, predicate);
 			return With(match);
 		}
 

--- a/src/Moq/CaptureMatch.cs
+++ b/src/Moq/CaptureMatch.cs
@@ -19,7 +19,7 @@ namespace Moq
 		/// </summary>
 		/// <param name="captureCallback">An action to run on captured value</param>
 		public CaptureMatch(Action<T> captureCallback)
-		: base(matchAllPredicate, () => It.IsAny<T>(), captureCallback)
+			: base(matchAllPredicate, () => It.IsAny<T>(), captureCallback)
 		{
 		}
 
@@ -29,7 +29,7 @@ namespace Moq
 		/// <param name="captureCallback">An action to run on captured value</param>
 		/// <param name="predicate">A predicate used to filter captured parameters</param>
 		public CaptureMatch(Action<T> captureCallback, Expression<Func<T, bool>> predicate)
-		: base(BuildCondition(predicate), () => It.Is(predicate), captureCallback)
+			: base(BuildCondition(predicate), () => It.Is(predicate), captureCallback)
 		{
 		}
 

--- a/src/Moq/CaptureMatch.cs
+++ b/src/Moq/CaptureMatch.cs
@@ -12,27 +12,14 @@ namespace Moq
 	/// <typeparam name="T"></typeparam>
 	public class CaptureMatch<T> : Match<T>
 	{
-		private readonly Matcher matcher;
+		private static readonly Predicate<T> matchAllPredicate = _ => true;
 
 		/// <summary>
 		/// Initializes an instance of the capture match.
 		/// </summary>
 		/// <param name="captureCallback">An action to run on captured value</param>
 		public CaptureMatch(Action<T> captureCallback)
-			: this(captureCallback, false)
-		{
-		}
-		
-		/// <summary>
-		/// Initializes an instance of the capture match.
-		/// </summary>
-		/// <param name="captureCallback">An action to run on captured value</param>
-		/// <param name="captureOnSuccessOnly">
-		/// Indicates whether <paramref name="captureCallback"/> should be invoked on parameter evaluation
-		/// or only after all parameters were successfully evaluated.
-		/// </param>
-		public CaptureMatch(Action<T> captureCallback, bool captureOnSuccessOnly)
-			: this(new Matcher(captureCallback, null, captureOnSuccessOnly))
+		: base(matchAllPredicate, () => It.IsAny<T>(), captureCallback)
 		{
 		}
 
@@ -42,80 +29,14 @@ namespace Moq
 		/// <param name="captureCallback">An action to run on captured value</param>
 		/// <param name="predicate">A predicate used to filter captured parameters</param>
 		public CaptureMatch(Action<T> captureCallback, Expression<Func<T, bool>> predicate)
-			: this(captureCallback, predicate, false)
-		{
-		}
-		
-		/// <summary>
-		/// Initializes an instance of the capture match.
-		/// </summary>
-		/// <param name="captureCallback">An action to run on captured value</param>
-		/// <param name="predicate">A predicate used to filter captured parameters</param>
-		/// <param name="captureOnSuccessOnly">
-		/// Indicates whether <paramref name="captureCallback"/> should be invoked on parameter evaluation
-		/// or only after all parameters were successfully evaluated.
-		/// </param>
-		public CaptureMatch(Action<T> captureCallback, Expression<Func<T, bool>> predicate, bool captureOnSuccessOnly)
-			: this(new Matcher(captureCallback, predicate, captureOnSuccessOnly))
+		: base(BuildCondition(predicate), () => It.Is(predicate), captureCallback)
 		{
 		}
 
-		private CaptureMatch(Matcher matcher)
-			: base(matcher.Evaluate, matcher.RenderExpression)
+		private static Predicate<T> BuildCondition(Expression<Func<T, bool>> predicateExpression)
 		{
-			this.matcher = matcher;
-		}
-
-		internal override void OnSuccess()
-		{
-			this.matcher.OnSuccess();
-		}
-
-		private class Matcher
-		{
-			private readonly Action<T> captureCallback;
-			private readonly Func<T, bool> predicate;
-			private readonly bool captureOnSuccessOnly;
-			private T capturedValue;
-
-			public Matcher(Action<T> captureCallback, Expression<Func<T, bool>> predicate, bool captureOnSuccessOnly)
-			{
-				this.captureCallback = captureCallback;
-
-				if (predicate != null)
-				{
-					this.predicate = predicate.CompileUsingExpressionCompiler();
-					this.RenderExpression = () => It.Is(predicate);
-				}
-				else
-				{
-					this.predicate = _ => true;
-					this.RenderExpression = () => It.IsAny<T>();
-				}
-				
-				this.captureOnSuccessOnly = captureOnSuccessOnly;
-			}
-
-			public Expression<Func<T>> RenderExpression { get; }
-
-			public bool Evaluate(T value)
-			{
-				if (!this.predicate(value))
-					return false;
-
-				if (this.captureOnSuccessOnly)
-					this.capturedValue = value;
-				else
-					this.captureCallback.Invoke(value);
-
-				return true;
-			}
-
-			public void OnSuccess()
-			{
-				if (this.captureOnSuccessOnly)
-					this.captureCallback.Invoke(this.capturedValue);
-			}
+			var predicate = predicateExpression.CompileUsingExpressionCompiler();
+			return value => predicate.Invoke(value);
 		}
 	}
 }

--- a/src/Moq/CaptureMatch.cs
+++ b/src/Moq/CaptureMatch.cs
@@ -12,12 +12,27 @@ namespace Moq
 	/// <typeparam name="T"></typeparam>
 	public class CaptureMatch<T> : Match<T>
 	{
+		private readonly Matcher matcher;
+
 		/// <summary>
 		/// Initializes an instance of the capture match.
 		/// </summary>
 		/// <param name="captureCallback">An action to run on captured value</param>
 		public CaptureMatch(Action<T> captureCallback)
-			: base(CreatePredicate(captureCallback), () => It.IsAny<T>())
+			: this(captureCallback, false)
+		{
+		}
+		
+		/// <summary>
+		/// Initializes an instance of the capture match.
+		/// </summary>
+		/// <param name="captureCallback">An action to run on captured value</param>
+		/// <param name="captureOnSuccessOnly">
+		/// Indicates whether <paramref name="captureCallback"/> should be invoked on parameter evaluation
+		/// or only after all parameters were successfully evaluated.
+		/// </param>
+		public CaptureMatch(Action<T> captureCallback, bool captureOnSuccessOnly)
+			: this(new Matcher(captureCallback, null, captureOnSuccessOnly))
 		{
 		}
 
@@ -27,30 +42,80 @@ namespace Moq
 		/// <param name="captureCallback">An action to run on captured value</param>
 		/// <param name="predicate">A predicate used to filter captured parameters</param>
 		public CaptureMatch(Action<T> captureCallback, Expression<Func<T, bool>> predicate)
-			: base(CreatePredicate(captureCallback, predicate), () => It.Is(predicate))
+			: this(captureCallback, predicate, false)
+		{
+		}
+		
+		/// <summary>
+		/// Initializes an instance of the capture match.
+		/// </summary>
+		/// <param name="captureCallback">An action to run on captured value</param>
+		/// <param name="predicate">A predicate used to filter captured parameters</param>
+		/// <param name="captureOnSuccessOnly">
+		/// Indicates whether <paramref name="captureCallback"/> should be invoked on parameter evaluation
+		/// or only after all parameters were successfully evaluated.
+		/// </param>
+		public CaptureMatch(Action<T> captureCallback, Expression<Func<T, bool>> predicate, bool captureOnSuccessOnly)
+			: this(new Matcher(captureCallback, predicate, captureOnSuccessOnly))
 		{
 		}
 
-		private static Predicate<T> CreatePredicate(Action<T> captureCallback)
+		private CaptureMatch(Matcher matcher)
+			: base(matcher.Evaluate, matcher.RenderExpression)
 		{
-			return value =>
+			this.matcher = matcher;
+		}
+
+		internal override void OnSuccess()
+		{
+			this.matcher.OnSuccess();
+		}
+
+		private class Matcher
+		{
+			private readonly Action<T> captureCallback;
+			private readonly Func<T, bool> predicate;
+			private readonly bool captureOnSuccessOnly;
+			private T capturedValue;
+
+			public Matcher(Action<T> captureCallback, Expression<Func<T, bool>> predicate, bool captureOnSuccessOnly)
 			{
-				captureCallback.Invoke(value);
+				this.captureCallback = captureCallback;
+
+				if (predicate != null)
+				{
+					this.predicate = predicate.CompileUsingExpressionCompiler();
+					this.RenderExpression = () => It.Is(predicate);
+				}
+				else
+				{
+					this.predicate = _ => true;
+					this.RenderExpression = () => It.IsAny<T>();
+				}
+				
+				this.captureOnSuccessOnly = captureOnSuccessOnly;
+			}
+
+			public Expression<Func<T>> RenderExpression { get; }
+
+			public bool Evaluate(T value)
+			{
+				if (!this.predicate(value))
+					return false;
+
+				if (this.captureOnSuccessOnly)
+					this.capturedValue = value;
+				else
+					this.captureCallback.Invoke(value);
+
 				return true;
-			};
-		}
+			}
 
-		private static Predicate<T> CreatePredicate(Action<T> captureCallback, Expression<Func<T, bool>> predicate)
-		{
-			var predicateDelegate = predicate.CompileUsingExpressionCompiler();
-			return value =>
+			public void OnSuccess()
 			{
-				var matches = predicateDelegate.Invoke(value);
-				if (matches)
-					captureCallback.Invoke(value);
-
-				return matches;
-			};
+				if (this.captureOnSuccessOnly)
+					this.captureCallback.Invoke(this.capturedValue);
+			}
 		}
 	}
 }

--- a/src/Moq/Condition.cs
+++ b/src/Moq/Condition.cs
@@ -18,6 +18,6 @@ namespace Moq
 
 		public bool IsTrue => this.condition?.Invoke() == true;
 
-		public void EvaluatedSuccessfully() => this.success?.Invoke();
+		public void SetupEvaluatedSuccessfully() => this.success?.Invoke();
 	}
 }

--- a/src/Moq/IMatcher.cs
+++ b/src/Moq/IMatcher.cs
@@ -7,6 +7,6 @@ namespace Moq
 	{
 		bool Matches(object value);
 
-		void OnSuccess(object value);
+		void SetupEvaluatedSuccessfully(object value);
 	}
 }

--- a/src/Moq/IMatcher.cs
+++ b/src/Moq/IMatcher.cs
@@ -6,5 +6,7 @@ namespace Moq
 	internal interface IMatcher
 	{
 		bool Matches(object value);
+
+		void OnSuccess();
 	}
 }

--- a/src/Moq/IMatcher.cs
+++ b/src/Moq/IMatcher.cs
@@ -7,6 +7,6 @@ namespace Moq
 	{
 		bool Matches(object value);
 
-		void OnSuccess();
+		void OnSuccess(object value);
 	}
 }

--- a/src/Moq/Interception/InterceptionAspects.cs
+++ b/src/Moq/Interception/InterceptionAspects.cs
@@ -103,7 +103,7 @@ namespace Moq
 			var matchedSetup = mock.Setups.FindMatchFor(invocation);
 			if (matchedSetup != null)
 			{
-				matchedSetup.Condition?.EvaluatedSuccessfully();
+				matchedSetup.EvaluatedSuccessfully(invocation);
 
 				if (matchedSetup.IsVerifiable)
 				{

--- a/src/Moq/InvocationShape.cs
+++ b/src/Moq/InvocationShape.cs
@@ -79,9 +79,9 @@ namespace Moq
 				}
 			}
 
-			foreach (var argumentMatcher in this.argumentMatchers)
+			for (int i = 0, n = this.argumentMatchers.Length; i < n; ++i)
 			{
-				argumentMatcher.OnSuccess();
+				this.argumentMatchers[i].OnSuccess(arguments[i]);
 			}
 
 			return true;

--- a/src/Moq/InvocationShape.cs
+++ b/src/Moq/InvocationShape.cs
@@ -79,6 +79,11 @@ namespace Moq
 				}
 			}
 
+			foreach (var argumentMatcher in this.argumentMatchers)
+			{
+				argumentMatcher.OnSuccess();
+			}
+
 			return true;
 		}
 

--- a/src/Moq/InvocationShape.cs
+++ b/src/Moq/InvocationShape.cs
@@ -79,12 +79,16 @@ namespace Moq
 				}
 			}
 
+			return true;
+		}
+
+		public void EvaluatedSuccessfully(Invocation invocation)
+		{
+			var arguments = invocation.Arguments;
 			for (int i = 0, n = this.argumentMatchers.Length; i < n; ++i)
 			{
 				this.argumentMatchers[i].OnSuccess(arguments[i]);
 			}
-
-			return true;
 		}
 
 		private bool IsOverride(MethodInfo invocationMethod)

--- a/src/Moq/InvocationShape.cs
+++ b/src/Moq/InvocationShape.cs
@@ -82,7 +82,7 @@ namespace Moq
 			return true;
 		}
 
-		public void EvaluatedSuccessfully(Invocation invocation)
+		public void SetupEvaluatedSuccessfully(Invocation invocation)
 		{
 			var arguments = invocation.Arguments;
 			for (int i = 0, n = this.argumentMatchers.Length; i < n; ++i)

--- a/src/Moq/InvocationShape.cs
+++ b/src/Moq/InvocationShape.cs
@@ -87,7 +87,7 @@ namespace Moq
 			var arguments = invocation.Arguments;
 			for (int i = 0, n = this.argumentMatchers.Length; i < n; ++i)
 			{
-				this.argumentMatchers[i].OnSuccess(arguments[i]);
+				this.argumentMatchers[i].SetupEvaluatedSuccessfully(arguments[i]);
 			}
 		}
 

--- a/src/Moq/Match.cs
+++ b/src/Moq/Match.cs
@@ -33,13 +33,13 @@ namespace Moq
 
 		internal abstract bool Matches(object value);
 
-		internal virtual void OnSuccess(object value)
+		internal virtual void SetupEvaluatedSuccessfully(object value)
 		{
 		}
 
 		bool IMatcher.Matches(object value) => this.Matches(value);
 
-		void IMatcher.OnSuccess(object value) => this.OnSuccess(value);
+		void IMatcher.SetupEvaluatedSuccessfully(object value) => this.SetupEvaluatedSuccessfully(value);
 
 		internal Expression RenderExpression { get; set; }
 
@@ -99,13 +99,13 @@ namespace Moq
 	public class Match<T> : Match, IEquatable<Match<T>>
 	{
 		internal Predicate<T> Condition { get; set; }
-		internal Action<T> SuccessCallback { get; set; }
+		internal Action<T> SetupEvaluatedSuccessfullyCallback { get; set; }
 
-		internal Match(Predicate<T> condition, Expression<Func<T>> renderExpression, Action<T> successCallback = null)
+		internal Match(Predicate<T> condition, Expression<Func<T>> renderExpression, Action<T> setupEvaluatedSuccessfullyCallback = null)
 		{
 			this.Condition = condition;
 			this.RenderExpression = renderExpression.Body.Apply(EvaluateCaptures.Rewriter);
-			this.SuccessCallback = successCallback;
+			this.SetupEvaluatedSuccessfullyCallback = setupEvaluatedSuccessfullyCallback;
 		}
 
 		internal override bool Matches(object value)
@@ -132,9 +132,9 @@ namespace Moq
 			return this.Condition((T)value);
 		}
 
-		internal override void OnSuccess(object value)
+		internal override void SetupEvaluatedSuccessfully(object value)
 		{
-			this.SuccessCallback?.Invoke((T)value);
+			this.SetupEvaluatedSuccessfullyCallback?.Invoke((T)value);
 		}
 
 		/// <inheritdoc/>

--- a/src/Moq/Match.cs
+++ b/src/Moq/Match.cs
@@ -33,13 +33,13 @@ namespace Moq
 
 		internal abstract bool Matches(object value);
 
-		internal virtual void OnSuccess()
+		internal virtual void OnSuccess(object value)
 		{
 		}
 
 		bool IMatcher.Matches(object value) => this.Matches(value);
 
-		void IMatcher.OnSuccess() => this.OnSuccess();
+		void IMatcher.OnSuccess(object value) => this.OnSuccess(value);
 
 		internal Expression RenderExpression { get; set; }
 
@@ -99,11 +99,13 @@ namespace Moq
 	public class Match<T> : Match, IEquatable<Match<T>>
 	{
 		internal Predicate<T> Condition { get; set; }
+		internal Action<T> SuccessCallback { get; set; }
 
-		internal Match(Predicate<T> condition, Expression<Func<T>> renderExpression)
+		internal Match(Predicate<T> condition, Expression<Func<T>> renderExpression, Action<T> successCallback = null)
 		{
 			this.Condition = condition;
 			this.RenderExpression = renderExpression.Body.Apply(EvaluateCaptures.Rewriter);
+			this.SuccessCallback = successCallback;
 		}
 
 		internal override bool Matches(object value)
@@ -128,6 +130,11 @@ namespace Moq
 				return false;
 			}
 			return this.Condition((T)value);
+		}
+
+		internal override void OnSuccess(object value)
+		{
+			this.SuccessCallback?.Invoke((T)value);
 		}
 
 		/// <inheritdoc/>

--- a/src/Moq/Match.cs
+++ b/src/Moq/Match.cs
@@ -33,7 +33,13 @@ namespace Moq
 
 		internal abstract bool Matches(object value);
 
+		internal virtual void OnSuccess()
+		{
+		}
+
 		bool IMatcher.Matches(object value) => this.Matches(value);
+
+		void IMatcher.OnSuccess() => this.OnSuccess();
 
 		internal Expression RenderExpression { get; set; }
 

--- a/src/Moq/Match.cs
+++ b/src/Moq/Match.cs
@@ -33,9 +33,7 @@ namespace Moq
 
 		internal abstract bool Matches(object value);
 
-		internal virtual void SetupEvaluatedSuccessfully(object value)
-		{
-		}
+		internal abstract void SetupEvaluatedSuccessfully(object value);
 
 		bool IMatcher.Matches(object value) => this.Matches(value);
 

--- a/src/Moq/Match.cs
+++ b/src/Moq/Match.cs
@@ -99,13 +99,13 @@ namespace Moq
 	public class Match<T> : Match, IEquatable<Match<T>>
 	{
 		internal Predicate<T> Condition { get; set; }
-		internal Action<T> SetupEvaluatedSuccessfullyCallback { get; set; }
+		internal Action<T> Success { get; set; }
 
-		internal Match(Predicate<T> condition, Expression<Func<T>> renderExpression, Action<T> setupEvaluatedSuccessfullyCallback = null)
+		internal Match(Predicate<T> condition, Expression<Func<T>> renderExpression, Action<T> success = null)
 		{
 			this.Condition = condition;
 			this.RenderExpression = renderExpression.Body.Apply(EvaluateCaptures.Rewriter);
-			this.SetupEvaluatedSuccessfullyCallback = setupEvaluatedSuccessfullyCallback;
+			this.Success = success;
 		}
 
 		internal override bool Matches(object value)
@@ -134,7 +134,7 @@ namespace Moq
 
 		internal override void SetupEvaluatedSuccessfully(object value)
 		{
-			this.SetupEvaluatedSuccessfullyCallback?.Invoke((T)value);
+			this.Success?.Invoke((T)value);
 		}
 
 		/// <inheritdoc/>

--- a/src/Moq/Matchers/AnyMatcher.cs
+++ b/src/Moq/Matchers/AnyMatcher.cs
@@ -13,7 +13,7 @@ namespace Moq.Matchers
 
 		public bool Matches(object value) => true;
 
-		public void OnSuccess()
+		public void OnSuccess(object value)
 		{
 		}
     }

--- a/src/Moq/Matchers/AnyMatcher.cs
+++ b/src/Moq/Matchers/AnyMatcher.cs
@@ -12,5 +12,9 @@ namespace Moq.Matchers
 		}
 
 		public bool Matches(object value) => true;
-	}
+
+		public void OnSuccess()
+		{
+		}
+    }
 }

--- a/src/Moq/Matchers/AnyMatcher.cs
+++ b/src/Moq/Matchers/AnyMatcher.cs
@@ -13,7 +13,7 @@ namespace Moq.Matchers
 
 		public bool Matches(object value) => true;
 
-		public void OnSuccess(object value)
+		public void SetupEvaluatedSuccessfully(object value)
 		{
 		}
     }

--- a/src/Moq/Matchers/ConstantMatcher.cs
+++ b/src/Moq/Matchers/ConstantMatcher.cs
@@ -35,7 +35,7 @@ namespace Moq.Matchers
 			return false;
 		}
 
-		public void OnSuccess(object value)
+		public void SetupEvaluatedSuccessfully(object value)
 		{
 		}
 

--- a/src/Moq/Matchers/ConstantMatcher.cs
+++ b/src/Moq/Matchers/ConstantMatcher.cs
@@ -35,7 +35,7 @@ namespace Moq.Matchers
 			return false;
 		}
 
-		public void OnSuccess()
+		public void OnSuccess(object value)
 		{
 		}
 

--- a/src/Moq/Matchers/ConstantMatcher.cs
+++ b/src/Moq/Matchers/ConstantMatcher.cs
@@ -35,6 +35,10 @@ namespace Moq.Matchers
 			return false;
 		}
 
+		public void OnSuccess()
+		{
+		}
+
 		private bool MatchesEnumerable(IEnumerable enumerable)
 		{
 			var constValues = (IEnumerable)constantValue;

--- a/src/Moq/Matchers/ExpressionMatcher.cs
+++ b/src/Moq/Matchers/ExpressionMatcher.cs
@@ -20,5 +20,9 @@ namespace Moq.Matchers
 			return value is Expression valueExpression
 				&& ExpressionComparer.Default.Equals(this.expression, valueExpression);
 		}
+
+		public void OnSuccess()
+		{
+		}
 	}
 }

--- a/src/Moq/Matchers/ExpressionMatcher.cs
+++ b/src/Moq/Matchers/ExpressionMatcher.cs
@@ -21,7 +21,7 @@ namespace Moq.Matchers
 				&& ExpressionComparer.Default.Equals(this.expression, valueExpression);
 		}
 
-		public void OnSuccess(object value)
+		public void SetupEvaluatedSuccessfully(object value)
 		{
 		}
 	}

--- a/src/Moq/Matchers/ExpressionMatcher.cs
+++ b/src/Moq/Matchers/ExpressionMatcher.cs
@@ -21,7 +21,7 @@ namespace Moq.Matchers
 				&& ExpressionComparer.Default.Equals(this.expression, valueExpression);
 		}
 
-		public void OnSuccess()
+		public void OnSuccess(object value)
 		{
 		}
 	}

--- a/src/Moq/Matchers/LazyEvalMatcher.cs
+++ b/src/Moq/Matchers/LazyEvalMatcher.cs
@@ -26,7 +26,7 @@ namespace Moq.Matchers
 			return false;
 		}
 
-		public void OnSuccess()
+		public void OnSuccess(object value)
 		{
 		}
 	}

--- a/src/Moq/Matchers/LazyEvalMatcher.cs
+++ b/src/Moq/Matchers/LazyEvalMatcher.cs
@@ -25,5 +25,9 @@ namespace Moq.Matchers
 
 			return false;
 		}
+
+		public void OnSuccess()
+		{
+		}
 	}
 }

--- a/src/Moq/Matchers/LazyEvalMatcher.cs
+++ b/src/Moq/Matchers/LazyEvalMatcher.cs
@@ -26,7 +26,7 @@ namespace Moq.Matchers
 			return false;
 		}
 
-		public void OnSuccess(object value)
+		public void SetupEvaluatedSuccessfully(object value)
 		{
 		}
 	}

--- a/src/Moq/Matchers/MatcherAttributeMatcher.cs
+++ b/src/Moq/Matchers/MatcherAttributeMatcher.cs
@@ -89,7 +89,7 @@ namespace Moq.Matchers
 			return (bool)validatorMethod.Invoke(instance, args);
 		}
 
-		public void OnSuccess(object value)
+		public void SetupEvaluatedSuccessfully(object value)
 		{
 		}
 	}

--- a/src/Moq/Matchers/MatcherAttributeMatcher.cs
+++ b/src/Moq/Matchers/MatcherAttributeMatcher.cs
@@ -88,5 +88,9 @@ namespace Moq.Matchers
 			var instance = this.expression.Object == null ? null : (this.expression.Object.PartialEval() as ConstantExpression).Value;
 			return (bool)validatorMethod.Invoke(instance, args);
 		}
+
+		public void OnSuccess()
+		{
+		}
 	}
 }

--- a/src/Moq/Matchers/MatcherAttributeMatcher.cs
+++ b/src/Moq/Matchers/MatcherAttributeMatcher.cs
@@ -89,7 +89,7 @@ namespace Moq.Matchers
 			return (bool)validatorMethod.Invoke(instance, args);
 		}
 
-		public void OnSuccess()
+		public void OnSuccess(object value)
 		{
 		}
 	}

--- a/src/Moq/Matchers/ParamArrayMatcher.cs
+++ b/src/Moq/Matchers/ParamArrayMatcher.cs
@@ -36,11 +36,11 @@ namespace Moq.Matchers
 			return true;
 		}
 
-		public void OnSuccess(object value)
+		public void SetupEvaluatedSuccessfully(object value)
 		{
 			foreach (var matcher in this.matchers)
 			{
-				matcher.OnSuccess(value);
+				matcher.SetupEvaluatedSuccessfully(value);
 			}
 		}
 	}

--- a/src/Moq/Matchers/ParamArrayMatcher.cs
+++ b/src/Moq/Matchers/ParamArrayMatcher.cs
@@ -35,5 +35,13 @@ namespace Moq.Matchers
 
 			return true;
 		}
+
+		public void OnSuccess()
+		{
+			foreach (var matcher in this.matchers)
+			{
+				matcher.OnSuccess();
+			}
+		}
 	}
 }

--- a/src/Moq/Matchers/ParamArrayMatcher.cs
+++ b/src/Moq/Matchers/ParamArrayMatcher.cs
@@ -36,11 +36,11 @@ namespace Moq.Matchers
 			return true;
 		}
 
-		public void OnSuccess()
+		public void OnSuccess(object value)
 		{
 			foreach (var matcher in this.matchers)
 			{
-				matcher.OnSuccess();
+				matcher.OnSuccess(value);
 			}
 		}
 	}

--- a/src/Moq/Matchers/RefMatcher.cs
+++ b/src/Moq/Matchers/RefMatcher.cs
@@ -20,7 +20,7 @@ namespace Moq.Matchers
 			                                 : object.ReferenceEquals(this.reference, value);
 		}
 
-		public void OnSuccess(object value)
+		public void SetupEvaluatedSuccessfully(object value)
 		{
 		}
 	}

--- a/src/Moq/Matchers/RefMatcher.cs
+++ b/src/Moq/Matchers/RefMatcher.cs
@@ -19,5 +19,9 @@ namespace Moq.Matchers
 			return this.referenceIsValueType ? object.Equals(this.reference, value)
 			                                 : object.ReferenceEquals(this.reference, value);
 		}
+
+		public void OnSuccess()
+		{
+		}
 	}
 }

--- a/src/Moq/Matchers/RefMatcher.cs
+++ b/src/Moq/Matchers/RefMatcher.cs
@@ -20,7 +20,7 @@ namespace Moq.Matchers
 			                                 : object.ReferenceEquals(this.reference, value);
 		}
 
-		public void OnSuccess()
+		public void OnSuccess(object value)
 		{
 		}
 	}

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -68,8 +68,8 @@ namespace Moq
 
 		public void EvaluatedSuccessfully(Invocation invocation)
 		{
-			this.Condition?.EvaluatedSuccessfully();
-			this.expectation.EvaluatedSuccessfully(invocation);
+			this.Condition?.SetupEvaluatedSuccessfully();
+			this.expectation.SetupEvaluatedSuccessfully(invocation);
 		}
 
 		public virtual void SetOutParameters(Invocation invocation)

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -66,6 +66,12 @@ namespace Moq
 			}
 		}
 
+		public void EvaluatedSuccessfully(Invocation invocation)
+		{
+			this.Condition?.EvaluatedSuccessfully();
+			this.expectation.EvaluatedSuccessfully(invocation);
+		}
+
 		public virtual void SetOutParameters(Invocation invocation)
 		{
 		}

--- a/tests/Moq.Tests/CaptureFixture.cs
+++ b/tests/Moq.Tests/CaptureFixture.cs
@@ -64,6 +64,18 @@ namespace Moq.Tests
 			Assert.Equal(expectedValues, items);
 		}
 
+		[Fact]
+		public void ShouldNotCaptureParameterWhenConditionalSetupIsFalse()
+		{
+			var captures = new List<string>();
+			var mock = new Mock<IFoo>();
+			mock.When(() => false).Setup(m => m.DoSomething(Capture.In(captures)));
+
+			mock.Object.DoSomething("X");
+
+			Assert.Empty(captures);
+		}
+
 		public interface IFoo
 		{
 			void DoSomething(string s);

--- a/tests/Moq.Tests/CaptureFixture.cs
+++ b/tests/Moq.Tests/CaptureFixture.cs
@@ -23,6 +23,34 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public void ShouldOnlyCaptureParameterForSpecificArgumentBeforeCollection()
+		{
+			var items = new List<string>();
+			var mock = new Mock<IFoo>();
+			mock.Setup(x => x.DoSomething(1, Capture.In(items)));
+
+			mock.Object.DoSomething(1, "Hello!");
+			mock.Object.DoSomething(2, "World");
+
+			var expectedValues = new List<string> { "Hello!" };
+			Assert.Equal(expectedValues, items);
+		}
+
+		[Fact]
+		public void ShouldOnlyCaptureParameterForSpecificArgumentAfterCollection()
+		{
+			var items = new List<string>();
+			var mock = new Mock<IFoo>();
+			mock.Setup(x => x.DoSomething(Capture.In(items), 1));
+
+			mock.Object.DoSomething("Hello!", 1);
+			mock.Object.DoSomething("World", 2);
+
+			var expectedValues = new List<string> { "Hello!" };
+			Assert.Equal(expectedValues, items);
+		}
+
+		[Fact]
 		public void CanCaptureSpecificParameterInCollection()
 		{
 			var items = new List<string>();
@@ -39,6 +67,8 @@ namespace Moq.Tests
 		public interface IFoo
 		{
 			void DoSomething(string s);
+			void DoSomething(int i, string s);
+			void DoSomething(string s, int i);
 		}
 	}
 }


### PR DESCRIPTION
Hi.

I would like to improve the capture helper to support the following scenario:
```cs
[Fact]
public void ShouldOnlyCaptureParameterForSpecificArgumentAfterCollection()
{
	var items = new List<string>();
	var mock = new Mock<IFoo>();
	mock.Setup(x => x.DoSomething(Capture.In(items), 1));

	mock.Object.DoSomething("Hello!", 1);
	mock.Object.DoSomething("World", 2);

	var expectedValues = new List<string> { "Hello!" };
	Assert.Equal(expectedValues, items);
}
```

This test currently fails because the capture match is evaluated on every method call, even when other matches do not pass. The goal of this PR is to perform the capture only after all parameter match were successfully evaluated.

The current implementation is a proposal and I am clearly open to suggestions or improvements ideas.