### PR TITLE
#825 event handlers setup and verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 * Improved error message that is supplied with `ArgumentException` thrown when `Setup` or `Verify` are called on a protected method if the method could not be found with both the name and compatible argument types specified (@thomasfdm, #852).
 
+#### Added
+
+* Added support for setup and verification of the event handlers through `Setup[Add|Remove]` and `Verify[Add|Remove|All]` (@lepijohnny, #825) 
+
 ## 4.12.0 (2019-06-20)
 
 #### Changed

--- a/src/Moq/ExpressionStringBuilder.cs
+++ b/src/Moq/ExpressionStringBuilder.cs
@@ -344,6 +344,18 @@ namespace Moq
 					this.builder.Append('.').Append(node.Method.Name.Substring(4)).Append(" = ");
 					ToString(node.Arguments.Last());
 				}
+				else if (node.Method.LooksLikeEventAttach())
+				{
+					this.builder.Append('.')
+					.AppendNameOfAddEvent(node.Method, includeGenericArgumentList: true);
+					AsCommaSeparatedValues(node.Arguments.Skip(paramFrom), ToString);
+				}
+				else if (node.Method.LooksLikeEventDetach())
+				{
+					this.builder.Append('.')
+					.AppendNameOfRemoveEvent(node.Method, includeGenericArgumentList: true);
+					AsCommaSeparatedValues(node.Arguments.Skip(paramFrom), ToString);
+				}
 				else
 				{
 					this.builder

--- a/src/Moq/Guard.cs
+++ b/src/Moq/Guard.cs
@@ -82,6 +82,46 @@ namespace Moq
 			}
 		}
 
+		public static void IsEventAttach(LambdaExpression expression, string paramName)
+		{
+			Debug.Assert(expression != null);
+
+			switch (expression.Body.NodeType)
+			{
+				case ExpressionType.Call:
+					var call = (MethodCallExpression)expression.Body;
+					if (call.Method.LooksLikeEventAttach()) return;
+					break;
+			}
+
+			throw new ArgumentException(
+				string.Format(
+					CultureInfo.CurrentCulture,
+					Resources.SetupNotEventAttach,
+					expression.ToStringFixed()),
+				paramName);
+		}
+
+		public static void IsEventDetach(LambdaExpression expression, string paramName)
+		{
+			Debug.Assert(expression != null);
+
+			switch (expression.Body.NodeType)
+			{
+				case ExpressionType.Call:
+					var call = (MethodCallExpression)expression.Body;
+					if (call.Method.LooksLikeEventDetach()) return;
+					break;
+			}
+
+			throw new ArgumentException(
+				string.Format(
+					CultureInfo.CurrentCulture,
+					Resources.SetupNotEventDetach,
+					expression.ToStringFixed()),
+				paramName);
+		}
+
 		/// <summary>
 		/// Ensures the given <paramref name="value"/> is not null.
 		/// Throws <see cref="ArgumentNullException"/> otherwise.

--- a/src/Moq/Interception/InterceptionAspects.cs
+++ b/src/Moq/Interception/InterceptionAspects.cs
@@ -150,15 +150,22 @@ namespace Moq
 
 						if (mock.CallBase && !invocation.Method.IsAbstract)
 						{
-							invocation.ReturnBase();
-							return true;
+							if(!mock.Setups.HasEventSetup)
+							{
+								invocation.ReturnBase();
+							}
 						}
 						else if (invocation.Arguments.Length > 0 && invocation.Arguments[0] is Delegate delegateInstance)
 						{
 							mock.EventHandlers.Add(eventInfo.Name, delegateInstance);
-							invocation.Return();
-							return true;
+
+							if (!mock.Setups.HasEventSetup)
+							{
+								invocation.Return();
+							}
 						}
+
+						return !mock.Setups.HasEventSetup;
 					}
 				}
 				else if (methodName[0] == 'r' && methodName.Length > 7 && methodName[6] == '_' && invocation.Method.LooksLikeEventDetach())
@@ -172,15 +179,22 @@ namespace Moq
 
 						if (mock.CallBase && !invocation.Method.IsAbstract)
 						{
-							invocation.ReturnBase();
-							return true;
+							if (!mock.Setups.HasEventSetup)
+							{
+								invocation.ReturnBase();
+							}
 						}
 						else if (invocation.Arguments.Length > 0 && invocation.Arguments[0] is Delegate delegateInstance)
 						{
 							mock.EventHandlers.Remove(eventInfo.Name, delegateInstance);
-							invocation.Return();
-							return true;
+
+							if (!mock.Setups.HasEventSetup)
+							{
+								invocation.Return();
+							}
 						}
+
+						return !mock.Setups.HasEventSetup;
 					}
 				}
 			}

--- a/src/Moq/Interception/InterceptionAspects.cs
+++ b/src/Moq/Interception/InterceptionAspects.cs
@@ -148,9 +148,11 @@ namespace Moq
 						// If they are equal, then `invocation.Method` is definitely an event `add` accessor.
 						// Not sure whether this would work with F# and COM; see commit 44070a9.
 
+						bool doesntHaveEventSetup = !mock.Setups.HasEventSetup;
+
 						if (mock.CallBase && !invocation.Method.IsAbstract)
 						{
-							if(!mock.Setups.HasEventSetup)
+							if(doesntHaveEventSetup)
 							{
 								invocation.ReturnBase();
 							}
@@ -159,13 +161,13 @@ namespace Moq
 						{
 							mock.EventHandlers.Add(eventInfo.Name, delegateInstance);
 
-							if (!mock.Setups.HasEventSetup)
+							if (doesntHaveEventSetup)
 							{
 								invocation.Return();
 							}
 						}
 
-						return !mock.Setups.HasEventSetup;
+						return doesntHaveEventSetup;
 					}
 				}
 				else if (methodName[0] == 'r' && methodName.Length > 7 && methodName[6] == '_' && invocation.Method.LooksLikeEventDetach())
@@ -177,9 +179,11 @@ namespace Moq
 						// If they are equal, then `invocation.Method` is definitely an event `remove` accessor.
 						// Not sure whether this would work with F# and COM; see commit 44070a9.
 
+						bool doesntHaveEventSetup = !mock.Setups.HasEventSetup;
+
 						if (mock.CallBase && !invocation.Method.IsAbstract)
 						{
-							if (!mock.Setups.HasEventSetup)
+							if (doesntHaveEventSetup)
 							{
 								invocation.ReturnBase();
 							}
@@ -188,13 +192,13 @@ namespace Moq
 						{
 							mock.EventHandlers.Remove(eventInfo.Name, delegateInstance);
 
-							if (!mock.Setups.HasEventSetup)
+							if (doesntHaveEventSetup)
 							{
 								invocation.Return();
 							}
 						}
 
-						return !mock.Setups.HasEventSetup;
+						return doesntHaveEventSetup;
 					}
 				}
 			}

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -104,25 +104,16 @@ namespace Moq
 
 			this.callbackResponse?.Invoke(invocation.Arguments);
 
