### PR TITLE
Fix `SetupAllProperties` indexer regression & refactor accessor check methods for clarify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 * `Verify` throws `TargetInvocationException` instead of `MockException` when one of the recorded invocations was to an async method that threw. (@Cufeadir, #883)
 
+* Regression in 4.12.0: `SetupAllProperties` removes indexer setups. (@stakx, #901)
+
 
 ## 4.12.0 (2019-06-20)
 

--- a/src/Moq/Expressions/Visitors/UpgradePropertyAccessorMethods.cs
+++ b/src/Moq/Expressions/Visitors/UpgradePropertyAccessorMethods.cs
@@ -42,7 +42,7 @@ namespace Moq.Expressions.Visitors
 
 			if (node.Method.IsSpecialName)
 			{
-				if (node.Method.IsPropertyGetter())
+				if (node.Method.IsGetAccessor())
 				{
 					var name = node.Method.Name.Substring(4);
 					var argumentCount = node.Arguments.Count;
@@ -66,7 +66,7 @@ namespace Moq.Expressions.Visitors
 						return Expression.MakeIndex(instance, indexer, arguments.Take(argumentCount - 1));
 					}
 				}
-				else if (node.Method.IsPropertySetter())
+				else if (node.Method.IsSetAccessor())
 				{
 					var name = node.Method.Name.Substring(4);
 					var argumentCount = node.Arguments.Count;

--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -44,34 +44,28 @@ namespace Moq
 			return method.IsStatic && method.IsDefined(typeof(ExtensionAttribute));
 		}
 
-		public static bool IsPropertyGetter(this MethodInfo method)
+		public static bool IsGetAccessor(this MethodInfo method)
 		{
 			return method.IsSpecialName && method.Name.StartsWith("get_", StringComparison.Ordinal);
 		}
 
-		public static bool IsPropertyIndexerGetter(this MethodInfo method)
-		{
-			return method.IsSpecialName && method.Name.StartsWith("get_", StringComparison.Ordinal) && method.GetParameters().Length > 0;
-		}
-
-		public static bool IsPropertyIndexerSetter(this MethodInfo method)
-		{
-			return method.IsSpecialName && method.Name.StartsWith("set_", StringComparison.Ordinal) && method.GetParameters().Length > 1;
-		}
-
-		public static bool IsPropertySetter(this MethodInfo method)
+		public static bool IsSetAccessor(this MethodInfo method)
 		{
 			return method.IsSpecialName && method.Name.StartsWith("set_", StringComparison.Ordinal);
 		}
 
+		public static bool IsIndexerAccessor(this MethodInfo method)
+		{
+			var parameterCount = method.GetParameters().Length;
+			return (method.IsGetAccessor() && parameterCount > 0)
+			    || (method.IsSetAccessor() && parameterCount > 1);
+		}
+
 		public static bool IsPropertyAccessor(this MethodInfo method)
 		{
-			return method.IsPropertyGetter() || method.IsPropertySetter();
-		}
-		
-		public static bool IsPropertyIndexerAccessor(this MethodInfo method)
-		{
-			return method.IsPropertyIndexerGetter() || method.IsPropertyIndexerSetter();
+			var parameterCount = method.GetParameters().Length;
+			return (method.IsGetAccessor() && parameterCount == 0)
+			    || (method.IsSetAccessor() && parameterCount == 1);
 		}
 
 		// NOTE: The following two methods used to first check whether `method.IsSpecialName` was set
@@ -88,12 +82,12 @@ namespace Moq
 		//      - https://code.google.com/archive/p/moq/issues/238
 		//      - the unit tests in `FSharpCompatibilityFixture`
 
-		public static bool LooksLikeEventAttach(this MethodInfo method)
+		public static bool IsEventAddAccessor(this MethodInfo method)
 		{
 			return method.Name.StartsWith("add_", StringComparison.Ordinal);
 		}
 
-		public static bool LooksLikeEventDetach(this MethodInfo method)
+		public static bool IsEventRemoveAccessor(this MethodInfo method)
 		{
 			return method.Name.StartsWith("remove_", StringComparison.Ordinal);
 		}

--- a/src/Moq/Guard.cs
+++ b/src/Moq/Guard.cs
@@ -29,7 +29,7 @@ namespace Moq
 
 				case ExpressionType.Call:
 					var call = (MethodCallExpression)expression.Body;
-					if (call.Method.IsPropertySetter() || call.Method.IsPropertyIndexerSetter()) return;
+					if (call.Method.IsSetAccessor()) return;
 					break;
 			}
 
@@ -82,7 +82,7 @@ namespace Moq
 			}
 		}
 
