### PR TITLE
Make return values of loose mock setups having no `.Returns` nor `.CallBase` more consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 #### Changed
 
 * Improved performance for `Mock.Of<T>` and `mock.SetupAllProperties()` as the latter now performs property setups just-in-time, instead of as an ahead-of-time batch operation. (@vanashimko, #826)
+* Setups with no `.Returns(…)` nor `.CallBase()` no longer return `default(T)` for loose mocks, but a value that is consistent with the mock's `CallBase` and `DefaultValue[Provider]` settings. (@stakx, #849)
 
 #### Added
 
@@ -18,6 +19,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 #### Fixed
 
+* Adding `Callback` to a mock breaks async tests (@marcin-chwedczuk-meow, #702)
 * `mock.SetupAllProperties()` now setups write-only properties for strict mocks, so that accessing such properties will not throw anymore. (@vanashimko, #836)
 * Regression: `mock.SetupAllProperties()` and `Mock.Of<T>` fail due to inaccessible property accessors (@Mexe13, #845)
 * Regression: `VerifyNoOtherCalls` causes stack overflow when mock setup returns the mocked object (@bash, #846)

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -123,7 +123,11 @@ namespace Moq
 					}
 					else
 					{
-						invocation.Return(this.Method.ReturnType.GetDefaultValue());
+						// Instead of duplicating the entirety of `Return`'s implementation,
+						// let's just call it here. This is permissible only if the inter-
+						// ception pipeline will terminate right away (otherwise `Return`
+						// might be executed a second time).
+						Return.Handle(invocation, this.Mock);
 					}
 				}
 

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2294,6 +2294,46 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 702
+
+		public class Issue702
+		{
+			public interface ISomeDependency
+			{
+				Task DoMoreStuffAsync();
+			}
+
+			[Fact]
+			public async Task Can_await_async_method_if_Returns_used_to_set_return_value()
+			{
+				var mock = new Mock<ISomeDependency>();
+				mock.Setup(x => x.DoMoreStuffAsync())
+					.Returns(Task.CompletedTask)
+					.Callback(() => { });
+				await mock.Object.DoMoreStuffAsync();
+			}
+
+			[Theory]
+			[InlineData(DefaultValue.Empty)]
+			[InlineData(DefaultValue.Mock)]
+			public async Task Can_await_async_method_if_Returns_omitted(DefaultValue defaultValue)
+			{
+				// NOTE: This test expressly includes `DefaultValue` to document that
+				// the claim made in the method name isn't generally true due to some
+				// dedicated logic that treats "async methods" specially; it's simply
+				// the standard default value providers that happen to produce non-null
+				// return values for async methods.
+
+				var mock = new Mock<ISomeDependency>() { DefaultValue = defaultValue };
+				mock.Setup(x => x.DoMoreStuffAsync())
+				//  .Returns(Task.CompletedTask)
+				    .Callback(() => { });
+				await mock.Object.DoMoreStuffAsync();
+			}
+		}
+
+		#endregion
+
 		#region 706
 
 		public class Issue706

--- a/tests/Moq.Tests/ReturnsFixture.cs
+++ b/tests/Moq.Tests/ReturnsFixture.cs
@@ -360,6 +360,35 @@ namespace Moq.Tests
 			Assert.Same(expectedResult, actualResult); // should be returned by method as is
 		}
 
+		[Fact]
+		public void Given_a_loose_mock_Return_value_of_setup_without_Returns_nor_CallBase_equals_return_value_if_setup_werent_there_at_all()
+		{
+			const int expected = 42;
+
+			var mock = new Mock<IFoo>(MockBehavior.Loose);
+			mock.SetReturnsDefault<int>(expected);
+
+			var actualWithoutSetup = mock.Object.Value;
+			Assert.Equal(expected, actualWithoutSetup);
+
+			mock.SetupGet(m => m.Value);
+
+			var actualWithSetup = mock.Object.Value;
+			Assert.Equal(actualWithoutSetup, actualWithSetup);
+		}
+
+		[Fact]
+		public void Given_a_loose_mock_with_CallBase_Return_value_of_setup_without_Returns_nor_CallBase_equals_return_value_if_setup_werent_there_at_all()
+		{
+			var mock = new Mock<Foo>(MockBehavior.Loose) { CallBase = true };
+			var expected = mock.Object.StringProperty;
+
+			mock.SetupGet(m => m.StringProperty);
+			var actual = mock.Object.StringProperty;
+
+			Assert.Equal(expected, actual);
+		}
+
 		public interface IFoo
 		{
 			void Execute();


### PR DESCRIPTION
See details in commit message.

This also resolves #702.