-			var methodIsNonVoid = (this.flags & Flags.MethodIsNonVoid) != 0;
-
-			if (!methodIsNonVoid)
+			if ((this.flags & Flags.CallBase) != 0)
 			{
-				if ((this.flags & Flags.CallBase) != 0)
-				{
-					invocation.ReturnBase();
-				}
-				else
-				{
-					invocation.Return();
-				}
+				invocation.ReturnBase();
 			}
 
 			this.raiseEventResponse?.RespondTo(invocation);
 
 			this.returnOrThrowResponse?.RespondTo(invocation);
 
-			if (methodIsNonVoid)
+			if ((this.flags & Flags.MethodIsNonVoid) != 0)
 			{
 				if (this.returnOrThrowResponse == null)
 				{

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -104,16 +104,25 @@ namespace Moq
 
 			this.callbackResponse?.Invoke(invocation.Arguments);
 
-			if ((this.flags & Flags.CallBase) != 0)
+			var methodIsNonVoid = (this.flags & Flags.MethodIsNonVoid) != 0;
+
+			if (!methodIsNonVoid)
 			{
-				invocation.ReturnBase();
+				if ((this.flags & Flags.CallBase) != 0)
+				{
+					invocation.ReturnBase();
+				}
+				else
+				{
+					invocation.Return();
+				}
 			}
 
 			this.raiseEventResponse?.RespondTo(invocation);
 
 			this.returnOrThrowResponse?.RespondTo(invocation);
 
-			if ((this.flags & Flags.MethodIsNonVoid) != 0)
+			if (methodIsNonVoid)
 			{
 				if (this.returnOrThrowResponse == null)
 				{

--- a/src/Moq/Mock.Generic.cs
+++ b/src/Moq/Mock.Generic.cs
@@ -900,14 +900,14 @@ namespace Moq
 		/// <summary>
 		///   Verifies that an event was added to the mock.
 		/// </summary>
-		/// <param name="addEventExpression">Expression to verify.</param>
+		/// <param name="addExpression">Expression to verify.</param>
 		/// <exception cref="MockException">The invocation was not performed on the mock.</exception>
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyAdd(expression)"]/*'/>
-		public void VerifyAdd(Action<T> addEventExpression)
+		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyAdd(addExpression)"]/*'/>
+		public void VerifyAdd(Action<T> addExpression)
 		{
-			Guard.NotNull(addEventExpression, nameof(addEventExpression));
+			Guard.NotNull(addExpression, nameof(addExpression));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(addEventExpression, this.ConstructorArguments);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(addExpression, this.ConstructorArguments);
 			Mock.VerifyAdd(this, expression, Times.AtLeastOnce(), null);
 		}
 
@@ -915,15 +915,15 @@ namespace Moq
 		///   Verifies that an event was added to the mock.
 		/// </summary>
 		/// <param name="times">The number of times a method is expected to be called.</param>
-		/// <param name="addEventExpression">Expression to verify.</param>
+		/// <param name="addExpression">Expression to verify.</param>
 		/// <exception cref="MockException">
 		///   The invocation was not called the number of times specified by <paramref name="times"/>.
 		/// </exception>
-		public void VerifyAdd(Action<T> addEventExpression, Times times)
+		public void VerifyAdd(Action<T> addExpression, Times times)
 		{
-			Guard.NotNull(addEventExpression, nameof(addEventExpression));
+			Guard.NotNull(addExpression, nameof(addExpression));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(addEventExpression, this.ConstructorArguments);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(addExpression, this.ConstructorArguments);
 			Mock.VerifyAdd(this, expression, times, null);
 		}
 
@@ -931,30 +931,30 @@ namespace Moq
 		///   Verifies that an event was added to the mock.
 		/// </summary>
 		/// <param name="times">The number of times a method is expected to be called.</param>
-		/// <param name="addEventExpression">Expression to verify.</param>
+		/// <param name="addExpression">Expression to verify.</param>
 		/// <exception cref="MockException">
 		///   The invocation was not called the number of times specified by <paramref name="times"/>.
 		/// </exception>
-		public void VerifyAdd(Action<T> addEventExpression, Func<Times> times)
+		public void VerifyAdd(Action<T> addExpression, Func<Times> times)
 		{
-			Guard.NotNull(addEventExpression, nameof(addEventExpression));
+			Guard.NotNull(addExpression, nameof(addExpression));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(addEventExpression, this.ConstructorArguments);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(addExpression, this.ConstructorArguments);
 			Mock.VerifyAdd(this, expression, times(), null);
 		}
 
 		/// <summary>
 		///   Verifies that an event was added to the mock, specifying a failure message.
 		/// </summary>
-		/// <param name="addEventExpression">Expression to verify.</param>
+		/// <param name="addExpression">Expression to verify.</param>
 		/// <param name="failMessage">Message to show if verification fails.</param>
 		/// <exception cref="MockException">The invocation was not performed on the mock.</exception>
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyAdd(expression,failMessage)"]/*'/>
-		public void VerifyAdd(Action<T> addEventExpression, string failMessage)
+		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyAdd(addExpression,failMessage)"]/*'/>
+		public void VerifyAdd(Action<T> addExpression, string failMessage)
 		{
-			Guard.NotNull(addEventExpression, nameof(addEventExpression));
+			Guard.NotNull(addExpression, nameof(addExpression));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(addEventExpression, this.ConstructorArguments);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(addExpression, this.ConstructorArguments);
 			Mock.VerifyAdd(this, expression, Times.AtLeastOnce(), failMessage);
 		}
 
@@ -962,16 +962,16 @@ namespace Moq
 		///   Verifies that an event was added to the mock, specifying a failure message.
 		/// </summary>
 		/// <param name="times">The number of times a method is expected to be called.</param>
-		/// <param name="addEventExpression">Expression to verify.</param>
+		/// <param name="addExpression">Expression to verify.</param>
 		/// <param name="failMessage">Message to show if verification fails.</param>
 		/// <exception cref="MockException">
 		///   The invocation was not called the number of times specified by <paramref name="times"/>.
 		/// </exception>
-		public void VerifyAdd(Action<T> addEventExpression, Times times, string failMessage)
+		public void VerifyAdd(Action<T> addExpression, Times times, string failMessage)
 		{
-			Guard.NotNull(addEventExpression, nameof(addEventExpression));
+			Guard.NotNull(addExpression, nameof(addExpression));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(addEventExpression, this.ConstructorArguments);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(addExpression, this.ConstructorArguments);
 			Mock.VerifyAdd(this, expression, times, failMessage);
 		}
 
@@ -979,30 +979,30 @@ namespace Moq
 		///   Verifies that an event was added to the mock, specifying a failure message.
 		/// </summary>
 		/// <param name="times">The number of times a method is expected to be called.</param>
-		/// <param name="addEventExpression">Expression to verify.</param>
+		/// <param name="addExpression">Expression to verify.</param>
 		/// <param name="failMessage">Message to show if verification fails.</param>
 		/// <exception cref="MockException">
 		///   The invocation was not called the number of times specified by <paramref name="times"/>.
 		/// </exception>
-		public void VerifyAdd(Action<T> addEventExpression, Func<Times> times, string failMessage)
+		public void VerifyAdd(Action<T> addExpression, Func<Times> times, string failMessage)
 		{
-			Guard.NotNull(addEventExpression, nameof(addEventExpression));
+			Guard.NotNull(addExpression, nameof(addExpression));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(addEventExpression, this.ConstructorArguments);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(addExpression, this.ConstructorArguments);
 			Mock.VerifyAdd(this, expression, times(), failMessage);
 		}
 
 		/// <summary>
 		///   Verifies that an event was removed from the mock.
 		/// </summary>
-		/// <param name="removeEventExpression">Expression to verify.</param>
+		/// <param name="removeExpression">Expression to verify.</param>
 		/// <exception cref="MockException">The invocation was not performed on the mock.</exception>
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyRemove(expression)"]/*'/>
-		public void VerifyRemove(Action<T> removeEventExpression)
+		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyRemove(removeExpression)"]/*'/>
+		public void VerifyRemove(Action<T> removeExpression)
 		{
-			Guard.NotNull(removeEventExpression, nameof(removeEventExpression));
+			Guard.NotNull(removeExpression, nameof(removeExpression));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeEventExpression, this.ConstructorArguments);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeExpression, this.ConstructorArguments);
 			Mock.VerifyRemove(this, expression, Times.AtLeastOnce(), null);
 		}
 
@@ -1010,15 +1010,15 @@ namespace Moq
 		///   Verifies that an event was removed from the mock.
 		/// </summary>
 		/// <param name="times">The number of times a method is expected to be called.</param>
-		/// <param name="removeEventExpression">Expression to verify.</param>
+		/// <param name="removeExpression">Expression to verify.</param>
 		/// <exception cref="MockException">
 		///   The invocation was not called the number of times specified by <paramref name="times"/>.
 		/// </exception>
-		public void VerifyRemove(Action<T> removeEventExpression, Times times)
+		public void VerifyRemove(Action<T> removeExpression, Times times)
 		{
-			Guard.NotNull(removeEventExpression, nameof(removeEventExpression));
+			Guard.NotNull(removeExpression, nameof(removeExpression));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeEventExpression, this.ConstructorArguments);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeExpression, this.ConstructorArguments);
 			Mock.VerifyRemove(this, expression, times, null);
 		}
 