-		public static void IsEventAttach(LambdaExpression expression, string paramName)
+		public static void IsEventAdd(LambdaExpression expression, string paramName)
 		{
 			Debug.Assert(expression != null);
 
@@ -90,19 +90,19 @@ namespace Moq
 			{
 				case ExpressionType.Call:
 					var call = (MethodCallExpression)expression.Body;
-					if (call.Method.LooksLikeEventAttach()) return;
+					if (call.Method.IsEventAddAccessor()) return;
 					break;
 			}
 
 			throw new ArgumentException(
 				string.Format(
 					CultureInfo.CurrentCulture,
-					Resources.SetupNotEventAttach,
+					Resources.SetupNotEventAdd,
 					expression.ToStringFixed()),
 				paramName);
 		}
 
-		public static void IsEventDetach(LambdaExpression expression, string paramName)
+		public static void IsEventRemove(LambdaExpression expression, string paramName)
 		{
 			Debug.Assert(expression != null);
 
@@ -110,14 +110,14 @@ namespace Moq
 			{
 				case ExpressionType.Call:
 					var call = (MethodCallExpression)expression.Body;
-					if (call.Method.LooksLikeEventDetach()) return;
+					if (call.Method.IsEventRemoveAccessor()) return;
 					break;
 			}
 
 			throw new ArgumentException(
 				string.Format(
 					CultureInfo.CurrentCulture,
-					Resources.SetupNotEventDetach,
+					Resources.SetupNotEventRemove,
 					expression.ToStringFixed()),
 				paramName);
 		}

--- a/src/Moq/Interception/InterceptionAspects.cs
+++ b/src/Moq/Interception/InterceptionAspects.cs
@@ -139,7 +139,7 @@ namespace Moq
 			// more expensive checks (for the common case where the invoked method is *not* an event accessor).
 			if (methodName.Length > 4)
 			{
-				if (methodName[0] == 'a' && methodName[3] == '_' && invocation.Method.LooksLikeEventAttach())
+				if (methodName[0] == 'a' && methodName[3] == '_' && invocation.Method.IsEventAddAccessor())
 				{
 					var eventInfo = GetEventFromName(invocation.Method.Name.Substring("add_".Length), mock);
 					if (eventInfo != null)
@@ -170,7 +170,7 @@ namespace Moq
 						return doesntHaveEventSetup;
 					}
 				}
