### PR TITLE
`VerifyNoOtherCalls`: Prevent stack overflow by remembering already verified mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 * `mock.SetupAllProperties()` now setups write-only properties for strict mocks, so that accessing such properties will not throw anymore. (@vanashimko, #836)
 * Regression: `mock.SetupAllProperties()` and `Mock.Of<T>` fail due to inaccessible property accessors (@Mexe13, #845)
+* Regression: `VerifyNoOtherCalls` causes stack overflow when mock setup returns the mocked object (@bash, #846)
 
 
 ## 4.11.0 (2019-05-28)

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -338,6 +338,13 @@ namespace Moq
 
 		internal static void VerifyNoOtherCalls(Mock mock)
 		{
+			Mock.VerifyNoOtherCalls(mock, verifiedMocks: new HashSet<Mock>());
+		}
+
+		private static void VerifyNoOtherCalls(Mock mock, HashSet<Mock> verifiedMocks)
+		{
+			if (!verifiedMocks.Add(mock)) return;
+
 			var unverifiedInvocations = mock.MutableInvocations.ToArray(invocation => !invocation.Verified);
 
 			var innerMockSetups = mock.Setups.GetInnerMockSetups();
@@ -377,7 +384,7 @@ namespace Moq
 			// created by "transitive" invocations):
 			foreach (var inner in innerMockSetups)
 			{
-				VerifyNoOtherCalls(inner.GetInnerMock());
+				VerifyNoOtherCalls(inner.GetInnerMock(), verifiedMocks);
 			}
 		}
 

--- a/tests/Moq.Tests/VerifyFixture.cs
+++ b/tests/Moq.Tests/VerifyFixture.cs
@@ -1578,6 +1578,30 @@ namespace Moq.Tests
 			}
 		}
 
+		public class Object_graph_loops
+		{
+			public interface IX
+			{
+				IX Self { get; }
+			}
+
+			[Fact]
+			public void When_mock_returns_itself_via_setup_VerifyNoOtherCalls_wont_go_into_infinite_loop()
+			{
+				var mock = new Mock<IX>();
+				mock.Setup(m => m.Self).Returns(mock.Object);
+				mock.VerifyNoOtherCalls();
+			}
+
+			[Fact]
+			public void When_mock_returns_itself_lazily_via_setup_VerifyNoOtherCalls_wont_go_into_infinite_loop()
+			{
+				var mock = new Mock<IX>();
+				mock.Setup(m => m.Self).Returns(() => mock.Object);
+				mock.VerifyNoOtherCalls();
+			}
+		}
+
 		public interface IBar
 		{
 			int? Value { get; set; }


### PR DESCRIPTION
Fixes #846. Thanks again for reporting this defect!

/cc @bash, @jnferner, @Mafii