@@ -1026,30 +1026,30 @@ namespace Moq
 		///   Verifies that an event was removed from the mock.
 		/// </summary>
 		/// <param name="times">The number of times a method is expected to be called.</param>
-		/// <param name="removeEventExpression">Expression to verify.</param>
+		/// <param name="removeExpression">Expression to verify.</param>
 		/// <exception cref="MockException">
 		///   The invocation was not called the number of times specified by <paramref name="times"/>.
 		/// </exception>
-		public void VerifyRemove(Action<T> removeEventExpression, Func<Times> times)
+		public void VerifyRemove(Action<T> removeExpression, Func<Times> times)
 		{
-			Guard.NotNull(removeEventExpression, nameof(removeEventExpression));
+			Guard.NotNull(removeExpression, nameof(removeExpression));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeEventExpression, this.ConstructorArguments);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeExpression, this.ConstructorArguments);
 			Mock.VerifyRemove(this, expression, times(), null);
 		}
 
 		/// <summary>
 		///   Verifies that an event was removed from the mock, specifying a failure message.
 		/// </summary>
-		/// <param name="removeEventExpression">Expression to verify.</param>
+		/// <param name="removeExpression">Expression to verify.</param>
 		/// <param name="failMessage">Message to show if verification fails.</param>
 		/// <exception cref="MockException">The invocation was not performed on the mock.</exception>
-		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyRemove(expression,failMessage)"]/*'/>
-		public void VerifyRemove(Action<T> removeEventExpression, string failMessage)
+		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyRemove(removeExpression,failMessage)"]/*'/>
+		public void VerifyRemove(Action<T> removeExpression, string failMessage)
 		{
-			Guard.NotNull(removeEventExpression, nameof(removeEventExpression));
+			Guard.NotNull(removeExpression, nameof(removeExpression));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeEventExpression, this.ConstructorArguments);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeExpression, this.ConstructorArguments);
 			Mock.VerifyRemove(this, expression, Times.AtLeastOnce(), failMessage);
 		}
 
@@ -1057,16 +1057,16 @@ namespace Moq
 		///   Verifies that an event was removed from the mock, specifying a failure message.
 		/// </summary>
 		/// <param name="times">The number of times a method is expected to be called.</param>
-		/// <param name="removeEventExpression">Expression to verify.</param>
+		/// <param name="removeExpression">Expression to verify.</param>
 		/// <param name="failMessage">Message to show if verification fails.</param>
 		/// <exception cref="MockException">
 		///   The invocation was not called the number of times specified by <paramref name="times"/>.
 		/// </exception>
-		public void VerifyRemove(Action<T> removeEventExpression, Times times, string failMessage)
+		public void VerifyRemove(Action<T> removeExpression, Times times, string failMessage)
 		{
-			Guard.NotNull(removeEventExpression, nameof(removeEventExpression));
+			Guard.NotNull(removeExpression, nameof(removeExpression));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeEventExpression, this.ConstructorArguments);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeExpression, this.ConstructorArguments);
 			Mock.VerifyRemove(this, expression, times, failMessage);
 		}
 
@@ -1074,16 +1074,16 @@ namespace Moq
 		///   Verifies that an event was removed from the mock, specifying a failure message.
 		/// </summary>
 		/// <param name="times">The number of times a method is expected to be called.</param>
-		/// <param name="removeEventExpression">Expression to verify.</param>
+		/// <param name="removeExpression">Expression to verify.</param>
 		/// <param name="failMessage">Message to show if verification fails.</param>
 		/// <exception cref="MockException">
 		///   The invocation was not called the number of times specified by <paramref name="times"/>.
 		/// </exception>
-		public void VerifyRemove(Action<T> removeEventExpression, Func<Times> times, string failMessage)
+		public void VerifyRemove(Action<T> removeExpression, Func<Times> times, string failMessage)
 		{
-			Guard.NotNull(removeEventExpression, nameof(removeEventExpression));
+			Guard.NotNull(removeExpression, nameof(removeExpression));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeEventExpression, this.ConstructorArguments);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeExpression, this.ConstructorArguments);
 			Mock.VerifyRemove(this, expression, times(), failMessage);
 		}
 

