### PR TITLE
Fix `SetupAllProperties` for properties named `Item`

### DIFF
--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -50,12 +50,12 @@ namespace Moq
 
 		public static bool IsPropertyIndexerGetter(this MethodInfo method)
 		{
-			return method.IsSpecialName && method.Name.Equals("get_Item", StringComparison.Ordinal);
+			return method.IsSpecialName && method.Name.StartsWith("get_", StringComparison.Ordinal) && method.GetParameters().Length > 0;
 		}
 
 		public static bool IsPropertyIndexerSetter(this MethodInfo method)
 		{
-			return method.IsSpecialName && method.Name.Equals("set_Item", StringComparison.Ordinal);
+			return method.IsSpecialName && method.Name.StartsWith("set_", StringComparison.Ordinal) && method.GetParameters().Length > 1;
 		}
 
 		public static bool IsPropertySetter(this MethodInfo method)

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2705,9 +2705,23 @@ namespace Moq.Tests.Regressions
 				Assert.NotNull(httpContext.Object.Items);
 			}
 
+			[Fact]
+			public void SetupAllProperties_can_process_Item_property()
+			{
+				var mock = new Mock<IFoo>();
+				mock.SetupAllProperties();
+				mock.Object.Item = "value";
+				Assert.Equal("value", mock.Object.Item);
+			}
+
 			public abstract partial class HttpContext
 			{
 				public abstract IDictionary<object, object> Items { get; set; }
+			}
+
+			public interface IFoo
+			{
+				string Item { get; set; }
 			}
 		}
 


### PR DESCRIPTION
This is an addendum to #871.