### PR TITLE
New Reset Extensions

### DIFF
--- a/src/Moq/MockExtensions.cs
+++ b/src/Moq/MockExtensions.cs
@@ -23,7 +23,6 @@ namespace Moq
 			mock.Invocations.Clear();
 		}
 
-
 		/// <summary>
 		/// Reset the mock's configured default values
 		/// </summary>

--- a/src/Moq/MockExtensions.cs
+++ b/src/Moq/MockExtensions.cs
@@ -22,5 +22,42 @@ namespace Moq
 			mock.EventHandlers.Clear();
 			mock.Invocations.Clear();
 		}
+
+
+		/// <summary>
+		/// Reset the mock's configured default values
+		/// </summary>
+		/// <param name="mock">The mock whose default values should be reset.</param>
+		public static void ResetConfiguredDefaultValues(this Mock mock)
+		{
+			mock.ConfiguredDefaultValues.Clear();
+		}
+
+		/// <summary>
+		/// Reset the mock's configured setups
+		/// </summary>
+		/// <param name="mock">The mock whose setups should be reset.</param>
+		public static void ResetSetups(this Mock mock)
+		{
+			mock.Setups.Clear();
+		}
+
+		/// <summary>
+		/// Reset the mock's configured event handlers
+		/// </summary>
+		/// <param name="mock">The mock whose event handlers should be reset.</param>
+		public static void ResetEventHandlers(this Mock mock)
+		{
+			mock.EventHandlers.Clear();
+		}
+
+		/// <summary>
+		/// Reset the mock's recorded invocations
+		/// </summary>
+		/// <param name="mock">The mock whose recorded invocations should be reset.</param>
+		public static void ResetInvocations(this Mock mock)
+		{
+			mock.Invocations.Clear();
+		}
 	}
 }

--- a/tests/Moq.Tests/MockFixture.cs
+++ b/tests/Moq.Tests/MockFixture.cs
@@ -1240,6 +1240,63 @@ namespace Moq.Tests
 			Assert.False(after, "After reset");
 		}
 
+		[Fact]
+		public void ResetSetups_clears_event_setup_flag()
+		{
+			var mock = new Mock<IFoo>();
+			mock.SetupAdd(m => m.EventHandler += It.IsAny<EventHandler>());
+
+			var before = mock.Setups.HasEventSetup;
+			mock.ResetSetups();
+			var after = mock.Setups.HasEventSetup;
+
+			Assert.True(before, "Before reset");
+			Assert.False(after, "After reset");
+		}
+
+		[Fact]
+		public void ResetEventHandlers_clears_event_setup_flag()
+		{
+			var mock = new Mock<IFoo>();
+			Action testDelegate = () => { };
+
+			mock.EventHandlers.Add("TestResetEventHandlersEvent", testDelegate);
+
+			var before = mock.EventHandlers.ToArray("TestResetEventHandlersEvent");
+			mock.ResetEventHandlers();
+			var after = mock.EventHandlers.ToArray("TestResetEventHandlersEvent");
+
+			Assert.True(before.Length == 1, "Before reset");
+			Assert.True(after.Length == 0, "After reset");
+		}
+
+		[Fact]
+		public void ResetConfiguredDefaultValues_clears_configured_default_return_values()
+		{
+			var mock = new Mock<object>();
+			mock.SetReturnsDefault<int>(123);
+
+			mock.ResetConfiguredDefaultValues();
+
+			Assert.Empty(mock.ConfiguredDefaultValues);
+		}
+
+		[Fact]
+		public void ResetInvocations_clears_event_setup_flag()
+		{
+			var mock = new Mock<IFoo>();
+			mock.Object.Echo(0);
+
+			int invocationsBeforeReset = mock.Invocations.Count;
+			mock.ResetInvocations();
+			int invocationsAfterReset = mock.Invocations.Count;
+
+			// To check that only 1 invocation was performed, the one on the test
+			Assert.True(invocationsBeforeReset == 1, "Before reset");
+			// To check that the invocations have been correctly cleared
+			Assert.True(invocationsAfterReset == 0, "After reset");
+		}
+
 #if FEATURE_SERIALIZATION
 		[Serializable]
 		public class BadSerializable : ISerializable


### PR DESCRIPTION
The aim of this pull request is to provide new and isolated ways of resetting properties of the mock selectively, the parts that can be resetted selectively now are the following:

- ConfiguredDefaultValues
- Setups
- EventHandlers
- Invocations

This last one is the same as ResetCalls, which is obsolete so it could be ignored in the pull request.

A set of unit test have been added to demonstrate the behaviour of each of the isolated resets.

One thing to take into consideration is that Reset has not been thoroughly tested, specifically, the part about invocations and eventhandlers has not been tested