--- a/src/Moq/Mock.Generic.cs
+++ b/src/Moq/Mock.Generic.cs
@@ -389,6 +389,44 @@ namespace Moq
 		}
 
 		/// <summary>
+		///   Specifies a setup on the mocked type for a call to an event add.
+		/// </summary>
+		/// <param name="addExpression">Lambda expression that adds an event.</param>
+		/// <remarks>
+		///   If more than one setup is set for the same event add,
+		///   the latest one wins and is the one that will be executed.
+		/// </remarks>
+		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupAdd"]/*'/>
+		public ISetup<T> SetupAdd(Action<T> addExpression)
+		{
+			Guard.NotNull(addExpression, nameof(addExpression));
+
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(addExpression, this.ConstructorArguments);
+
+			var setup = Mock.SetupAdd(this, expression, condition: null);
+			return new VoidSetupPhrase<T>(setup);
+		}
+
+		/// <summary>
+		///   Specifies a setup on the mocked type for a call to an event 'remove.
+		/// </summary>
+		/// <param name="removeExpression">Lambda expression that removes an event.</param>
+		/// <remarks>
+		///   If more than one setup is set for the same event remove,
+		///   the latest one wins and is the one that will be executed.
+		/// </remarks>
+		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.SetupRemove"]/*'/>
+		public ISetup<T> SetupRemove(Action<T> removeExpression)
+		{
+			Guard.NotNull(removeExpression, nameof(removeExpression));
+
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeExpression, this.ConstructorArguments);
+
+			var setup = Mock.SetupRemove(this, expression, condition: null);
+			return new VoidSetupPhrase<T>(setup);
+		}
+
+		/// <summary>
 		///   Specifies that the given property should have "property behavior",
 		///   meaning that setting its value will cause it to be saved and later returned when the property is requested.
 		///   (This is also known as "stubbing".)
@@ -857,6 +895,196 @@ namespace Moq
 
 			var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression, this.ConstructorArguments);
 			Mock.VerifySet(this, expression , times(), failMessage);
+		}
+
+		/// <summary>
+		///   Verifies that an event was added to the mock.
+		/// </summary>
+		/// <param name="addEventExpression">Expression to verify.</param>
+		/// <exception cref="MockException">The invocation was not performed on the mock.</exception>
+		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyAdd(expression)"]/*'/>
+		public void VerifyAdd(Action<T> addEventExpression)
+		{
+			Guard.NotNull(addEventExpression, nameof(addEventExpression));
+
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(addEventExpression, this.ConstructorArguments);
+			Mock.VerifyAdd(this, expression, Times.AtLeastOnce(), null);
+		}
+
+		/// <summary>
+		///   Verifies that an event was added to the mock.
+		/// </summary>
+		/// <param name="times">The number of times a method is expected to be called.</param>
+		/// <param name="addEventExpression">Expression to verify.</param>
+		/// <exception cref="MockException">
+		///   The invocation was not called the number of times specified by <paramref name="times"/>.
+		/// </exception>
+		public void VerifyAdd(Action<T> addEventExpression, Times times)
+		{
+			Guard.NotNull(addEventExpression, nameof(addEventExpression));
+
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(addEventExpression, this.ConstructorArguments);
+			Mock.VerifyAdd(this, expression, times, null);
+		}
+
+		/// <summary>
+		///   Verifies that an event was added to the mock.
+		/// </summary>
+		/// <param name="times">The number of times a method is expected to be called.</param>
+		/// <param name="addEventExpression">Expression to verify.</param>
+		/// <exception cref="MockException">
+		///   The invocation was not called the number of times specified by <paramref name="times"/>.
+		/// </exception>
+		public void VerifyAdd(Action<T> addEventExpression, Func<Times> times)
+		{
+			Guard.NotNull(addEventExpression, nameof(addEventExpression));
+
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(addEventExpression, this.ConstructorArguments);
+			Mock.VerifyAdd(this, expression, times(), null);
+		}
+
+		/// <summary>
+		///   Verifies that an event was added to the mock, specifying a failure message.
+		/// </summary>
+		/// <param name="addEventExpression">Expression to verify.</param>
+		/// <param name="failMessage">Message to show if verification fails.</param>
+		/// <exception cref="MockException">The invocation was not performed on the mock.</exception>
+		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyAdd(expression,failMessage)"]/*'/>
+		public void VerifyAdd(Action<T> addEventExpression, string failMessage)
+		{
+			Guard.NotNull(addEventExpression, nameof(addEventExpression));
+
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(addEventExpression, this.ConstructorArguments);
+			Mock.VerifyAdd(this, expression, Times.AtLeastOnce(), failMessage);
+		}
+
+		/// <summary>
+		///   Verifies that an event was added to the mock, specifying a failure message.
+		/// </summary>
+		/// <param name="times">The number of times a method is expected to be called.</param>
+		/// <param name="addEventExpression">Expression to verify.</param>
+		/// <param name="failMessage">Message to show if verification fails.</param>
+		/// <exception cref="MockException">
+		///   The invocation was not called the number of times specified by <paramref name="times"/>.
+		/// </exception>
+		public void VerifyAdd(Action<T> addEventExpression, Times times, string failMessage)
+		{
+			Guard.NotNull(addEventExpression, nameof(addEventExpression));
+
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(addEventExpression, this.ConstructorArguments);
+			Mock.VerifyAdd(this, expression, times, failMessage);
+		}
+
+		/// <summary>
+		///   Verifies that an event was added to the mock, specifying a failure message.
+		/// </summary>
+		/// <param name="times">The number of times a method is expected to be called.</param>
+		/// <param name="addEventExpression">Expression to verify.</param>
+		/// <param name="failMessage">Message to show if verification fails.</param>
+		/// <exception cref="MockException">
+		///   The invocation was not called the number of times specified by <paramref name="times"/>.
+		/// </exception>
+		public void VerifyAdd(Action<T> addEventExpression, Func<Times> times, string failMessage)
+		{
+			Guard.NotNull(addEventExpression, nameof(addEventExpression));
+
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(addEventExpression, this.ConstructorArguments);
+			Mock.VerifyAdd(this, expression, times(), failMessage);
+		}
+
+		/// <summary>
+		///   Verifies that an event was removed from the mock.
+		/// </summary>
+		/// <param name="removeEventExpression">Expression to verify.</param>
+		/// <exception cref="MockException">The invocation was not performed on the mock.</exception>
+		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyRemove(expression)"]/*'/>
+		public void VerifyRemove(Action<T> removeEventExpression)
+		{
+			Guard.NotNull(removeEventExpression, nameof(removeEventExpression));
+
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeEventExpression, this.ConstructorArguments);
+			Mock.VerifyRemove(this, expression, Times.AtLeastOnce(), null);
+		}
+
+		/// <summary>
+		///   Verifies that an event was removed from the mock.
+		/// </summary>
+		/// <param name="times">The number of times a method is expected to be called.</param>
+		/// <param name="removeEventExpression">Expression to verify.</param>
+		/// <exception cref="MockException">
+		///   The invocation was not called the number of times specified by <paramref name="times"/>.
+		/// </exception>
+		public void VerifyRemove(Action<T> removeEventExpression, Times times)
+		{
+			Guard.NotNull(removeEventExpression, nameof(removeEventExpression));
+
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeEventExpression, this.ConstructorArguments);
+			Mock.VerifyRemove(this, expression, times, null);
+		}
+
+		/// <summary>
+		///   Verifies that an event was removed from the mock.
+		/// </summary>
+		/// <param name="times">The number of times a method is expected to be called.</param>
+		/// <param name="removeEventExpression">Expression to verify.</param>
+		/// <exception cref="MockException">
+		///   The invocation was not called the number of times specified by <paramref name="times"/>.
+		/// </exception>
+		public void VerifyRemove(Action<T> removeEventExpression, Func<Times> times)
+		{
+			Guard.NotNull(removeEventExpression, nameof(removeEventExpression));
+
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeEventExpression, this.ConstructorArguments);
+			Mock.VerifyRemove(this, expression, times(), null);
+		}
+
+		/// <summary>
+		///   Verifies that an event was removed from the mock, specifying a failure message.
+		/// </summary>
+		/// <param name="removeEventExpression">Expression to verify.</param>
+		/// <param name="failMessage">Message to show if verification fails.</param>
+		/// <exception cref="MockException">The invocation was not performed on the mock.</exception>
+		/// <include file='Mock.Generic.xdoc' path='docs/doc[@for="Mock{T}.VerifyRemove(expression,failMessage)"]/*'/>
+		public void VerifyRemove(Action<T> removeEventExpression, string failMessage)
+		{
+			Guard.NotNull(removeEventExpression, nameof(removeEventExpression));
+
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeEventExpression, this.ConstructorArguments);
+			Mock.VerifyRemove(this, expression, Times.AtLeastOnce(), failMessage);
+		}
+
+		/// <summary>
+		///   Verifies that an event was removed from the mock, specifying a failure message.
+		/// </summary>
+		/// <param name="times">The number of times a method is expected to be called.</param>
+		/// <param name="removeEventExpression">Expression to verify.</param>
+		/// <param name="failMessage">Message to show if verification fails.</param>
+		/// <exception cref="MockException">
+		///   The invocation was not called the number of times specified by <paramref name="times"/>.
+		/// </exception>
+		public void VerifyRemove(Action<T> removeEventExpression, Times times, string failMessage)
+		{
+			Guard.NotNull(removeEventExpression, nameof(removeEventExpression));
+
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeEventExpression, this.ConstructorArguments);
+			Mock.VerifyRemove(this, expression, times, failMessage);
+		}
+
+		/// <summary>
+		///   Verifies that an event was removed from the mock, specifying a failure message.
+		/// </summary>
+		/// <param name="times">The number of times a method is expected to be called.</param>
+		/// <param name="removeEventExpression">Expression to verify.</param>
+		/// <param name="failMessage">Message to show if verification fails.</param>
+		/// <exception cref="MockException">
+		///   The invocation was not called the number of times specified by <paramref name="times"/>.
+		/// </exception>
+		public void VerifyRemove(Action<T> removeEventExpression, Func<Times> times, string failMessage)
+		{
+			Guard.NotNull(removeEventExpression, nameof(removeEventExpression));
+
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeEventExpression, this.ConstructorArguments);
+			Mock.VerifyRemove(this, expression, times(), failMessage);
 		}
 
 		/// <summary>

