### PR TITLE
New algorithm for matching invoked methods against expected methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,15 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 * Moq will throw when it detects that an argument matcher will never match anything due to the presence of an implicit conversion operator. (@michelcedric, #897, #898)
 
+* New algorithm for matching invoked methods against methods specified in setup/verification expressions. (@stakx, #904)
+
 #### Added
 
 * Added support for setup and verification of the event handlers through `Setup[Add|Remove]` and `Verify[Add|Remove|All]` (@lepijohnny, #825) 
 
 #### Fixed
+
+* Moq does not mock explicit interface implementation and `protected virtual` correctly. (@oddbear, #657)
 
 * `Invocations.Clear()` does not cause `Verify` to fail (@jchessir, #733)
 
@@ -34,6 +38,8 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * `Verify` throws `TargetInvocationException` instead of `MockException` when one of the recorded invocations was to an async method that threw. (@Cufeadir, #883)
 
 * Regression in 4.12.0: `SetupAllProperties` removes indexer setups. (@stakx, #901)
+
+* Parameter types are ignored when matching an invoked generic method against setups. (@stakx, #903)
 
 
 ## 4.12.0 (2019-06-20)

--- a/src/Moq/Invocation.cs
+++ b/src/Moq/Invocation.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
@@ -10,6 +11,7 @@ namespace Moq
 {
 	internal abstract class Invocation : IInvocation
 	{
+		private readonly Type proxyType;
 		private object[] arguments;
 		private MethodInfo method;
 		private object returnValue;
@@ -18,13 +20,16 @@ namespace Moq
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Invocation"/> class.
 		/// </summary>
+		/// <param name="proxyType">The <see cref="Type"/> of the concrete proxy object on which a method is being invoked.</param>
 		/// <param name="method">The method being invoked.</param>
 		/// <param name="arguments">The arguments with which the specified <paramref name="method"/> is being invoked.</param>
-		protected Invocation(MethodInfo method, params object[] arguments)
+		protected Invocation(Type proxyType, MethodInfo method, params object[] arguments)
 		{
+			Debug.Assert(proxyType != null);
 			Debug.Assert(arguments != null);
 			Debug.Assert(method != null);
 
+			this.proxyType = proxyType;
 			this.arguments = arguments;
 			this.method = method;
 		}
@@ -44,6 +49,8 @@ namespace Moq
 		public object[] Arguments => this.arguments;
 
 		IReadOnlyList<object> IInvocation.Arguments => this.arguments;
+
+		public Type ProxyType => this.proxyType;
 
 		public object ReturnValue => this.returnValue;
 

--- a/src/Moq/Invocation.cs
+++ b/src/Moq/Invocation.cs
@@ -11,9 +11,10 @@ namespace Moq
 {
 	internal abstract class Invocation : IInvocation
 	{
-		private readonly Type proxyType;
 		private object[] arguments;
 		private MethodInfo method;
+		private MethodInfo methodImplementation;
+		private readonly Type proxyType;
 		private object returnValue;
 		private VerificationState verificationState;
 
@@ -29,15 +30,28 @@ namespace Moq
 			Debug.Assert(arguments != null);
 			Debug.Assert(method != null);
 
-			this.proxyType = proxyType;
 			this.arguments = arguments;
 			this.method = method;
+			this.proxyType = proxyType;
 		}
 
 		/// <summary>
 		/// Gets the method of the invocation.
 		/// </summary>
 		public MethodInfo Method => this.method;
+
+		public MethodInfo MethodImplementation
+		{
+			get
+			{
+				if (this.methodImplementation == null)
+				{
+					this.methodImplementation = this.method.GetImplementingMethod(this.proxyType);
+				}
+
+				return this.methodImplementation;
+			}
+		}
 
 		/// <summary>
 		/// Gets the arguments of the invocation.

--- a/src/Moq/ProxyFactories/CastleProxyFactory.cs
+++ b/src/Moq/ProxyFactories/CastleProxyFactory.cs
@@ -129,7 +129,7 @@ namespace Moq
 		{
 			private Castle.DynamicProxy.IInvocation underlying;
 
-			internal Invocation(Castle.DynamicProxy.IInvocation underlying) : base(underlying.Method, underlying.Arguments)
+			internal Invocation(Castle.DynamicProxy.IInvocation underlying) : base(underlying.Proxy.GetType(), underlying.Method, underlying.Arguments)
 			{
 				this.underlying = underlying;
 			}

--- a/src/Moq/ProxyFactories/InterfaceProxy.cs
+++ b/src/Moq/ProxyFactories/InterfaceProxy.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Reflection;
@@ -25,8 +26,9 @@ namespace Moq.Internals
 		public sealed override bool Equals(object obj)
 		{
 			// Forward this call to the interceptor, so that `object.Equals` can be set up.
-			var invocation = new Invocation(equalsMethod, obj);
-			((IInterceptor)((IProxy)this).Interceptor).Intercept(invocation);
+			var interceptor = (IInterceptor)((IProxy)this).Interceptor;
+			var invocation = new Invocation(interceptor.GetType(), equalsMethod, obj);
+			interceptor.Intercept(invocation);
 			return (bool)invocation.ReturnValue;
 		}
 
@@ -35,8 +37,9 @@ namespace Moq.Internals
 		public sealed override int GetHashCode()
 		{
 			// Forward this call to the interceptor, so that `object.GetHashCode` can be set up.
-			var invocation = new Invocation(getHashCodeMethod);
-			((IInterceptor)((IProxy)this).Interceptor).Intercept(invocation);
+			var interceptor = (IInterceptor)((IProxy)this).Interceptor;
+			var invocation = new Invocation(interceptor.GetType(), getHashCodeMethod);
+			interceptor.Intercept(invocation);
 			return (int)invocation.ReturnValue;
 		}
 
@@ -45,8 +48,9 @@ namespace Moq.Internals
 		public sealed override string ToString()
 		{
 			// Forward this call to the interceptor, so that `object.ToString` can be set up.
-			var invocation = new Invocation(toStringMethod);
-			((IInterceptor)((IProxy)this).Interceptor).Intercept(invocation);
+			var interceptor = (IInterceptor)((IProxy)this).Interceptor;
+			var invocation = new Invocation(interceptor.GetType(), toStringMethod);
+			interceptor.Intercept(invocation);
 			return (string)invocation.ReturnValue;
 		}
 
@@ -54,13 +58,13 @@ namespace Moq.Internals
 		{
 			private static object[] noArguments = new object[0];
 
-			public Invocation(MethodInfo method, params object[] arguments)
-				: base(method, arguments)
+			public Invocation(Type proxyType, MethodInfo method, params object[] arguments)
+				: base(proxyType, method, arguments)
 			{
 			}
 
-			public Invocation(MethodInfo method)
-				: base(method, noArguments)
+			public Invocation(Type proxyType, MethodInfo method)
+				: base(proxyType, method, noArguments)
 			{
 			}
 

--- a/tests/Moq.Tests/AsInterfaceFixture.cs
+++ b/tests/Moq.Tests/AsInterfaceFixture.cs
@@ -171,6 +171,33 @@ namespace Moq.Tests
 			bag.Get("test");
 		}
 
+		[Fact]
+		public void Setup_targets_method_implementing_interface_not_other_method_with_same_signature()
+		{
+			var mock = new Mock<Service>() { CallBase = true };
+			mock.As<IService>().Setup(m => m.GetValue()).Returns(3);
+
+			// The public method should have been left alone since it's not the one implementing `IService`:
+			var valueOfOtherMethod = mock.Object.GetValue();
+			Assert.Equal(1, valueOfOtherMethod);
+
+			// The method implementing the interface method should have be mocked:
+			var valueOfSetupMethod = ((IService)mock.Object).GetValue();
+			Assert.Equal(3, valueOfSetupMethod);
+		}
+
+		public class Service : IService
+		{
+			public virtual int GetValue() => 1;
+
+			int IService.GetValue() => 2;
+		}
+
+		public interface IService
+		{
+			int GetValue();
+		}
+
 		// see also test fixture `Issue458` in `IssueReportsFixture`
 
 		public interface IFoo


### PR DESCRIPTION
This replaces the machinery that was responsible for determining whether an invoked method matches that encoded in a setup or verification expression. This previous machinery is very ad-hoc and performs a bunch of tests, such as method name equality, assignment compatibility, and parameter list equality. 

Instead of all that, why not let the runtime do that work by leveraging `method.GetBaseDefinition()`, then simply comparing `MethodInfo`s? (There are some finer points, such as converting generic methods to their (open) generic method definitions; mapping interface methods to the concrete proxy type's methods that provide their implementations; special handling for delegate invocations; etc.)

Fixes #657. Supercedes #658. Fixes #903.