### PR TITLE
Fix too-optimistic Task unwrapping logic in `Unwrap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 * Regression: `MockDefaultValueProvider` will no longer attempt to set `CallBase` to true for mocks generated for delegates. (@dammejed, #874)
 
+* `Verify` throws `TargetInvocationException` instead of `MockException` when one of the recorded invocations was to an async method that threw. (@Cufeadir, #883)
+
 
 ## 4.12.0 (2019-06-20)
 

--- a/src/Moq/Unwrap.cs
+++ b/src/Moq/Unwrap.cs
@@ -25,8 +25,20 @@ namespace Moq
 						var isCompleted = (bool)objType.GetProperty("IsCompleted").GetValue(obj, null);
 						if (isCompleted)
 						{
-							var innerObj = objType.GetProperty("Result").GetValue(obj, null);
-							return Unwrap.ResultIfCompletedTask(innerObj);
+							try
+							{
+								var innerObj = objType.GetProperty("Result").GetValue(obj, null);
+								return Unwrap.ResultIfCompletedTask(innerObj);
+							}
+							catch
+							{
+								// We end up here when the task has completed, but not successfully;
+								// e.g. when an exception was thrown. (We *could* check for this by reading
+								// the task's `State` property, however this requires yet more reflection.
+								// For now, let's just leave this as is.)
+								//
+								// In this case, there's no return value to unwrap, so fall through.
+							}
 						}
 					}
 				}

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2761,27 +2761,45 @@ namespace Moq.Tests.Regressions
 		public class Issue883
 		{
 			[Fact]
-			public async Task Verify_can_process_recorded_invocation_that_threw_exception()
+			public async Task Verify_produces_correct_exception_type_if_one_async_invocation_threw()
+			{
+				// This test is here because below code has been known to throw
+				// a `TargetInvocationException` instead of a `MockException`.
+				var ex = await GetVerificationErrorAsync();
+				var mex = Assert.IsAssignableFrom<MockException>(ex);
+				Assert.True(mex.IsVerificationError);
+			}
+
+			[Fact]
+			public async Task Verify_produces_correct_count_in_exception_message_if_one_async_invocation_threw()
+			{
+				var ex = await GetVerificationErrorAsync();
+				Assert.Contains("exactly 3 times, but was 2 times", ex.Message);
+			}
+
+			private async Task<Exception> GetVerificationErrorAsync()
 			{
 				var mock = new Mock<IFoo>();
 
 				// Setup one invocation to throw an exception:
 				mock.SetupSequence(m => m.DoAsync())
 					.Returns(Task.FromException(new InvalidOperationException()))
+					.Returns(Task.CompletedTask)
 					.Returns(Task.CompletedTask);
 
-				// Perform fewer calls (1) than will be expected by verification (2),
+				// Perform fewer calls (2) than will be expected by verification (3),
 				// while ignoring the exception (we only want Moq to record the invocation):
-				try
+				for (int i = 0; i < 2; ++i)
 				{
-					await mock.Object.DoAsync();
+					try
+					{
+						await mock.Object.DoAsync();
+					}
+					catch (InvalidOperationException) { }
 				}
-				catch (InvalidOperationException) { }
 
 				// Cause verification failure. We expect a regular verification exception.
-				// (This test is here because this code has been known to throw TargetInvocationException instead.)
-				var ex = Assert.Throws<MockException>(() => mock.Verify(m => m.DoAsync(), Times.AtLeast(3)));
-				Assert.True(ex.IsVerificationError);
+				return Record.Exception(() => mock.Verify(m => m.DoAsync(), Times.Exactly(3)));
 			}
 
 			public interface IFoo


### PR DESCRIPTION
... because not all completed `Task`s have successfully produced a `.Result`!

This fixes #883.