--- a/src/Moq/Mock.Generic.xdoc
+++ b/src/Moq/Mock.Generic.xdoc
@@ -280,7 +280,7 @@
 	<doc for="Mock{T}.VerifyAdd(expression,failMessage)">
 		<example group="verification">
 			This example assumes that the mock has been used,
-			and later we want to verify that a given event'
+			and later we want to verify that a given event
 			was added to it:
 			<code>
 				var mock = new Mock&lt;IWarehouse&gt;();

--- a/src/Moq/Mock.Generic.xdoc
+++ b/src/Moq/Mock.Generic.xdoc
@@ -263,7 +263,7 @@
 			</code>
 		</example>
 	</doc>
-	<doc for="Mock{T}.VerifyAdd(expression)">
+	<doc for="Mock{T}.VerifyAdd(addExpression)">
 		<example group="verification">
 			This example assumes that the mock has been used,
 			and later we want to verify that a given event
@@ -272,12 +272,12 @@
 				var mock = new Mock&lt;IWarehouse&gt;();
 				// exercise mock
 				//...
-				// Will throw if the test code didn't set the IsClosed property.
+				// Will throw if the test code didn't subscribe to the OnClosed event.
 				mock.VerifyAdd(warehouse =&gt; warehouse.OnClose += It.IsAny&lt;EventHandler&gt;());
 			</code>
 		</example>
 	</doc>
-	<doc for="Mock{T}.VerifyAdd(expression,failMessage)">
+	<doc for="Mock{T}.VerifyAdd(addExpression,failMessage)">
 		<example group="verification">
 			This example assumes that the mock has been used,
 			and later we want to verify that a given event
@@ -286,12 +286,12 @@
 				var mock = new Mock&lt;IWarehouse&gt;();
 				// exercise mock
 				//...
-				// Will throw if the test code didn't add the OnClose event.
+				// Will throw if the test code didn't subscribe to the OnClose event.
 				mock.VerifyAdd(warehouse =&gt; warehouse.OnClose += It.IsAny&lt;EventHandler&gt;(), "Warehouse should add an event");
 			</code>
 		</example>
 	</doc>
-	<doc for="Mock{T}.VerifyRemove(expression)">
+	<doc for="Mock{T}.VerifyRemove(removeExpression)">
 		<example group="verification">
 			This example assumes that the mock has been used,
 			and later we want to verify that a given event
@@ -300,12 +300,12 @@
 				var mock = new Mock&lt;IWarehouse&gt;();
 				// exercise mock
 				//...
-				// Will throw if the test code didn't set the IsClosed property.
-				mock.VerifyAdd(warehouse =&gt; warehouse.OnClose -= It.IsAny&lt;EventHandler&gt;());
+				// Will throw if the test code didn't unsubscribe from the OnClosed event.
+				mock.VerifyRemove(warehouse =&gt; warehouse.OnClose -= It.IsAny&lt;EventHandler&gt;());
 			</code>
 		</example>
 	</doc>
