### PR TITLE
Uninvoke `SequenceSetup` on `mock.Invocations.Clear()`

### DIFF
--- a/src/Moq/SequenceSetup.cs
+++ b/src/Moq/SequenceSetup.cs
@@ -98,6 +98,11 @@ namespace Moq
 			return this.invoked ? null : MockException.UnmatchedSetup(this);
 		}
 
+		public override void Uninvoke()
+		{
+			this.invoked = false;
+		}
+
 		private readonly struct Response
 		{
 			private readonly ResponseKind kind;

--- a/tests/Moq.Tests/InvocationsFixture.cs
+++ b/tests/Moq.Tests/InvocationsFixture.cs
@@ -130,10 +130,23 @@ namespace Moq.Tests
 		}
 
 		[Fact]
-		public void Invocations_Clear_also_resets_setup_verification_state()
+		public void Invocations_Clear_also_resets_setup_verification_state_of_regular_setups()
 		{
 			var mock = new Mock<IComparable>();
 			mock.Setup(m => m.CompareTo(default));
+			_ = mock.Object.CompareTo(default);
+			mock.VerifyAll();  // ensure setup has been matched
+
+			mock.Invocations.Clear();
+			var ex = Assert.Throws<MockException>(() => mock.VerifyAll());
+			Assert.Equal(MockExceptionReasons.UnmatchedSetup, ex.Reasons);
+		}
+
+		[Fact]
+		public void Invocations_Clear_also_resets_setup_verification_state_of_sequence_setups()
+		{
+			var mock = new Mock<IComparable>();
+			mock.SetupSequence(m => m.CompareTo(default));
 			_ = mock.Object.CompareTo(default);
 			mock.VerifyAll();  // ensure setup has been matched
 


### PR DESCRIPTION
Amends #854.