### PR TITLE
Fail when implicit conversion operator renders argument matcher unmatchable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 * Subscription to mocked events used to be handled less strictly than subscription to regular CLI events. As with the latter, subscribing to mocked events now also requires all handlers to have the same delegate type. (@stakx, #891)
 
+* Moq will throw when it detects that an argument matcher will never match anything due to the presence of an implicit conversion operator. (@michelcedric, #897, #898)
+
 #### Added
 
 * Added support for setup and verification of the event handlers through `Setup[Add|Remove]` and `Verify[Add|Remove|All]` (@lepijohnny, #825) 

--- a/src/Moq/Properties/Resources.Designer.cs
+++ b/src/Moq/Properties/Resources.Designer.cs
@@ -79,6 +79,15 @@ namespace Moq.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Matcher &apos;{0}&apos; is unmatchable: An implicit conversion operator will convert arguments of type &apos;{1}&apos; to the parameter&apos;s type &apos;{2}&apos;, which is assignment-incompatible..
+        /// </summary>
+        internal static string ArgumentMatcherWillNeverMatch {
+            get {
+                return ResourceManager.GetString("ArgumentMatcherWillNeverMatch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Can only add interfaces to the mock..
         /// </summary>
         internal static string AsMustBeInterface {

--- a/src/Moq/Properties/Resources.resx
+++ b/src/Moq/Properties/Resources.resx
@@ -363,4 +363,7 @@ This could be caused by an unrecognized type conversion, coercion, narrowing, or
   <data name="SetupNotEventRemove" xml:space="preserve">
     <value>Expression is not an event remove: {0}</value>
   </data>
+  <data name="ArgumentMatcherWillNeverMatch" xml:space="preserve">
+    <value>Matcher '{0}' is unmatchable: An implicit conversion operator will convert arguments of type '{1}' to the parameter's type '{2}', which is assignment-incompatible.</value>
+  </data>
 </root>

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2804,6 +2804,46 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 897
+
+		public class Issue897
+		{
+			private readonly List<int> data;
+
+			public Issue897()
+			{
+				this.data = new List<int> { 1, 2, 3 };
+			}
+
+			[Fact]
+			public void DateTimeOffset()
+			{
+				var serviceMock = new Mock<IMeteringDataServiceAgent>();
+				serviceMock.Setup(s => s.GetDataList(It.IsAny<DateTimeOffset>())).Returns(this.data);
+
+				var result = serviceMock.Object.GetDataList(DateTime.Now);
+
+				Assert.Equal(this.data, result);
+			}
+
+			[Fact]
+			public void DateTimeNotWorking()
+			{
+				var serviceMock = new Mock<IMeteringDataServiceAgent>();
+
+				Action setup = () => serviceMock.Setup(s => s.GetDataList(It.IsAny<DateTime>()));
+
+				Assert.Throws<ArgumentException>(setup);
+			}
+
+			public interface IMeteringDataServiceAgent
+			{
+				List<int> GetDataList(DateTimeOffset date);
+			}
+		}
+
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47

--- a/tests/Moq.Tests/UnmatchableMatchersFixture.cs
+++ b/tests/Moq.Tests/UnmatchableMatchersFixture.cs
@@ -1,0 +1,61 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+
+using Xunit;
+
+namespace Moq.Tests
+{
+	public class UnmatchableMatchersFixture
+	{
+		[Fact]
+		public void Matchers_that_are_unmatchable_due_to_implicit_conversion_operator_cause_setup_failure()
+		{
+			var mock = new Mock<IX>();
+			var ex = Assert.Throws<ArgumentException>(() => mock.Setup(x => x.UseB(It.IsAny<A>())));
+			Assert.Contains("'It.IsAny<UnmatchableMatchersFixture.A>()' is unmatchable", ex.Message);
+		}
+
+		[Fact]
+		public void Matchers_with_explicit_primitive_type_cast_are_not_considered_unmatchable()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(x => x.UseLong((int)It.IsAny<long>()));
+		}
+
+		[Fact]
+		public void Matchers_with_implicit_primitive_type_coercions_are_not_considered_unmatchable_1()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(x => x.UseLong(It.IsAny<int>()));
+		}
+
+		[Fact]
+		public void Matchers_with_implicit_primitive_nullable_type_coercions_are_not_considered_unmatchable_2()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(x => x.UseNullableLong(It.IsAny<long>()));
+		}
+
+		public interface IX
+		{
+			void UseB(B arg);
+			void UseInt(int arg);
+			void UseLong(long arg);
+			void UseNullableLong(long? arg);
+		}
+
+		public readonly struct A
+		{
+		}
+
+		public readonly struct B
+		{
+			public static implicit operator B(A a)
+			{
+				return new B();
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #897, #898.