-	<doc for="Mock{T}.VerifyRemove(expression,failMessage)">
+	<doc for="Mock{T}.VerifyRemove(removeExpression,failMessage)">
 		<example group="verification">
 			This example assumes that the mock has been used,
 			and later we want to verify that a given event
@@ -314,8 +314,8 @@
 				var mock = new Mock&lt;IWarehouse&gt;();
 				// exercise mock
 				//...
-				// Will throw if the test code didn't set the IsClosed property.
-				mock.VerifyAdd(warehouse =&gt; warehouse.OnClose -= It.IsAny&lt;EventHandler&gt;(), "Warehouse should remove an event");
+				// Will throw if the test code didn't unsubscribe from the OnClosed event.
+				mock.VerifyRemove(warehouse =&gt; warehouse.OnClose -= It.IsAny&lt;EventHandler&gt;(), "Warehouse should remove an event");
 			</code>
 		</example>
 	</doc>

--- a/src/Moq/Mock.Generic.xdoc
+++ b/src/Moq/Mock.Generic.xdoc
@@ -101,6 +101,20 @@
 			</code>
 		</example>
 	</doc>
+	<doc for="Mock{T}.SetupAdd">
+		<example group="setups">
+			<code>
+				mock.SetupAdd(x =&gt; x.EventHandler += (s, e) => {});
+			</code>
+		</example>
+	</doc>
+	<doc for="Mock{T}.SetupRemove">
+		<example group="setups">
+			<code>
+				mock.SetupRemove(x =&gt; x.EventHandler -= (s, e) => {});
+			</code>
+		</example>
+	</doc>
 	<doc for="Mock{T}.SetupProperty(property)">
 		<example>
 			If you have an interface with an int property <c>Value</c>, you might
@@ -246,6 +260,62 @@
 				//...
 				// Will throw if the test code didn't set the IsClosed property.
 				mock.VerifySet(warehouse =&gt; warehouse.IsClosed = true, "Warehouse should always be closed after the action");
+			</code>
+		</example>
+	</doc>
+	<doc for="Mock{T}.VerifyAdd(expression)">
+		<example group="verification">
+			This example assumes that the mock has been used,
+			and later we want to verify that a given event
+			was added to it:
+			<code>
+				var mock = new Mock&lt;IWarehouse&gt;();
+				// exercise mock
+				//...
+				// Will throw if the test code didn't set the IsClosed property.
+				mock.VerifyAdd(warehouse =&gt; warehouse.OnClose += It.IsAny&lt;EventHandler&gt;());
+			</code>
+		</example>
+	</doc>
+	<doc for="Mock{T}.VerifyAdd(expression,failMessage)">
+		<example group="verification">
+			This example assumes that the mock has been used,
+			and later we want to verify that a given event'
+			was added to it:
+			<code>
+				var mock = new Mock&lt;IWarehouse&gt;();
+				// exercise mock
+				//...
+				// Will throw if the test code didn't add the OnClose event.
+				mock.VerifyAdd(warehouse =&gt; warehouse.OnClose += It.IsAny&lt;EventHandler&gt;(), "Warehouse should add an event");
+			</code>
+		</example>
+	</doc>
+	<doc for="Mock{T}.VerifyRemove(expression)">
+		<example group="verification">
+			This example assumes that the mock has been used,
+			and later we want to verify that a given event
+			was removed from it:
+			<code>
+				var mock = new Mock&lt;IWarehouse&gt;();
+				// exercise mock
+				//...
+				// Will throw if the test code didn't set the IsClosed property.
+				mock.VerifyAdd(warehouse =&gt; warehouse.OnClose -= It.IsAny&lt;EventHandler&gt;());
+			</code>
+		</example>
+	</doc>
+	<doc for="Mock{T}.VerifyRemove(expression,failMessage)">
+		<example group="verification">
+			This example assumes that the mock has been used,
+			and later we want to verify that a given event
+			was removed from it:
+			<code>
+				var mock = new Mock&lt;IWarehouse&gt;();
+				// exercise mock
+				//...
+				// Will throw if the test code didn't set the IsClosed property.
+				mock.VerifyAdd(warehouse =&gt; warehouse.OnClose -= It.IsAny&lt;EventHandler&gt;(), "Warehouse should remove an event");
 			</code>
 		</example>
 	</doc>

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -585,7 +585,7 @@ namespace Moq
 
 		internal static void SetupAllProperties(Mock mock, DefaultValueProvider defaultValueProvider)
 		{
-			mock.Setups.RemoveAll(x => x.Method.IsPropertyAccessor());
+			mock.Setups.RemoveAllPropertyAccessorSetups();
 			// Removing all the previous properties setups to keep the behaviour of overriding
 			// existing setups in `SetupAllProperties`.
 			

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -336,6 +336,22 @@ namespace Moq
 			Mock.Verify(mock, expression, times, failMessage);
 		}
 
+		internal static void VerifyAdd(Mock mock, LambdaExpression expression, Times times, string failMessage)
+		{
+			Guard.NotNull(expression, nameof(expression));
+			Guard.IsEventAttach(expression, nameof(expression));
+
+			Mock.Verify(mock, expression, times, failMessage);
+		}
+
+		internal static void VerifyRemove(Mock mock, LambdaExpression expression, Times times, string failMessage)
+		{
+			Guard.NotNull(expression, nameof(expression));
+			Guard.IsEventDetach(expression, nameof(expression));
+
+			Mock.Verify(mock, expression, times, failMessage);
+		}
+
 		internal static void VerifyNoOtherCalls(Mock mock)
 		{
 			Mock.VerifyNoOtherCalls(mock, verifiedMocks: new HashSet<Mock>());
@@ -488,6 +504,22 @@ namespace Moq
 		{
 			Guard.NotNull(expression, nameof(expression));
 			Guard.IsAssignmentToPropertyOrIndexer(expression, nameof(expression));
+
+			return Mock.Setup(mock, expression, condition);
+		}
+
+		internal static MethodCall SetupAdd(Mock mock, LambdaExpression expression, Condition condition)
+		{
+			Guard.NotNull(expression, nameof(expression));
+			Guard.IsEventAttach(expression, nameof(expression));
+
+			return Mock.Setup(mock, expression, condition);
+		}
+
+		internal static MethodCall SetupRemove(Mock mock, LambdaExpression expression, Condition condition)
+		{
+			Guard.NotNull(expression, nameof(expression));
+			Guard.IsEventDetach(expression, nameof(expression));
 
 			return Mock.Setup(mock, expression, condition);
 		}

--- a/src/Moq/Properties/Resources.Designer.cs
+++ b/src/Moq/Properties/Resources.Designer.cs
@@ -581,6 +581,24 @@ namespace Moq.Properties {
 		}
 		
 		/// <summary>
+		///   Looks up a localized string similar to Expression is not an event add invocation..
+		/// </summary>
+		internal static string SetupNotEventAttach {
+			get {
+				return ResourceManager.GetString("SetupNotEventAttach", resourceCulture);
+			}
+		}
+		
+		/// <summary>
+		///   Looks up a localized string similar to Expression is not an event remove invocation..
+		/// </summary>
+		internal static string SetupNotEventDetach {
+			get {
+				return ResourceManager.GetString("SetupNotEventDetach", resourceCulture);
+			}
+		}
+		
+		/// <summary>
 		///   Looks up a localized string similar to Type {0} does not implement required interface {1}.
 		/// </summary>
 		internal static string TypeNotImplementInterface {

--- a/src/Moq/Properties/Resources.resx
+++ b/src/Moq/Properties/Resources.resx
@@ -357,4 +357,10 @@ This could be caused by an unrecognized type conversion, coercion, narrowing, or
 	<data name="MethodMissing" xml:space="preserve">
 		<value>No protected method {0}.{1} found whose signature is compatible with the provided arguments ({2}).</value>
 	</data>
+	<data name="SetupNotEventAttach" xml:space="preserve">
+		<value>Expression is not an event add: {0}</value>
+	</data>
+	<data name="SetupNotEventDetach" xml:space="preserve">
+		<value>Expression is not an event remove: {0}</value>
+	</data>
 </root>

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -49,8 +49,6 @@ namespace Moq
 			}
 		}
 
