### PR TITLE
Fix `ExpressionStringBuilder` formatting of indexer assignment

### DIFF
--- a/src/Moq/ExpressionStringBuilder.cs
+++ b/src/Moq/ExpressionStringBuilder.cs
@@ -325,7 +325,7 @@ namespace Moq
 				else if (node.Method.IsPropertyIndexerSetter())
 				{
 					this.builder.Append('[');
-					AsCommaSeparatedValues(node.Arguments.Skip(paramFrom), ToString);
+					AsCommaSeparatedValues(node.Arguments.Skip(paramFrom).Take(node.Arguments.Count - paramFrom - 1), ToString);
 					this.builder.Append("] = ");
 					ToString(node.Arguments.Last());
 				}

--- a/tests/Moq.Tests/ExpressionStringBuilderFixture.cs
+++ b/tests/Moq.Tests/ExpressionStringBuilderFixture.cs
@@ -1,0 +1,40 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.Linq.Expressions;
+
+using Xunit;
+
+namespace Moq.Tests
+{
+	public class ExpressionStringBuilderFixture
+	{
+		[Fact]
+		public void Formats_call_to_indexer_setter_method_using_indexer_syntax()
+		{
+			// foo => foo.set_Item("index", "value")
+			var foo = Expression.Parameter(typeof(IFoo), "foo");
+			var expression =
+				Expression.Lambda<Action<IFoo>>(
+					Expression.Call(
+						foo,
+						typeof(IFoo).GetProperty("Item").SetMethod,
+						Expression.Constant("index"),
+						Expression.Constant("value")),
+					foo);
+
+			Assert.Equal(@"foo => foo[""index""] = ""value""", Format(expression));
+		}
+
+		private static string Format(Expression expression)
+		{
+			return new ExpressionStringBuilder().Append(expression).ToString();
+		}
+
+		public interface IFoo
+		{
+			object this[object index] { get; set; }
+		}
+	}
+}


### PR DESCRIPTION
In some cases, `ExpressionStringBuilder` will format an indexer assignment expression `x => x[i1, i2] = v` incorrectly as `x => x[i1, i2, v] = v`.