### PR TITLE
Make post-`Returns` callback delegate validation more strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 * Improved error message that is supplied with `ArgumentException` thrown when `Setup` or `Verify` are called on a protected method if the method could not be found with both the name and compatible argument types specified (@thomasfdm, #852).
 
+* Consistent `Callback` delegate validation regardless of whether or not `Callback` is preceded by a `Returns`: Validation for post-`Returns` callback delegates used to be very relaxed, but is now equally strict as in the pre-`Returns` case.) (@stakx, #876)
+
 #### Added
 
 * Added support for setup and verification of the event handlers through `Setup[Add|Remove]` and `Verify[Add|Remove|All]` (@lepijohnny, #825) 

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -168,27 +168,17 @@ namespace Moq
 
 		public void SetCallbackResponse(Delegate callback)
 		{
-			if (this.returnOrThrowResponse != null)
-			{
-				if (callback is Action afterReturnCallbackWithoutArguments)
-				{
-					this.afterReturnCallback = delegate { afterReturnCallbackWithoutArguments(); };
-				}
-				else
-				{
-					this.afterReturnCallback = delegate (object[] args) { callback.InvokePreserveStack(args); };
-				}
-				return;
-			}
-
 			if (callback == null)
 			{
 				throw new ArgumentNullException(nameof(callback));
 			}
 
+			ref Action<object[]> response = ref this.returnOrThrowResponse == null ? ref this.callbackResponse
+			                                                                       : ref this.afterReturnCallback;
+
 			if (callback is Action callbackWithoutArguments)
 			{
-				this.callbackResponse = (object[] args) => callbackWithoutArguments();
+				response = (object[] args) => callbackWithoutArguments();
 			}
 			else
 			{
@@ -209,7 +199,7 @@ namespace Moq
 					throw new ArgumentException(Resources.InvalidCallbackNotADelegateWithReturnTypeVoid, nameof(callback));
 				}
 
-				this.callbackResponse = (object[] args) => callback.InvokePreserveStack(args);
+				response = (object[] args) => callback.InvokePreserveStack(args);
 			}
 		}
 

--- a/tests/Moq.Tests/AfterReturnCallbackDelegateValidationFixture.cs
+++ b/tests/Moq.Tests/AfterReturnCallbackDelegateValidationFixture.cs
@@ -1,0 +1,96 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+
+using Moq.Language.Flow;
+
+using Xunit;
+
+namespace Moq.Tests
+{
+	public class AfterReturnCallbackDelegateValidationFixture
+	{
+		private readonly ISetup<IFoo, bool> setup;
+
+		public AfterReturnCallbackDelegateValidationFixture()
+		{
+			this.setup = new Mock<IFoo>().Setup(m => m.Method(It.IsAny<string>(), It.IsAny<object>()));
+		}
+
+		[Fact]
+		public void Callback_before_Returns__delegate_may_not_be_null()
+		{
+			var setup = this.setup;
+			Assert.Throws<ArgumentNullException>(() => setup.Callback(null));
+		}
+
+		[Fact]
+		public void Callback_after_Returns__delegate_may_not_be_null()
+		{
+			var setup = this.setup.Returns(true);
+			Assert.Throws<ArgumentNullException>(() => setup.Callback(null));
+		}
+
+		[Fact]
+		public void Callback_before_Returns__delegate_may_completely_omit_parameters()
+		{
+			var setup = this.setup;
+			setup.Callback(() => { });
+		}
+
+		[Fact]
+		public void Callback_after_Returns__delegate_may_completely_omit_parameters()
+		{
+			var setup = this.setup.Returns(true);
+			setup.Callback(() => { });
+		}
+
+		[Fact]
+		public void Callback_before_Returns__delegate_may_not_partially_omit_parameters()
+		{
+			var setup = this.setup;
+			Assert.Throws<ArgumentException>(() => setup.Callback((string arg1) => { }));
+		}
+
+		[Fact]
+		public void Callback_after_Returns__delegate_may_not_partially_omit_parameters()
+		{
+			var setup = this.setup.Returns(true);
+			Assert.Throws<ArgumentException>(() => setup.Callback((string arg1) => { }));
+		}
+
+		[Fact]
+		public void Callback_before_Returns__delegate_may_use_less_specific_parameter_types()
+		{
+			var setup = this.setup;
+			setup.Callback((object arg1, object arg2) => { });
+		}
+
+		[Fact]
+		public void Callback_after_Returns__delegate_may_use_less_specific_parameter_types()
+		{
+			var setup = this.setup.Returns(true);
+			setup.Callback((object arg1, object arg2) => { });
+		}
+
+		[Fact]
+		public void Callback_before_Returns__delegate_may_not_use_more_specific_parameter_types()
+		{
+			var setup = this.setup;
+			Assert.Throws<ArgumentException>(() => setup.Callback((string arg1, string arg2) => { }));
+		}
+
+		[Fact]
+		public void Callback_after_Returns__delegate_may_not_use_more_specific_parameter_types()
+		{
+			var setup = this.setup.Returns(true);
+			Assert.Throws<ArgumentException>(() => setup.Callback((string arg1, string arg2) => { }));
+		}
+
+		public interface IFoo
+		{
+			bool Method(string arg1, object arg2);
+		}
+	}
+}


### PR DESCRIPTION
This is in response to, and closes, #872.

There's currently an inconsistency regarding how `Callback` delegates are validated: In the post-`Returns` position, validation is very relaxed, while it's more strict in a pre-`Returns` or no-`Returns` scenario.

This makes `Callback` delegate validation strict regardless of `Callback`'s position in the setup.