-
-
 		public void RemoveAllPropertyAccessorSetups()
 		{
 			// Fast path (no `lock`) when there are no setups:

--- a/src/Moq/StringBuilderExtensions.cs
+++ b/src/Moq/StringBuilderExtensions.cs
@@ -41,18 +41,31 @@ namespace Moq
 
 			if (includeGenericArgumentList && method.IsGenericMethod)
 			{
-				stringBuilder.Append('<');
-				var genericArguments = method.GetGenericArguments();
-				for (int i = 0, n = genericArguments.Length; i < n; ++i)
-				{
-					if (i > 0)
-					{
-						stringBuilder.Append(", ");
-					}
-					stringBuilder.AppendNameOf(genericArguments[i]);
-				}
+				stringBuilder.AppendGenericArguments(method);
+			}
 
-				stringBuilder.Append('>');
+			return stringBuilder;
+		}
+
+		public static StringBuilder AppendNameOfAddEvent(this StringBuilder stringBuilder, MethodBase method, bool includeGenericArgumentList)
+		{
+			stringBuilder.Append(method.Name.Replace("add_", "")).Append(" += ");
+
+			if (includeGenericArgumentList && method.IsGenericMethod)
+			{
+				stringBuilder.AppendGenericArguments(method);
+			}
+
+			return stringBuilder;
+		}
+
+		public static StringBuilder AppendNameOfRemoveEvent(this StringBuilder stringBuilder, MethodBase method, bool includeGenericArgumentList)
+		{
+			stringBuilder.Append(method.Name.Replace("remove_", "")).Append(" -= ");
+
+			if (includeGenericArgumentList && method.IsGenericMethod)
+			{
+				stringBuilder.AppendGenericArguments(method);
 			}
 
 			return stringBuilder;
@@ -131,6 +144,23 @@ namespace Moq
 			{
 				--stringBuilder.Length;
 			}
+			return stringBuilder;
+		}
+
+		private static StringBuilder AppendGenericArguments(this StringBuilder stringBuilder, MethodBase method)
+		{
+			stringBuilder.Append('<');
+			var genericArguments = method.GetGenericArguments();
+			for (int i = 0, n = genericArguments.Length; i < n; ++i)
+			{
+				if (i > 0)
+				{
+					stringBuilder.Append(", ");
+				}
+				stringBuilder.AppendNameOf(genericArguments[i]);
+			}
+			stringBuilder.Append('>');
+
 			return stringBuilder;
 		}
 	}

--- a/src/Moq/StringBuilderExtensions.cs
+++ b/src/Moq/StringBuilderExtensions.cs
@@ -41,7 +41,17 @@ namespace Moq
 
 			if (includeGenericArgumentList && method.IsGenericMethod)
 			{
-				stringBuilder.AppendGenericArguments(method);
+				stringBuilder.Append('<');
+				var genericArguments = method.GetGenericArguments();
+				for (int i = 0, n = genericArguments.Length; i < n; ++i)
+				{
+					if (i > 0)
+					{
+						stringBuilder.Append(", ");
+					}
+					stringBuilder.AppendNameOf(genericArguments[i]);
+				}
+				stringBuilder.Append('>');
 			}
 
 			return stringBuilder;
@@ -49,26 +59,12 @@ namespace Moq
 
 		public static StringBuilder AppendNameOfAddEvent(this StringBuilder stringBuilder, MethodBase method, bool includeGenericArgumentList)
 		{
-			stringBuilder.Append(method.Name.Replace("add_", "")).Append(" += ");
-
-			if (includeGenericArgumentList && method.IsGenericMethod)
-			{
-				stringBuilder.AppendGenericArguments(method);
-			}
-
-			return stringBuilder;
+			return stringBuilder.Append(method.Name.Substring("add_".Length)).Append(" += ");
 		}
 
 		public static StringBuilder AppendNameOfRemoveEvent(this StringBuilder stringBuilder, MethodBase method, bool includeGenericArgumentList)
 		{
-			stringBuilder.Append(method.Name.Replace("remove_", "")).Append(" -= ");
-
-			if (includeGenericArgumentList && method.IsGenericMethod)
-			{
-				stringBuilder.AppendGenericArguments(method);
-			}
-
-			return stringBuilder;
+			return stringBuilder.Append(method.Name.Substring("remove_".Length)).Append(" -= ");
 		}
 
 		public static StringBuilder AppendNameOf(this StringBuilder stringBuilder, Type type)
@@ -144,23 +140,6 @@ namespace Moq
 			{
 				--stringBuilder.Length;
 			}
-			return stringBuilder;
-		}
-
-		private static StringBuilder AppendGenericArguments(this StringBuilder stringBuilder, MethodBase method)
-		{
-			stringBuilder.Append('<');
-			var genericArguments = method.GetGenericArguments();
-			for (int i = 0, n = genericArguments.Length; i < n; ++i)
-			{
-				if (i > 0)
-				{
-					stringBuilder.Append(", ");
-				}
-				stringBuilder.AppendNameOf(genericArguments[i]);
-			}
-			stringBuilder.Append('>');
-
 			return stringBuilder;
 		}
 	}

--- a/tests/Moq.Tests/MockFixture.cs
+++ b/tests/Moq.Tests/MockFixture.cs
@@ -1240,36 +1240,6 @@ namespace Moq.Tests
 			Assert.False(after, "After reset");
 		}
 