-				else if (methodName[0] == 'r' && methodName.Length > 7 && methodName[6] == '_' && invocation.Method.LooksLikeEventDetach())
+				else if (methodName[0] == 'r' && methodName.Length > 7 && methodName[6] == '_' && invocation.Method.IsEventRemoveAccessor())
 				{
 					var eventInfo = GetEventFromName(invocation.Method.Name.Substring("remove_".Length), mock);
 					if (eventInfo != null)
@@ -302,7 +302,7 @@ namespace Moq
 						{
 							// Case 2a: Re-implemented interface.
 							// The base class has its own implementation. Only call base method if it isn't an event accessor.
-							if (!method.LooksLikeEventAttach() && !method.LooksLikeEventDetach())
+							if (!method.IsEventAddAccessor() && !method.IsEventRemoveAccessor())
 							{
 								invocation.ReturnBase();
 								return;
@@ -359,7 +359,7 @@ namespace Moq
 			}
 			
 			MethodInfo invocationMethod = invocation.Method;
-			if (invocationMethod.IsPropertyAccessor() && !invocationMethod.IsPropertyIndexerAccessor())
+			if (invocationMethod.IsPropertyAccessor())
 			{
 				string propertyNameToSearch = invocationMethod.Name.Substring(AccessorPrefixLength);
 				PropertyInfo property = invocationMethod.DeclaringType.GetProperty(propertyNameToSearch);
@@ -409,7 +409,7 @@ namespace Moq
 					}
 				}
 
-				Setup setupToExecute = invocationMethod.IsPropertyGetter() ? getterSetup : setterSetup;
+				Setup setupToExecute = invocationMethod.IsGetAccessor() ? getterSetup : setterSetup;
 				setupToExecute.Execute(invocation);
 
 				return true;

--- a/src/Moq/Invocation.cs
+++ b/src/Moq/Invocation.cs
@@ -138,11 +138,11 @@ namespace Moq
 			builder.AppendNameOf(method.DeclaringType);
 			builder.Append('.');
 
-			if (method.IsPropertyGetter())
+			if (method.IsGetAccessor())
 			{
 				builder.Append(method.Name, 4, method.Name.Length - 4);
 			}
-			else if (method.IsPropertySetter())
+			else if (method.IsSetAccessor())
 			{
 				builder.Append(method.Name, 4, method.Name.Length - 4);
 				builder.Append(" = ");

--- a/src/Moq/MatcherFactory.cs
+++ b/src/Moq/MatcherFactory.cs
@@ -131,7 +131,7 @@ namespace Moq
 #pragma warning restore 618
 
 				var method = call.Method;
-				if (!method.IsPropertyGetter() && !method.IsPropertyIndexerGetter())
+				if (!method.IsGetAccessor())
 				{
 					return new Pair<IMatcher, Expression>(new LazyEvalMatcher(originalExpression), originalExpression);
 				}

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -339,7 +339,7 @@ namespace Moq
 		internal static void VerifyAdd(Mock mock, LambdaExpression expression, Times times, string failMessage)
 		{
 			Guard.NotNull(expression, nameof(expression));
-			Guard.IsEventAttach(expression, nameof(expression));
+			Guard.IsEventAdd(expression, nameof(expression));
 
 			Mock.Verify(mock, expression, times, failMessage);
 		}
@@ -347,7 +347,7 @@ namespace Moq
 		internal static void VerifyRemove(Mock mock, LambdaExpression expression, Times times, string failMessage)
 		{
 			Guard.NotNull(expression, nameof(expression));
-			Guard.IsEventDetach(expression, nameof(expression));
+			Guard.IsEventRemove(expression, nameof(expression));
 
 			Mock.Verify(mock, expression, times, failMessage);
 		}
@@ -511,7 +511,7 @@ namespace Moq
 		internal static MethodCall SetupAdd(Mock mock, LambdaExpression expression, Condition condition)
 		{
 			Guard.NotNull(expression, nameof(expression));
-			Guard.IsEventAttach(expression, nameof(expression));
+			Guard.IsEventAdd(expression, nameof(expression));
 
 			return Mock.Setup(mock, expression, condition);
 		}
@@ -519,7 +519,7 @@ namespace Moq
 		internal static MethodCall SetupRemove(Mock mock, LambdaExpression expression, Condition condition)
 		{
 			Guard.NotNull(expression, nameof(expression));
-			Guard.IsEventDetach(expression, nameof(expression));
+			Guard.IsEventRemove(expression, nameof(expression));
 
 			return Mock.Setup(mock, expression, condition);
 		}

--- a/src/Moq/Properties/Resources.Designer.cs
+++ b/src/Moq/Properties/Resources.Designer.cs
@@ -556,18 +556,18 @@ namespace Moq.Properties {
         /// <summary>
         ///   Looks up a localized string similar to Expression is not an event add: {0}.
         /// </summary>
-        internal static string SetupNotEventAttach {
+        internal static string SetupNotEventAdd {
             get {
-                return ResourceManager.GetString("SetupNotEventAttach", resourceCulture);
+                return ResourceManager.GetString("SetupNotEventAdd", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Expression is not an event remove: {0}.
         /// </summary>
-        internal static string SetupNotEventDetach {
+        internal static string SetupNotEventRemove {
             get {
-                return ResourceManager.GetString("SetupNotEventDetach", resourceCulture);
+                return ResourceManager.GetString("SetupNotEventRemove", resourceCulture);
             }
         }
         

--- a/src/Moq/Properties/Resources.resx
+++ b/src/Moq/Properties/Resources.resx
@@ -357,10 +357,10 @@ This could be caused by an unrecognized type conversion, coercion, narrowing, or
   <data name="MethodMissing" xml:space="preserve">
     <value>No protected method {0}.{1} found whose signature is compatible with the provided arguments ({2}).</value>
   </data>
-  <data name="SetupNotEventAttach" xml:space="preserve">
+  <data name="SetupNotEventAdd" xml:space="preserve">
     <value>Expression is not an event add: {0}</value>
   </data>
-  <data name="SetupNotEventDetach" xml:space="preserve">
+  <data name="SetupNotEventRemove" xml:space="preserve">
     <value>Expression is not an event remove: {0}</value>
   </data>
 </root>

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -32,7 +32,7 @@ namespace Moq
 		{
 			lock (this.setups)
 			{
-				if (setup.Method.LooksLikeEventAttach() || setup.Method.LooksLikeEventDetach())
+				if (setup.Method.IsEventAddAccessor() || setup.Method.IsEventRemoveAccessor())
 				{
 					this.hasEventSetup = true;
 				}
@@ -59,7 +59,7 @@ namespace Moq
 
 			lock (this.setups)
 			{
-				this.setups.RemoveAll(x => x.Method.IsPropertyAccessor() && !x.Method.IsPropertyIndexerAccessor());
+				this.setups.RemoveAll(x => x.Method.IsPropertyAccessor());
 				this.overridden = 0U;
 			}
 		}

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -59,7 +59,7 @@ namespace Moq
 
 			lock (this.setups)
 			{
-				this.setups.RemoveAll(x => x.Method.IsPropertyAccessor());
+				this.setups.RemoveAll(x => x.Method.IsPropertyAccessor() && !x.Method.IsPropertyIndexerAccessor());
 				this.overridden = 0U;
 			}
 		}

--- a/tests/Moq.Tests/ComCompatibilityFixture.cs
+++ b/tests/Moq.Tests/ComCompatibilityFixture.cs
@@ -69,7 +69,7 @@ namespace Moq.Tests
 		{
 			var property = typeof(IHasProperty).GetProperty(nameof(IHasProperty.Property));
 			var getter = property.GetGetMethod(true);
-			Assert.True(getter.IsPropertyGetter());
+			Assert.True(getter.IsGetAccessor());
 		}
 
 		[Fact]
@@ -77,7 +77,7 @@ namespace Moq.Tests
 		{
 			var property = typeof(IHasProperty).GetProperty(nameof(IHasProperty.Property));
 			var setter = property.GetSetMethod(true);
-			Assert.True(setter.IsPropertySetter());
+			Assert.True(setter.IsSetAccessor());
 		}
 
 		[Fact]
@@ -92,7 +92,7 @@ namespace Moq.Tests
 		{
 			var indexer = typeof(IHasIndexer).GetProperty(nameof(IHasIndexer.Item));
 			var getter = indexer.GetGetMethod(true);
-			Assert.True(getter.IsPropertyIndexerGetter());
+			Assert.True(getter.IsGetAccessor() && getter.IsIndexerAccessor());
 		}
 
 		[Fact]
@@ -100,7 +100,7 @@ namespace Moq.Tests
 		{
 			var indexer = typeof(IHasIndexer).GetProperty(nameof(IHasIndexer.Item));
 			var setter = indexer.GetSetMethod(true);
-			Assert.True(setter.IsPropertyIndexerSetter());
+			Assert.True(setter.IsSetAccessor() && setter.IsIndexerAccessor());
 		}
 	}
 }

--- a/tests/Moq.Tests/FSharpCompatibilityFixture.cs
+++ b/tests/Moq.Tests/FSharpCompatibilityFixture.cs
@@ -99,7 +99,7 @@ namespace Moq.Tests
 		public void All_FSharp_indexer_getters_are_recognized_as_such(PropertyInfo indexer)
 		{
 			var getter = indexer.GetGetMethod(true);
-			Assert.True(getter.IsPropertyGetter());
+			Assert.True(getter.IsGetAccessor());
 		}
 
 		[Theory]
@@ -107,7 +107,7 @@ namespace Moq.Tests
 		public void All_FSharp_indexer_setters_are_recognized_as_such(PropertyInfo indexer)
 		{
 			var setter = indexer.GetSetMethod(true);
-			Assert.True(setter.IsPropertySetter());
+			Assert.True(setter.IsSetAccessor());
 		}
 
 		public static IEnumerable<object[]> FSharpProperties
@@ -132,7 +132,7 @@ namespace Moq.Tests
 		public void All_FSharp_property_getters_are_recognized_as_such(PropertyInfo property)
 		{
 			var getter = property.GetGetMethod(true);
-			Assert.True(getter.IsPropertyGetter());
+			Assert.True(getter.IsGetAccessor());
 		}
 
 		[Theory]
@@ -140,7 +140,7 @@ namespace Moq.Tests
 		public void All_FSharp_property_setters_are_recognized_as_such(PropertyInfo property)
 		{
 			var setter = property.GetSetMethod(true);
-			Assert.True(setter.IsPropertySetter());
+			Assert.True(setter.IsSetAccessor());
 		}
 	}
 }

--- a/tests/Moq.Tests/PropertiesFixture.cs
+++ b/tests/Moq.Tests/PropertiesFixture.cs
@@ -172,6 +172,16 @@ namespace Moq.Tests
 			Assert.Null(exception);
 		}
 
+		[Fact]
+		public void SetupAllProperties_should_not_reset_indexer_setups()
+		{
+			var mock = new Mock<IIndexedFoo>();
+			mock.SetupGet(m => m[1]).Returns("value from setup");
+			Assert.Equal("value from setup", mock.Object[1]);
+			mock.SetupAllProperties();
+			Assert.Equal("value from setup", mock.Object[1]);
+		}
+
 		public abstract class FooBase
 		{
 			public abstract object A { get; }


### PR DESCRIPTION
Fixes #901.