### PR TITLE
Fix `SetupAllProperties` for properties whose name starts with `Item`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 * Added support for setup and verification of the event handlers through `Setup[Add|Remove]` and `Verify[Add|Remove|All]` (@lepijohnny, #825) 
 
+#### Fixed
+
+* Regression: `SetupAllProperties` can no longer set up properties whose names start with `Item`. (@mattzink, #870; @kaan-kaya, #869)
+
+
 ## 4.12.0 (2019-06-20)
 
 #### Changed

--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -50,12 +50,12 @@ namespace Moq
 
 		public static bool IsPropertyIndexerGetter(this MethodInfo method)
 		{
-			return method.IsSpecialName && method.Name.StartsWith("get_Item", StringComparison.Ordinal);
+			return method.IsSpecialName && method.Name.Equals("get_Item", StringComparison.Ordinal);
 		}
 
 		public static bool IsPropertyIndexerSetter(this MethodInfo method)
 		{
-			return method.IsSpecialName && method.Name.StartsWith("set_Item", StringComparison.Ordinal);
+			return method.IsSpecialName && method.Name.Equals("set_Item", StringComparison.Ordinal);
 		}
 
 		public static bool IsPropertySetter(this MethodInfo method)

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2677,6 +2677,42 @@ namespace Moq.Tests.Regressions
 		}
 		#endregion
 
+		#region 870
+
+		public class Issue870
+		{
+			[Fact]
+			public void SetupAllProperties_can_process_Items_property_1()
+			{
+				var httpContext = Mock.Of<HttpContext>();
+				httpContext.Items = new Dictionary<object, object>();
+				Assert.NotNull(httpContext.Items);
+			}
+
+			[Fact]
+			public void SetupAllProperties_can_process_Items_property_2()
+			{
+				var httpContext = Mock.Of<HttpContext>(c => c.Items == new Dictionary<object, object>());
+				Assert.NotNull(httpContext.Items);
+			}
+
+			[Fact]
+			public void SetupAllProperties_can_process_Items_property_3()
+			{
+				var httpContext = new Mock<HttpContext>();
+				httpContext.SetupAllProperties();
+				httpContext.Object.Items = new Dictionary<object, object>();
+				Assert.NotNull(httpContext.Object.Items);
+			}
+
+			public abstract partial class HttpContext
+			{
+				public abstract IDictionary<object, object> Items { get; set; }
+			}
+		}
+
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47


### PR DESCRIPTION
Fixes #870 and likely also #869.