-		[Fact]
-		public void RemoveAll_clears_event_setup_flag_when_predicate_matched()
-		{
-			var mock = new Mock<IFoo>();
-			mock.Setup(m => m.Submit()).Verifiable();
-			mock.SetupAdd(m => m.EventHandler += It.IsAny<EventHandler>()).Verifiable();
-
-			var before = mock.Setups.HasEventSetup;
-			mock.Setups.RemoveAll(s => s.IsVerifiable);
-			var after = mock.Setups.HasEventSetup;
-
-			Assert.True(before, "Before RemoveAll");
-			Assert.False(after, "After RemoveAll");
-		}
-
-		[Fact]
-		public void RemoveAll_doesnt_clears_event_setup_flag_when_predicate_not_matched()
-		{
-			var mock = new Mock<IFoo>();
-			mock.Setup(m => m.Submit()).Verifiable();
-			mock.SetupAdd(m => m.EventHandler += It.IsAny<EventHandler>());
-
-			var before = mock.Setups.HasEventSetup;
-			mock.Setups.RemoveAll(s => s.IsVerifiable);
-			var after = mock.Setups.HasEventSetup;
-
-			Assert.True(before, "Before RemoveAll");
-			Assert.True(after, "After RemoveAll");
-		}
-
 #if FEATURE_SERIALIZATION
 		[Serializable]
 		public class BadSerializable : ISerializable

--- a/tests/Moq.Tests/MockedEventsFixture.cs
+++ b/tests/Moq.Tests/MockedEventsFixture.cs
@@ -4,7 +4,6 @@
 using System;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-
 using Xunit;
 
 namespace Moq.Tests
@@ -655,7 +654,7 @@ namespace Moq.Tests
 		}
 
 		[Fact]
-		public void Should_verify_event_add_if_invoked()
+		public void VerifyAdd_should_not_throw_when_subscribed()
 		{
 			//Arrange
 			var mock = new Mock<IAdder<EventArgs>>();
@@ -670,7 +669,7 @@ namespace Moq.Tests
 		}
 
 		[Fact]
-		public void Should_verify_event_remove_if_invoked()
+		public void VerifyRemove_should_not_throw_when_unsubscribed()
 		{
 			//Arrange
 			var mock = new Mock<IAdder<EventArgs>>();
@@ -685,7 +684,7 @@ namespace Moq.Tests
 		}
 
 		[Fact]
-		public void Should_verify_event_add_remove_using_verifyall()
+		public void VerifyAll_should_not_throw_when_events_verified()
 		{
 			//Arrange
 			var mock = new Mock<IAdder<EventArgs>>();
@@ -701,7 +700,7 @@ namespace Moq.Tests
 		}
 
 		[Fact]
-		public void Should_verify_event_add_remove_using_verifiable()
+		public void Verify_should_not_throw_when_events_verified()
 		{
 			//Arrange
 			var mock = new Mock<IAdder<EventArgs>>();
@@ -716,7 +715,7 @@ namespace Moq.Tests
 		}
 
 		[Fact]
-		public void Should_throw_when_event_not_verified()
+		public void Verify_should_throw_when_event_not_verified()
 		{
 			//Arrange
 			var mock = new Mock<IAdder<EventArgs>>();
@@ -767,7 +766,7 @@ namespace Moq.Tests
 		}
 
 		[Fact]
-		public void Should_throw_verify_no_other_calls_when_not_verified()
+		public void VerifyNoOtherCalls_should_throw_when_not_verified()
 		{
 			//Arrange
 			var mock = new Mock<IAdder<EventArgs>>();
@@ -781,7 +780,7 @@ namespace Moq.Tests
 		}
 
 		[Fact]
-		public void Should_not_throw_verify_no_other_calls_when_verified()
+		public void VerifyNoOtherCalls_should_not_throw_when_verified()
 		{
 			//Arrange
 			var mock = new Mock<IAdder<EventArgs>>();
@@ -793,6 +792,62 @@ namespace Moq.Tests
 			//Assert
 			mock.Verify();
 			mock.VerifyNoOtherCalls();
+		}
+
+		[Fact]
+		public void VerifyAdd_should_throw_when_not_an_add_event()
+		{
+			//Arrange
+			var mock = new Mock<IAdder<EventArgs>>();
+
+			//Act
+			var exception = Record.Exception(() => mock.VerifyAdd(m => m.Do(It.IsAny<string>())));
+
+			//Assert
+			Assert.IsType<ArgumentException>(exception);
+		}
+
+		[Fact]
+		public void VerifyRemove_should_throw_when_not_an_remove_event()
+		{
+			//Arrange
+			var mock = new Mock<IAdder<EventArgs>>();
+
+			//Act
+			var exception = Record.Exception(() => mock.VerifyRemove(m => m.Do(It.IsAny<string>())));
+
+			//Assert
+			Assert.IsType<ArgumentException>(exception);
+		}
+
+		[Fact]
+		public void Should_invoke_callback_on_add_event_accessor_setup()
+		{
+			//Arrange
+			var invoked = false;
+			var mock = new Mock<IAdder<EventArgs>>();
+			mock.SetupAdd(m => m.Added += It.IsAny<EventHandler>()).Callback(() => invoked = true);
+
+			//Act
+			mock.Object.Added += (s, a) => { };
+
+			//Assert
+			Assert.True(invoked);
+		}
+
+		[Fact]
+		public void Should_invoke_callback_on_remove_event_accessor_setup()
+		{
+			//Arrange
+			var invoked = false;
+			var mock = new Mock<IAdder<EventArgs>>();
+			mock.SetupRemove(m => m.Added -= It.IsAny<EventHandler>()).Callback(() => invoked = true);
+
+			//Act
+			mock.Object.Added -= (s, a) => { };
+
+			//Assert
+			Assert.True(invoked);
 		}
 
 		public delegate void CustomEvent(string message, int value);
@@ -826,15 +881,10 @@ namespace Moq.Tests
 			public string Value { get; set; }
 		}
 
-		public delegate void MyEventHandler<T>(object sender, T args) where T: EventArgs;
-
-		public class MyEventArgs : EventArgs { }
-
 		public interface IAdder<T>
 		{
 			event EventHandler<DoneArgs> Done;
 			event EventHandler Added;
-			event MyEventHandler<MyEventArgs> MyEvent;
 			void Add(T value);
 			int Insert(T value, int index);
 			void Do(string s);


### PR DESCRIPTION
Hi,

I was busy during the weekend with this feature, it adds the functionality to Setup and Verify events as all other methods. I tried to preserve backward compatibility and also I have added new test scenarios to verify this feature. Four new methods have been added (I am maybe thinking of merging this to `SetupEvent` and `VerifyEvent`):
`SetupAdd`
`SetupRemove`
`VerifyAdd`
`VerifyRemove`

Besides these methods `Verify()`, `VerifyAll()` and `VerifyNoOtherCalls` work as well. 

Kind regards,
Nikola