### PR TITLE
Add event subscription tests to regression test suite

### DIFF
--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2658,6 +2658,7 @@ namespace Moq.Tests.Regressions
 			public void Can_subscribe_to_virtual_event_from_ctor()
 			{
 				var c = new Mock<C1>();
+				_ = c.Object;  // ensure that the ctor (and therefore event subscription) has run
 				c.Raise(x => x.E += null);
 				Assert.True(c.Object.Raised);
 			}

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2650,6 +2650,68 @@ namespace Moq.Tests.Regressions
 		}
 		#endregion
 
+		#region 867
+
+		public class Issue867
+		{
+			[Fact]
+			public void Can_subscribe_to_virtual_event_from_ctor()
+			{
+				var c = new Mock<C1>();
+				c.Raise(x => x.E += null);
+				Assert.True(c.Object.Raised);
+			}
+
+			[Fact]
+			public void Can_subscribe_to_virtual_event_outside_type()
+			{
+				var raised = false;
+				var c = new Mock<C2>();
+				c.Object.E += () => raised = true;
+
+				c.Raise(x => x.E += null);
+
+				Assert.True(raised);
+			}
+
+			[Fact]
+			public void Can_subscribe_to_virtual_event_from_method()
+			{
+				var c = new Mock<C3>();
+				c.Object.M();
+				c.Raise(x => x.E += null);
+
+				Assert.True(c.Object.Raised);
+			}
+
+			public class C1
+			{
+				public bool Raised { get; private set; }
+				public virtual event Action E;
+				public C1()
+				{
+					E += () => Raised = true;
+				}
+			}
+
+			public class C2
+			{
+				public virtual event Action E;
+			}
+
+			public class C3
+			{
+				public bool Raised { get; private set; }
+				public virtual event Action E;
+				public void M()
+				{
+					E += () => Raised = true;
+				}
+			}
+		}
+
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47


### PR DESCRIPTION
This adds the tests from #867 to the regression test suite, along with a brief documentation of how to resolve a possible issue when subscribing to an event from a mocked type's ctor. (Client code must ensure the ctor actually runs for event subscription to happen.)