### PR TITLE
fix: Don't attempt to set CallBase on auto-generated mocks for delegates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 #### Fixed
 
 * Regression: `SetupAllProperties` can no longer set up properties whose names start with `Item`. (@mattzink, #870; @kaan-kaya, #869)
+* Regression: `MockDefaultValueProvider` will no longer attempt to set `CallBase` to true for mocks generated for delegates. (@dammejed, #874)
 
 
 ## 4.12.0 (2019-06-20)

--- a/src/Moq/MockDefaultValueProvider.cs
+++ b/src/Moq/MockDefaultValueProvider.cs
@@ -36,7 +36,10 @@ namespace Moq
 				var mockType = typeof(Mock<>).MakeGenericType(type);
 				Mock newMock = (Mock)Activator.CreateInstance(mockType, mock.Behavior);
 				newMock.DefaultValueProvider = mock.DefaultValueProvider;
-				newMock.CallBase = mock.CallBase;
+				if(!type.IsDelegate())
+				{
+					newMock.CallBase = mock.CallBase;
+				}
 				newMock.Switches = mock.Switches;
 				return newMock.Object;
 			}

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2713,6 +2713,35 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 874
+		public class Issue874
+		{
+			[Fact]
+			public void MockDefaultValueProvider_will_Propagate_Callbase_to_nondelegates()
+			{
+				var mock = new Mock<IDictionary<string, IDictionary<string, string>>>()
+				{
+					CallBase = true,
+					DefaultValue = DefaultValue.Mock
+				};
+				var mockedIndexResult = mock.Object["foo"];
+				Assert.Null(mockedIndexResult["foo"]);
+			}
+
+			[Fact]
+			public void MockDefaultValueProvide_will_not_propagate_Callback_to_delegates()
+			{
+				var mock = new Mock<IDictionary<string, Func<string>>>()
+				{
+					CallBase = true,
+					DefaultValue = DefaultValue.Mock
+				};
+				var mockedIndexResult = mock.Object["foo"];
+				Assert.Null(mockedIndexResult());
+			}
+		}
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47


### PR DESCRIPTION
Fixes #874.