### PR TITLE
Add support for generic type argument matchers (It.IsAnyType and custom matchers)

### DIFF
--- a/src/Moq/Capture.cs
+++ b/src/Moq/Capture.cs
@@ -75,7 +75,8 @@ namespace Moq
 		/// </example>
 		public static T With<T>(CaptureMatch<T> match)
 		{
-			return Match.Create(match);
+			Match.Register(match);
+			return default(T);
 		}
 	}
 }

--- a/src/Moq/ExpressionExtensions.cs
+++ b/src/Moq/ExpressionExtensions.cs
@@ -208,7 +208,7 @@ namespace Moq
 							{
 								if (typeArgument.IsTypeMatcher(out var typeMatcherType))
 								{
-									Guard.HasDefaultConstructor(typeMatcherType);
+									Guard.CanCreateInstance(typeMatcherType);
 								}
 							}
 						}

--- a/src/Moq/ExpressionExtensions.cs
+++ b/src/Moq/ExpressionExtensions.cs
@@ -208,7 +208,7 @@ namespace Moq
 							{
 								if (typeArgument.IsTypeMatcher(out var typeMatcherType))
 								{
-									Guard.CanCreateInstance(typeMatcherType);
+									Guard.ImplementsTypeMatcherProtocol(typeMatcherType);
 								}
 							}
 						}

--- a/src/Moq/ExpressionExtensions.cs
+++ b/src/Moq/ExpressionExtensions.cs
@@ -206,9 +206,9 @@ namespace Moq
 						{
 							foreach (var typeArgument in methodCallExpression.Method.GetGenericArguments())
 							{
-								if (typeArgument.IsTypeMatcher())
+								if (typeArgument.IsTypeMatcher(out var typeMatcherType))
 								{
-									Guard.HasDefaultConstructor(typeArgument);
+									Guard.HasDefaultConstructor(typeMatcherType);
 								}
 							}
 						}

--- a/src/Moq/ExpressionExtensions.cs
+++ b/src/Moq/ExpressionExtensions.cs
@@ -201,6 +201,18 @@ namespace Moq
 					case ExpressionType.Call:  // regular method call
 					{
 						var methodCallExpression = (MethodCallExpression)e;
+
+						if (methodCallExpression.Method.IsGenericMethod)
+						{
+							foreach (var typeArgument in methodCallExpression.Method.GetGenericArguments())
+							{
+								if (typeArgument.IsTypeMatcher())
+								{
+									Guard.HasDefaultConstructor(typeArgument);
+								}
+							}
+						}
+
 						if (!methodCallExpression.Method.IsStatic)
 						{
 							r = methodCallExpression.Object;

--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -4,21 +4,21 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Text;
 
-using Moq.Properties;
-
-using TypeNameFormatter;
-
 namespace Moq
 {
 	internal static class Extensions
 	{
+		public static bool CanCreateInstance(this Type type)
+		{
+			return type.IsValueType || type.GetConstructor(Type.EmptyTypes) != null;
+		}
+
 		/// <summary>
 		///   Gets the default value for the specified type. This is the Reflection counterpart of C#'s <see langword="default"/> operator.
 		/// </summary>
@@ -63,11 +63,6 @@ namespace Moq
 
 				return method.GetBaseDefinition();
 			}
-		}
-
-		public static bool HasDefaultConstructor(this Type type)
-		{
-			return type.GetConstructor(Type.EmptyTypes) != null;
 		}
 
 		public static object InvokePreserveStack(this Delegate del, params object[] args)
@@ -239,7 +234,7 @@ namespace Moq
 					{
 						if (types[i].IsTypeMatcher(out var typeMatcherType))
 						{
-							Debug.Assert(typeMatcherType.HasDefaultConstructor());
+							Debug.Assert(typeMatcherType.CanCreateInstance());
 
 							var typeMatcher = (ITypeMatcher)Activator.CreateInstance(typeMatcherType);
 							if (typeMatcher.Matches(otherTypes[i]) == false)

--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -6,13 +6,14 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Text;
 
 using Moq.Properties;
+
+using TypeNameFormatter;
 
 namespace Moq
 {
@@ -214,7 +215,14 @@ namespace Moq
 					{
 						if (typeof(ITypeMatcher).IsAssignableFrom(types[i]))
 						{
-							Debug.Assert(types[i].GetConstructor(Type.EmptyTypes) != null);
+							if (types[i].GetConstructor(Type.EmptyTypes) == null)
+							{
+								throw new ArgumentException(
+									string.Format(
+										CultureInfo.CurrentCulture,
+										Resources.TypeHasNoDefaultConstructor,
+										types[i].GetFormattedName()));
+							}
 
 							var typeMatcher = (ITypeMatcher)Activator.CreateInstance(types[i]);
 							if (typeMatcher.Matches(otherTypes[i]) == false)

--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -65,6 +65,11 @@ namespace Moq
 			}
 		}
 
+		public static bool HasDefaultConstructor(this Type type)
+		{
+			return type.GetConstructor(Type.EmptyTypes) != null;
+		}
+
 		public static object InvokePreserveStack(this Delegate del, params object[] args)
 		{
 			try
@@ -145,6 +150,11 @@ namespace Moq
 			return !type.IsSealed || type.IsDelegateType();
 		}
 
+		public static bool IsTypeMatcher(this Type type)
+		{
+			return typeof(ITypeMatcher).IsAssignableFrom(type);
+		}
+
 		public static bool CanOverride(this MethodBase method)
 		{
 			return method.IsVirtual && !method.IsFinal && !method.IsPrivate;
@@ -213,16 +223,9 @@ namespace Moq
 				case TypeComparison.TypeMatchersOrElseAssignmentCompatibility:
 					for (int i = 0; i < count; ++i)
 					{
-						if (typeof(ITypeMatcher).IsAssignableFrom(types[i]))
+						if (types[i].IsTypeMatcher())
 						{
-							if (types[i].GetConstructor(Type.EmptyTypes) == null)
-							{
-								throw new ArgumentException(
-									string.Format(
-										CultureInfo.CurrentCulture,
-										Resources.TypeHasNoDefaultConstructor,
-										types[i].GetFormattedName()));
-							}
+							Debug.Assert(types[i].HasDefaultConstructor());
 
 							var typeMatcher = (ITypeMatcher)Activator.CreateInstance(types[i]);
 							if (typeMatcher.Matches(otherTypes[i]) == false)

--- a/src/Moq/Guard.cs
+++ b/src/Moq/Guard.cs
@@ -28,6 +28,23 @@ namespace Moq
 			}
 		}
 
+		public static void ImplementsTypeMatcherProtocol(Type type)
+		{
+			Debug.Assert(type != null);
+
+			if (typeof(ITypeMatcher).IsAssignableFrom(type) == false)
+			{
+				throw new ArgumentException(
+					string.Format(
+						CultureInfo.CurrentCulture,
+						Resources.TypeNotImplementInterface,
+						type.GetFormattedName(),
+						typeof(ITypeMatcher).GetFormattedName()));
+			}
+
+			Guard.CanCreateInstance(type);
+		}
+
 		public static void IsAssignmentToPropertyOrIndexer(LambdaExpression expression, string paramName)
 		{
 			Debug.Assert(expression != null);

--- a/src/Moq/Guard.cs
+++ b/src/Moq/Guard.cs
@@ -16,6 +16,18 @@ namespace Moq
 	[DebuggerStepThrough]
 	internal static class Guard
 	{
+		public static void HasDefaultConstructor(Type type)
+		{
+			if (!type.HasDefaultConstructor())
+			{
+				throw new ArgumentException(
+					string.Format(
+						CultureInfo.CurrentCulture,
+						Resources.TypeHasNoDefaultConstructor,
+						type.GetFormattedName()));
+			}
+		}
+
 		public static void IsAssignmentToPropertyOrIndexer(LambdaExpression expression, string paramName)
 		{
 			Debug.Assert(expression != null);

--- a/src/Moq/Guard.cs
+++ b/src/Moq/Guard.cs
@@ -16,9 +16,9 @@ namespace Moq
 	[DebuggerStepThrough]
 	internal static class Guard
 	{
-		public static void HasDefaultConstructor(Type type)
+		public static void CanCreateInstance(Type type)
 		{
-			if (!type.HasDefaultConstructor())
+			if (!type.CanCreateInstance())
 			{
 				throw new ArgumentException(
 					string.Format(

--- a/src/Moq/IMatcher.cs
+++ b/src/Moq/IMatcher.cs
@@ -1,12 +1,14 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using System;
+
 namespace Moq
 {
 	internal interface IMatcher
 	{
-		bool Matches(object value);
+		bool Matches(object argument, Type parameterType);
 
-		void SetupEvaluatedSuccessfully(object value);
+		void SetupEvaluatedSuccessfully(object argument, Type parameterType);
 	}
 }

--- a/src/Moq/ITypeMatcher.cs
+++ b/src/Moq/ITypeMatcher.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Moq
+{
+	/// <summary>
+	///   A type matcher represents a criterion against which generic type arguments are matched.
+	/// </summary>
+	internal interface ITypeMatcher
+	{
+		/// <summary>
+		///   Matches the provided type argument against the criterion represented by this type matcher.
+		/// </summary>
+		/// <param name="typeArgument">
+		///   The generic type argument that should be matched.
+		/// </param>
+		/// <returns>
+		///   <see langword="true"/> if the provided type argument matched the criterion represented by this instance;
+		///   otherwise, <see langword="false"/>.
+		/// </returns>
+		bool Matches(Type typeArgument);
+	}
+}

--- a/src/Moq/ITypeMatcher.cs
+++ b/src/Moq/ITypeMatcher.cs
@@ -3,7 +3,10 @@ using System;
 namespace Moq
 {
 	/// <summary>
-	///   A type matcher represents a criterion against which generic type arguments are matched.
+	///   Types that implement this interface represent a criterion against which generic type arguments are matched.
+	///   <para>
+	///     To be used in combination with <see cref="TypeMatcherAttribute"/>.
+	///   </para>
 	/// </summary>
 	public interface ITypeMatcher
 	{

--- a/src/Moq/ITypeMatcher.cs
+++ b/src/Moq/ITypeMatcher.cs
@@ -5,7 +5,7 @@ namespace Moq
 	/// <summary>
 	///   A type matcher represents a criterion against which generic type arguments are matched.
 	/// </summary>
-	internal interface ITypeMatcher
+	public interface ITypeMatcher
 	{
 		/// <summary>
 		///   Matches the provided type argument against the criterion represented by this type matcher.

--- a/src/Moq/InvocationAction.cs
+++ b/src/Moq/InvocationAction.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+
+namespace Moq
+{
+	/// <summary>
+	///   A delegate-like type for use with `setup.Callback` which instructs the `Callback` verb
+	///   to provide the callback with the current <see cref="IInvocation"/>, instead of
+	///   with a list of arguments.
+	///   <para>
+	///     This type is useful in scenarios involving generic type argument matchers (such as
+	///     <see cref="It.IsAnyType" />) as <see cref="IInvocation"/> allows the discovery of both
+	///     arguments and type arguments.
+	///   </para>
+	/// </summary>
+	public readonly struct InvocationAction
+	{
+		internal readonly Action<IInvocation> Action;
+
+		/// <summary>
+		///   Initializes a new instance of the <see cref="InvocationAction"/> type.
+		/// </summary>
+		/// <param name="action">The delegate that should be wrapped by this instance.</param>
+		public InvocationAction(Action<IInvocation> action)
+		{
+			this.Action = action;
+		}
+	}
+}

--- a/src/Moq/InvocationFunc.cs
+++ b/src/Moq/InvocationFunc.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+
+namespace Moq
+{
+	/// <summary>
+	///   A delegate-like type for use with `setup.Returns` which instructs the `Returns` verb
+	///   to provide the callback with the current <see cref="IInvocation"/>, instead of
+	///   with a list of arguments.
+	///   <para>
+	///     This type is useful in scenarios involving generic type argument matchers (such as
+	///     <see cref="It.IsAnyType" />) as <see cref="IInvocation"/> allows the discovery of both
+	///     arguments and type arguments.
+	///   </para>
+	/// </summary>
+	public readonly struct InvocationFunc
+	{
+		internal readonly Func<IInvocation, object> Func;
+
+		/// <summary>
+		///   Initializes a new instance of the <see cref="InvocationFunc"/> type.
+		/// </summary>
+		/// <param name="func">The delegate that should be wrapped by this instance.</param>
+		public InvocationFunc(Func<IInvocation, object> func)
+		{
+			this.Func = func;
+		}
+	}
+}

--- a/src/Moq/InvocationShape.cs
+++ b/src/Moq/InvocationShape.cs
@@ -70,9 +70,10 @@ namespace Moq
 			}
 
 			var arguments = invocation.Arguments;
+			var parameterTypes = invocation.Method.GetParameterTypes();
 			for (int i = 0, n = this.argumentMatchers.Length; i < n; ++i)
 			{
-				if (this.argumentMatchers[i].Matches(arguments[i]) == false)
+				if (this.argumentMatchers[i].Matches(arguments[i], parameterTypes[i]) == false)
 				{
 					return false;
 				}
@@ -84,9 +85,10 @@ namespace Moq
 		public void SetupEvaluatedSuccessfully(Invocation invocation)
 		{
 			var arguments = invocation.Arguments;
+			var parameterTypes = invocation.Method.GetParameterTypes();
 			for (int i = 0, n = this.argumentMatchers.Length; i < n; ++i)
 			{
-				this.argumentMatchers[i].SetupEvaluatedSuccessfully(arguments[i]);
+				this.argumentMatchers[i].SetupEvaluatedSuccessfully(arguments[i], parameterTypes[i]);
 			}
 		}
 

--- a/src/Moq/InvocationShape.cs
+++ b/src/Moq/InvocationShape.cs
@@ -127,7 +127,7 @@ namespace Moq
 
 			if (method.IsGenericMethod || invocationMethod.IsGenericMethod)
 			{
-				if (!method.GetGenericArguments().CompareTo(invocationMethod.GetGenericArguments(), exact: false))
+				if (!method.GetGenericArguments().CompareTo(invocationMethod.GetGenericArguments(), TypeComparison.TypeMatchersOrElseAssignmentCompatibility))
 				{
 					return false;
 				}

--- a/src/Moq/It.cs
+++ b/src/Moq/It.cs
@@ -58,6 +58,17 @@ namespace Moq
 		}
 
 		/// <summary>
+		///   A type matcher that matches any generic type argument.
+		/// </summary>
+		public sealed class IsAnyType : ITypeMatcher
+		{
+			bool ITypeMatcher.Matches(Type type)
+			{
+				return true;
+			}
+		}
+
+		/// <summary>
 		///   Matches any value of the given <typeparamref name="TValue"/> type, except null.
 		/// </summary>
 		/// <typeparam name="TValue">Type of the value.</typeparam>

--- a/src/Moq/It.cs
+++ b/src/Moq/It.cs
@@ -45,9 +45,18 @@ namespace Moq
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsAny"]/*'/>
 		public static TValue IsAny<TValue>()
 		{
-			return Match<TValue>.Create(
-				value => value is TValue || value == null,
-				() => It.IsAny<TValue>());
+			if (typeof(TValue).IsTypeMatcher(out _))
+			{
+				return Match.Create<TValue>(
+					(argument, parameterType) => argument == null || parameterType.IsAssignableFrom(argument.GetType()),
+					() => It.IsAny<TValue>());
+			}
+			else
+			{
+				return Match.Create<TValue>(
+					 argument                 => argument == null || argument is TValue,
+					() => It.IsAny<TValue>());
+			}
 		}
 
 		private static readonly MethodInfo isAnyMethod = typeof(It).GetMethod(nameof(It.IsAny), BindingFlags.Public | BindingFlags.Static);

--- a/src/Moq/It.cs
+++ b/src/Moq/It.cs
@@ -46,7 +46,7 @@ namespace Moq
 		/// <include file='It.xdoc' path='docs/doc[@for="It.IsAny"]/*'/>
 		public static TValue IsAny<TValue>()
 		{
-			if (typeof(TValue).IsTypeMatcher(out _))
+			if (typeof(TValue).IsTypeMatcher())
 			{
 				return Match.Create<TValue>(
 					(argument, parameterType) => argument == null || parameterType.IsAssignableFrom(argument.GetType()),
@@ -70,6 +70,7 @@ namespace Moq
 		/// <summary>
 		///   A type matcher that matches any generic type argument.
 		/// </summary>
+		[TypeMatcher]
 		public sealed class IsAnyType : ITypeMatcher
 		{
 			bool ITypeMatcher.Matches(Type type)
@@ -84,7 +85,7 @@ namespace Moq
 		/// <typeparam name="TValue">Type of the value.</typeparam>
 		public static TValue IsNotNull<TValue>()
 		{
-			if (typeof(TValue).IsTypeMatcher(out _))
+			if (typeof(TValue).IsTypeMatcher())
 			{
 				return Match.Create<TValue>(
 					(argument, parameterType) => argument != null && parameterType.IsAssignableFrom(argument.GetType()),
@@ -110,7 +111,7 @@ namespace Moq
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
 		public static TValue Is<TValue>(Expression<Func<TValue, bool>> match)
 		{
-			if (typeof(TValue).IsTypeMatcher(out _))
+			if (typeof(TValue).IsTypeMatcher())
 			{
 				throw new ArgumentException(Resources.UseItIsOtherOverload, nameof(match));
 			}

--- a/src/Moq/It.cs
+++ b/src/Moq/It.cs
@@ -69,6 +69,15 @@ namespace Moq
 
 		/// <summary>
 		///   A type matcher that matches any generic type argument.
+		///   <para>
+		///     If the generic type parameter is constrained to <see langword="struct"/> (C#) / <see langword="Structure"/>
+		///     (VB.NET), use <see cref="It.IsValueType"/> instead.
+		///   </para>
+		///   <para>
+		///     If the generic type parameter has more specific constraints,
+		///     you can define your own type matcher inheriting from the type to which the type parameter is constrained.
+		///     See <see cref="TypeMatcherAttribute"/> and <see cref="ITypeMatcher"/>.
+		///   </para>
 		/// </summary>
 		[TypeMatcher]
 		public sealed class IsAnyType : ITypeMatcher
@@ -250,6 +259,31 @@ namespace Moq
 
 			// But evaluated every time :)
 			return Match<string>.Create(value => value != null && re.IsMatch(value), () => It.IsRegex(regex, options));
+		}
+
+		/// <summary>
+		///   A type matcher that matches subtypes of <typeparamref name="T"/>, as well as <typeparamref name="T"/> itself.
+		/// </summary>
+		/// <typeparam name="T">The type whose subtypes should match.</typeparam>
+		[TypeMatcher]
+		public sealed class IsSubtype<T> : ITypeMatcher
+		{
+			bool ITypeMatcher.Matches(Type type)
+			{
+				return typeof(T).IsAssignableFrom(type);
+			}
+		}
+
+		/// <summary>
+		///   A type matcher that matches any value type.
+		/// </summary>
+		[TypeMatcher]
+		public readonly struct IsValueType : ITypeMatcher
+		{
+			bool ITypeMatcher.Matches(Type type)
+			{
+				return type.IsValueType;
+			}
 		}
 	}
 }

--- a/src/Moq/Language/Flow/NonVoidSetupPhrase.cs
+++ b/src/Moq/Language/Flow/NonVoidSetupPhrase.cs
@@ -11,6 +11,12 @@ namespace Moq.Language.Flow
 		{
 		}
 
+		public new IReturnsThrows<T, TResult> Callback(InvocationAction action)
+		{
+			this.Setup.SetCallbackResponse(action.Action);
+			return this;
+		}
+
 		public new IReturnsThrows<T, TResult> Callback(Delegate callback)
 		{
 			this.Setup.SetCallbackResponse(callback);
@@ -248,6 +254,12 @@ namespace Moq.Language.Flow
 		public IReturnsResult<T> Returns(TResult value)
 		{
 			this.Setup.SetEagerReturnsResponse(value);
+			return this;
+		}
+
+		public IReturnsResult<T> Returns(InvocationFunc valueFunction)
+		{
+			this.Setup.SetReturnsResponse(valueFunction.Func);
 			return this;
 		}
 

--- a/src/Moq/Language/Flow/SetupPhrase.cs
+++ b/src/Moq/Language/Flow/SetupPhrase.cs
@@ -27,6 +27,12 @@ namespace Moq.Language.Flow
 
 		public IVerifies AtMostOnce() => this.AtMost(1);
 
+		public ICallbackResult Callback(InvocationAction action)
+		{
+			this.setup.SetCallbackResponse(action.Action);
+			return this;
+		}
+
 		public ICallbackResult Callback(Delegate callback)
 		{
 			this.setup.SetCallbackResponse(callback);

--- a/src/Moq/Language/ICallback.cs
+++ b/src/Moq/Language/ICallback.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+
 using Moq.Language.Flow;
 
 namespace Moq.Language
@@ -13,6 +14,32 @@ namespace Moq.Language
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public partial interface ICallback : IFluentInterface
 	{
+		/// <summary>
+		///   Specifies a callback to invoke when the method is called that receives the original <see cref="IInvocation"/>.
+		///   <para>
+		///     This overload is intended to be used in scenarios involving generic type argument matchers
+		///     (such as <see cref="It.IsAnyType"/>). The callback will receive the current <see cref="IInvocation"/>,
+		///     which allows discovery of both arguments and type arguments.
+		///   </para>
+		///   <para>
+		///     For all other use cases, you should prefer the other <c>Callback</c> overloads as they provide
+		///     better static type safety.
+		///   </para>
+		/// </summary>
+		/// <example>
+		///   <code>
+		///     Figure out the generic type argument used for a mocked method call:
+		///     mock.Setup(m => m.DoSomethingWith&lt;It.IsAnyType&gt;(...))
+		///         .Callback(new InvocationAction(invocation =>
+		///                  {
+		///                      var typeArgument = invocation.Method.GetGenericArguments()[0];
+		///                      // do something interesting with the type argument
+		///                  });
+		///     mock.Object.DoSomethingWith&lt;Something&gt;();
+		///   </code>
+		/// </example>
+		ICallbackResult Callback(InvocationAction action);
+
 		/// <summary>
 		/// Specifies a callback of any delegate type to invoke when the method is called.
 		/// This overload specifically allows you to define callbacks for methods with by-ref parameters.
@@ -76,6 +103,32 @@ namespace Moq.Language
 	public partial interface ICallback<TMock, TResult> : IFluentInterface
 		where TMock : class
 	{
+		/// <summary>
+		///   Specifies a callback to invoke when the method is called that receives the original <see cref="IInvocation"/>.
+		///   <para>
+		///     This overload is intended to be used in scenarios involving generic type argument matchers
+		///     (such as <see cref="It.IsAnyType"/>). The callback will receive the current <see cref="IInvocation"/>,
+		///     which allows discovery of both arguments and type arguments.
+		///   </para>
+		///   <para>
+		///     For all other use cases, you should prefer the other <c>Callback</c> overloads as they provide
+		///     better static type safety.
+		///   </para>
+		/// </summary>
+		/// <example>
+		///     Figure out the generic type argument used for a mocked method call:
+		///   <code>
+		///     mock.Setup(m => m.DoSomethingWith&lt;It.IsAnyType&gt;(...))
+		///         .Callback(new InvocationAction(invocation =>
+		///                  {
+		///                      var typeArgument = invocation.Method.GetGenericArguments()[0];
+		///                      // do something interesting with the type argument
+		///                  });
+		///     mock.Object.DoSomethingWith&lt;Something&gt;();
+		///   </code>
+		/// </example>
+		IReturnsThrows<TMock, TResult> Callback(InvocationAction action);
+
 		/// <summary>
 		/// Specifies a callback of any delegate type to invoke when the method is called.
 		/// This overload specifically allows you to define callbacks for methods with by-ref parameters.

--- a/src/Moq/Language/IReturns.cs
+++ b/src/Moq/Language/IReturns.cs
@@ -30,6 +30,32 @@ namespace Moq.Language
 		IReturnsResult<TMock> Returns(TResult value);
 
 		/// <summary>
+		///   Specifies a function that will calculate the value to return from the method.
+		///   <para>
+		///     This overload is intended to be used in scenarios involving generic type argument matchers,
+		///     such as <see cref="It.IsAnyType"/>. The function will receive the current <see cref="IInvocation"/>,
+		///     which allows discovery of both arguments and type arguments.
+		///   </para>
+		///   <para>
+		///     For all other use cases, you should prefer the other <c>Returns</c> overloads as they provide
+		///     better static type safety.
+		///   </para>
+		/// </summary>
+		/// <example>
+		///   Mock a method to act like a generic factory method:
+		///   <code>
+		///     factory.Setup(m => m.Create&lt;It.IsAnyType&gt;())
+		///            .Returns(new InvocationFunc(invocation =>
+		///                     {
+		///                         var typeArgument = invocation.Method.GetGenericArguments()[0];
+		///                         return Activator.CreateInstance(typeArgument);
+		///                     });
+		///     var something = factory.Object.Create&lt;Something&gt;();
+		///   </code>
+		/// </example>
+		IReturnsResult<TMock> Returns(InvocationFunc valueFunction);
+
+		/// <summary>
 		/// Specifies a function that will calculate the value to return from the method.
 		/// This overload specifically allows you to specify a function with by-ref parameters.
 		/// Those by-ref parameters can be assigned to (though you should probably do that from

--- a/src/Moq/Match.cs
+++ b/src/Moq/Match.cs
@@ -49,7 +49,8 @@ namespace Moq
 		/// <param name="condition">The condition to match against actual values.</param>
 		public static T Create<T>(Predicate<T> condition)
 		{
-			return Create(new Match<T>(condition, () => Matcher<T>()));
+			Match.Register(new Match<T>(condition, () => Matcher<T>()));
+			return default(T);
 		}
 
 		/// <summary>
@@ -64,10 +65,11 @@ namespace Moq
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
 		public static T Create<T>(Predicate<T> condition, Expression<Func<T>> renderExpression)
 		{
-			return Create(new Match<T>(condition, renderExpression));
+			Match.Register(new Match<T>(condition, renderExpression));
+			return default(T);
 		}
 
-		internal static T Create<T>(Match<T> match)
+		internal static void Register(Match match)
 		{
 			// This method is used to set an expression as the last matcher invoked,
 			// which is used in the SetupSet to allow matchers in the prop = value
@@ -84,8 +86,6 @@ namespace Moq
 			{
 				observer.OnMatch(match);
 			}
-
-			return default(T);
 		}
 	}
 

--- a/src/Moq/Match.cs
+++ b/src/Moq/Match.cs
@@ -32,13 +32,13 @@ namespace Moq
 			return default(TValue);
 		}
 
-		internal abstract bool Matches(object value);
+		internal abstract bool Matches(object argument, Type parameterType);
 
-		internal abstract void SetupEvaluatedSuccessfully(object value);
+		internal abstract void SetupEvaluatedSuccessfully(object argument, Type parameterType);
 
-		bool IMatcher.Matches(object value) => this.Matches(value);
+		bool IMatcher.Matches(object argument, Type parameterType) => this.Matches(argument, parameterType);
 
-		void IMatcher.SetupEvaluatedSuccessfully(object value) => this.SetupEvaluatedSuccessfully(value);
+		void IMatcher.SetupEvaluatedSuccessfully(object value, Type parameterType) => this.SetupEvaluatedSuccessfully(value, parameterType);
 
 		internal Expression RenderExpression { get; set; }
 
@@ -107,17 +107,17 @@ namespace Moq
 			this.Success = success;
 		}
 
-		internal override bool Matches(object value)
+		internal override bool Matches(object argument, Type parameterType)
 		{
-			return CanCast(value) && this.Condition((T)value);
+			return CanCast(argument) && this.Condition((T)argument);
 		}
 
-		internal override void SetupEvaluatedSuccessfully(object value)
+		internal override void SetupEvaluatedSuccessfully(object argument, Type parameterType)
 		{
-			Debug.Assert(this.Matches(value));
-			Debug.Assert(CanCast(value));
+			Debug.Assert(this.Matches(argument, parameterType));
+			Debug.Assert(CanCast(argument));
 
-			this.Success?.Invoke((T)value);
+			this.Success?.Invoke((T)argument);
 		}
 
 		private static bool CanCast(object value)

--- a/src/Moq/Matchers/AnyMatcher.cs
+++ b/src/Moq/Matchers/AnyMatcher.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using System;
 using System.Diagnostics;
 
 namespace Moq.Matchers
@@ -13,11 +14,11 @@ namespace Moq.Matchers
 		{
 		}
 
-		public bool Matches(object value) => true;
+		public bool Matches(object argument, Type parameterType) => true;
 
-		public void SetupEvaluatedSuccessfully(object value)
+		public void SetupEvaluatedSuccessfully(object argument, Type parameterType)
 		{
-			Debug.Assert(this.Matches(value));
+			Debug.Assert(this.Matches(argument, parameterType));
 		}
 	}
 }

--- a/src/Moq/Matchers/ConstantMatcher.cs
+++ b/src/Moq/Matchers/ConstantMatcher.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using System;
 using System.Collections;
 using System.Diagnostics;
 using System.Linq;
@@ -16,15 +17,15 @@ namespace Moq.Matchers
 			this.constantValue = constantValue;
 		}
 
-		public bool Matches(object value)
+		public bool Matches(object argument, Type parameterType)
 		{
-			if (object.Equals(value, constantValue))
+			if (object.Equals(argument, constantValue))
 			{
 				return true;
 			}
 
-			if (this.constantValue is IEnumerable && value is IEnumerable enumerable &&
-				!(this.constantValue is IMocked) && !(value is IMocked))
+			if (this.constantValue is IEnumerable && argument is IEnumerable enumerable &&
+				!(this.constantValue is IMocked) && !(argument is IMocked))
 				// the above checks on the second line are necessary to ensure we have usable
 				// implementations of IEnumerable, which might very well not be the case for
 				// mocked objects.
@@ -35,9 +36,9 @@ namespace Moq.Matchers
 			return false;
 		}
 
-		public void SetupEvaluatedSuccessfully(object value)
+		public void SetupEvaluatedSuccessfully(object argument, Type parameterType)
 		{
-			Debug.Assert(this.Matches(value));
+			Debug.Assert(this.Matches(argument, parameterType));
 		}
 
 		private bool MatchesEnumerable(IEnumerable enumerable)

--- a/src/Moq/Matchers/ExpressionMatcher.cs
+++ b/src/Moq/Matchers/ExpressionMatcher.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using System;
 using System.Diagnostics;
 using System.Linq.Expressions;
 
@@ -15,15 +16,15 @@ namespace Moq.Matchers
 			this.expression = expression;
 		}
 
-		public bool Matches(object value)
+		public bool Matches(object argument, Type parameterType)
 		{
-			return value is Expression valueExpression
+			return argument is Expression valueExpression
 				&& ExpressionComparer.Default.Equals(this.expression, valueExpression);
 		}
 
-		public void SetupEvaluatedSuccessfully(object value)
+		public void SetupEvaluatedSuccessfully(object argument, Type parameterType)
 		{
-			Debug.Assert(this.Matches(value));
+			Debug.Assert(this.Matches(argument, parameterType));
 		}
 	}
 }

--- a/src/Moq/Matchers/LazyEvalMatcher.cs
+++ b/src/Moq/Matchers/LazyEvalMatcher.cs
@@ -16,20 +16,20 @@ namespace Moq.Matchers
 			this.expression = expression;
 		}
 
-		public bool Matches(object value)
+		public bool Matches(object argument, Type parameterType)
 		{
 			var eval = Evaluator.PartialEval(this.expression);
 			if (eval.NodeType == ExpressionType.Constant)
 			{
-				return object.Equals(((ConstantExpression)eval).Value, value);
+				return object.Equals(((ConstantExpression)eval).Value, argument);
 			}
 
 			return false;
 		}
 
-		public void SetupEvaluatedSuccessfully(object value)
+		public void SetupEvaluatedSuccessfully(object argument, Type parameterType)
 		{
-			Debug.Assert(this.Matches(value));
+			Debug.Assert(this.Matches(argument, parameterType));
 		}
 	}
 }

--- a/src/Moq/Matchers/MatcherAttributeMatcher.cs
+++ b/src/Moq/Matchers/MatcherAttributeMatcher.cs
@@ -80,19 +80,19 @@ namespace Moq.Matchers
 			return method;
 		}
 
-		public bool Matches(object value)
+		public bool Matches(object argument, Type parameterType)
 		{
 			// use matcher Expression to get extra arguments
 			var extraArgs = this.expression.Arguments.Select(ae => ((ConstantExpression)ae.PartialEval()).Value);
-			var args = new[] { value }.Concat(extraArgs).ToArray();
+			var args = new[] { argument }.Concat(extraArgs).ToArray();
 			// for static and non-static method
 			var instance = this.expression.Object == null ? null : (this.expression.Object.PartialEval() as ConstantExpression).Value;
 			return (bool)validatorMethod.Invoke(instance, args);
 		}
 
-		public void SetupEvaluatedSuccessfully(object value)
+		public void SetupEvaluatedSuccessfully(object argument, Type parameterType)
 		{
-			Debug.Assert(this.Matches(value));
+			Debug.Assert(this.Matches(argument, parameterType));
 		}
 	}
 }

--- a/src/Moq/Matchers/ParamArrayMatcher.cs
+++ b/src/Moq/Matchers/ParamArrayMatcher.cs
@@ -17,17 +17,19 @@ namespace Moq.Matchers
 			this.matchers = matchers;
 		}
 
-		public bool Matches(object value)
+		public bool Matches(object argument, Type parameterType)
 		{
-			Array values = value as Array;
+			Array values = argument as Array;
 			if (values == null || this.matchers.Length != values.Length)
 			{
 				return false;
 			}
 
+			var elementType = parameterType.GetElementType();
+
 			for (int index = 0; index < values.Length; index++)
 			{
-				if (!this.matchers[index].Matches(values.GetValue(index)))
+				if (!this.matchers[index].Matches(values.GetValue(index), elementType))
 				{
 					return false;
 				}
@@ -36,15 +38,16 @@ namespace Moq.Matchers
 			return true;
 		}
 
-		public void SetupEvaluatedSuccessfully(object value)
+		public void SetupEvaluatedSuccessfully(object argument, Type parameterType)
 		{
-			Debug.Assert(this.Matches(value));
-			Debug.Assert(value is Array array && array.Length == this.matchers.Length);
+			Debug.Assert(this.Matches(argument, parameterType));
+			Debug.Assert(argument is Array array && array.Length == this.matchers.Length);
 
-			var values = (Array)value;
+			var values = (Array)argument;
+			var elementType = parameterType.GetElementType();
 			for (int i = 0, n = this.matchers.Length; i < n; ++i)
 			{
-				this.matchers[i].SetupEvaluatedSuccessfully(values.GetValue(i));
+				this.matchers[i].SetupEvaluatedSuccessfully(values.GetValue(i), elementType);
 			}
 		}
 	}

--- a/src/Moq/Matchers/RefMatcher.cs
+++ b/src/Moq/Matchers/RefMatcher.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using System;
 using System.Diagnostics;
 
 namespace Moq.Matchers
@@ -16,15 +17,15 @@ namespace Moq.Matchers
 			this.referenceIsValueType = reference?.GetType().IsValueType ?? false;
 		}
 
-		public bool Matches(object value)
+		public bool Matches(object argument, Type parameterType)
 		{
-			return this.referenceIsValueType ? object.Equals(this.reference, value)
-			                                 : object.ReferenceEquals(this.reference, value);
+			return this.referenceIsValueType ? object.Equals(this.reference, argument)
+			                                 : object.ReferenceEquals(this.reference, argument);
 		}
 
-		public void SetupEvaluatedSuccessfully(object value)
+		public void SetupEvaluatedSuccessfully(object value, Type parameterType)
 		{
-			Debug.Assert(this.Matches(value));
+			Debug.Assert(this.Matches(value, parameterType));
 		}
 	}
 }

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -301,12 +301,16 @@ namespace Moq
 
 				if (!expectedReturnType.IsAssignableFrom(actualReturnType))
 				{
-					throw new ArgumentException(
-						string.Format(
-							CultureInfo.CurrentCulture,
-							Resources.InvalidCallbackReturnTypeMismatch,
-							expectedReturnType,
-							actualReturnType));
+					// TODO: If the return type is a matcher, does the callback's return type need to be matched against it?
+					if (typeof(ITypeMatcher).IsAssignableFrom(expectedReturnType) == false)
+					{
+						throw new ArgumentException(
+							string.Format(
+								CultureInfo.CurrentCulture,
+								Resources.InvalidCallbackReturnTypeMismatch,
+								expectedReturnType,
+								actualReturnType));
+					}
 				}
 			}
 		}

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -13,14 +12,12 @@ using System.Text;
 
 using Moq.Properties;
 
-using TypeNameFormatter;
-
 namespace Moq
 {
 	internal sealed partial class MethodCall : SetupWithOutParameterSupport
 	{
-		private Action<object[]> afterReturnCallbackResponse;
-		private Action<object[]> callbackResponse;
+		private Response afterReturnCallbackResponse;
+		private Response callbackResponse;
 		private LimitInvocationCountResponse limitInvocationCountResponse;
 		private Condition condition;
 		private string failMessage;
@@ -98,7 +95,7 @@ namespace Moq
 
 			this.limitInvocationCountResponse?.RespondTo(invocation);
 
-			this.callbackResponse?.Invoke(invocation.Arguments);
+			this.callbackResponse?.RespondTo(invocation);
 
 			if ((this.flags & Flags.CallBase) != 0)
 			{
@@ -127,7 +124,7 @@ namespace Moq
 					}
 				}
 
-				this.afterReturnCallbackResponse?.Invoke(invocation.Arguments);
+				this.afterReturnCallbackResponse?.RespondTo(invocation);
 			}
 		}
 
@@ -169,12 +166,19 @@ namespace Moq
 				throw new ArgumentNullException(nameof(callback));
 			}
 
-			ref Action<object[]> response = ref this.returnOrThrowResponse == null ? ref this.callbackResponse
-			                                                                       : ref this.afterReturnCallbackResponse;
+			ref Response response = ref this.returnOrThrowResponse == null ? ref this.callbackResponse
+			                                                               : ref this.afterReturnCallbackResponse;
 
 			if (callback is Action callbackWithoutArguments)
 			{
-				response = (object[] args) => callbackWithoutArguments();
+				response = new CallbackResponse(args => callbackWithoutArguments());
+			}
+			else if (callback.GetType() == typeof(Action<IInvocation>))
+			{
+				// NOTE: Do NOT rewrite the above condition as `callback is Action<IInvocation>`,
+				// because this will also yield true if `callback` is a `Action<object>` and thus
+				// break existing uses of `(object arg) => ...` callbacks!
+				response = new InvocationCallbackResponse((Action<IInvocation>)callback);
 			}
 			else
 			{
@@ -194,7 +198,7 @@ namespace Moq
 					throw new ArgumentException(Resources.InvalidCallbackNotADelegateWithReturnTypeVoid, nameof(callback));
 				}
 
-				response = (object[] args) => callback.InvokePreserveStack(args);
+				response = new CallbackResponse(args => callback.InvokePreserveStack(args));
 			}
 		}
 
@@ -252,6 +256,13 @@ namespace Moq
 				// We don't want to invoke the passed delegate to get a return value; the passed delegate
 				// already is the return value.
 				this.returnOrThrowResponse = new ReturnEagerValueResponse(valueFactory);
+			}
+			else if (valueFactory.GetType() == typeof(Func<IInvocation, object>))
+			{
+				// NOTE: Do NOT rewrite the above condition as `valueFactory is Func<IInvocation, object>`,
+				// for similar reasons as noted above in `SetCallbackResponse`. We want to test for this
+				// particular delegate type and no others that may happen to be implicitly convertible to it!
+				this.returnOrThrowResponse = new ReturnInvocationLazyValueResponse((Func<IInvocation, object>)valueFactory);
 			}
 			else
 			{
@@ -420,6 +431,40 @@ namespace Moq
 			public abstract void RespondTo(Invocation invocation);
 		}
 
+		private sealed class CallbackResponse : Response
+		{
+			private readonly Action<object[]> callback;
+
+			public CallbackResponse(Action<object[]> callback)
+			{
+				Debug.Assert(callback != null);
+
+				this.callback = callback;
+			}
+
+			public override void RespondTo(Invocation invocation)
+			{
+				this.callback.Invoke(invocation.Arguments);
+			}
+		}
+
+		private sealed class InvocationCallbackResponse : Response
+		{
+			private readonly Action<IInvocation> callback;
+
+			public InvocationCallbackResponse(Action<IInvocation> callback)
+			{
+				Debug.Assert(callback != null);
+
+				this.callback = callback;
+			}
+
+			public override void RespondTo(Invocation invocation)
+			{
+				this.callback.Invoke(invocation);
+			}
+		}
+
 		private sealed class ReturnBaseResponse : Response
 		{
 			public static readonly ReturnBaseResponse Instance = new ReturnBaseResponse();
@@ -446,6 +491,23 @@ namespace Moq
 			public override void RespondTo(Invocation invocation)
 			{
 				invocation.Return(this.Value);
+			}
+		}
+
+		private sealed class ReturnInvocationLazyValueResponse : Response
+		{
+			private readonly Func<IInvocation, object> valueFactory;
+
+			public ReturnInvocationLazyValueResponse(Func<IInvocation, object> valueFactory)
+			{
+				Debug.Assert(valueFactory != null);
+
+				this.valueFactory = valueFactory;
+			}
+
+			public override void RespondTo(Invocation invocation)
+			{
+				invocation.Return(this.valueFactory.Invoke(invocation));
 			}
 		}
 

--- a/src/Moq/Properties/Resources.Designer.cs
+++ b/src/Moq/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Moq.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -541,6 +541,15 @@ namespace Moq.Properties {
         internal static string SetupNotSetter {
             get {
                 return ResourceManager.GetString("SetupNotSetter", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Type {0} does not have a default (public parameterless) constructor..
+        /// </summary>
+        internal static string TypeHasNoDefaultConstructor {
+            get {
+                return ResourceManager.GetString("TypeHasNoDefaultConstructor", resourceCulture);
             }
         }
         

--- a/src/Moq/Properties/Resources.Designer.cs
+++ b/src/Moq/Properties/Resources.Designer.cs
@@ -705,6 +705,15 @@ namespace Moq.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to It is impossible to call the provided strongly-typed predicate due to the use of a type matcher. Provide a weakly-typed predicate with two parameters (object, Type) instead..
+        /// </summary>
+        internal static string UseItIsOtherOverload {
+            get {
+                return ResourceManager.GetString("UseItIsOtherOverload", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0}:.
         /// </summary>
         internal static string VerificationErrorsOfInnerMock {

--- a/src/Moq/Properties/Resources.resx
+++ b/src/Moq/Properties/Resources.resx
@@ -351,4 +351,7 @@ This could be caused by an unrecognized type conversion, coercion, narrowing, or
   <data name="TypeHasNoDefaultConstructor" xml:space="preserve">
     <value>Type {0} does not have a default (public parameterless) constructor.</value>
   </data>
+  <data name="UseItIsOtherOverload" xml:space="preserve">
+    <value>It is impossible to call the provided strongly-typed predicate due to the use of a type matcher. Provide a weakly-typed predicate with two parameters (object, Type) instead.</value>
+  </data>
 </root>

--- a/src/Moq/Properties/Resources.resx
+++ b/src/Moq/Properties/Resources.resx
@@ -348,4 +348,7 @@ This could be caused by an unrecognized type conversion, coercion, narrowing, or
   <data name="NoConstructorCallFound" xml:space="preserve">
     <value>No constructor call could be found.</value>
   </data>
+  <data name="TypeHasNoDefaultConstructor" xml:space="preserve">
+    <value>Type {0} does not have a default (public parameterless) constructor.</value>
+  </data>
 </root>

--- a/src/Moq/Protected/ItExpr.cs
+++ b/src/Moq/Protected/ItExpr.cs
@@ -123,9 +123,8 @@ namespace Moq.Protected
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
 		public static Expression Is<TValue>(Expression<Func<TValue, bool>> match)
 		{
-			return Expression.Call(
-				typeof(It).GetMethod(nameof(It.Is), BindingFlags.Public | BindingFlags.Static).MakeGenericMethod(typeof(TValue)),
-				match);
+			Expression<Func<TValue>> expr = () => It.Is((Expression<Func<TValue, bool>>)null);
+			return Expression.Call(((MethodCallExpression)expr.Body).Method, match);
 		}
 
 		/// <summary>

--- a/src/Moq/Protected/ProtectedMock.cs
+++ b/src/Moq/Protected/ProtectedMock.cs
@@ -245,7 +245,7 @@ namespace Moq.Protected
 		{
 			var argTypes = ToArgTypes(args);
 			return typeof(T).GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
-				.SingleOrDefault(m => m.Name == methodName && m.GetParameterTypes().CompareTo(argTypes, exact));
+				.SingleOrDefault(m => m.Name == methodName && m.GetParameterTypes().CompareTo(argTypes, exact ? TypeComparison.Equality : TypeComparison.AssignmentCompatibility));
 		}
 
 		private static Expression<Func<T, TResult>> GetMethodCall<TResult>(MethodInfo method, object[] args)

--- a/src/Moq/TypeComparison.cs
+++ b/src/Moq/TypeComparison.cs
@@ -1,0 +1,12 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+namespace Moq
+{
+	internal enum TypeComparison
+	{
+		AssignmentCompatibility,
+		Equality,
+		TypeMatchersOrElseAssignmentCompatibility,
+	}
+}

--- a/src/Moq/TypeMatcherAttribute.cs
+++ b/src/Moq/TypeMatcherAttribute.cs
@@ -44,7 +44,7 @@ namespace Moq
 						typeof(ITypeMatcher).GetFormattedName()));
 			}
 
-			Guard.HasDefaultConstructor(type);
+			Guard.CanCreateInstance(type);
 
 			this.type = type;
 		}

--- a/src/Moq/TypeMatcherAttribute.cs
+++ b/src/Moq/TypeMatcherAttribute.cs
@@ -2,18 +2,13 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
-using System.Globalization;
-
-using Moq.Properties;
-
-using TypeNameFormatter;
 
 namespace Moq
 {
 	/// <summary>
-	///   Marks a type as a type matcher, specifying another <see cref="ITypeMatcher"/> type that will perform the matching.
+	///   Marks a type as a type matcher, optionally specifying another <see cref="ITypeMatcher"/> type that will perform the matching.
 	///   <para>
-	///     Type matchers preferably implement <see cref="ITypeMatcher"/> directly. Use this attribute only in situations
+	///     Type matchers preferably implement <see cref="ITypeMatcher"/> themselves. Use the parameterized form of this attribute
 	///     where this is not possible, such as when the type matcher needs to be a <see langword="delegate"/> or
 	///     <see langword="enum"/> type in order to satisfy generic type constraints of the method where it is used.
 	///   </para>
@@ -25,6 +20,21 @@ namespace Moq
 
 		/// <summary>
 		///   Initializes a new instance of the <see cref="TypeMatcherAttribute"/> class.
+		///   <para>
+		///     Use this constructor overload if the type on which this attribute is placed implements <see cref="ITypeMatcher"/> itself.
+		///   </para>
+		/// </summary>
+		public TypeMatcherAttribute()
+		{
+			this.type = null;
+		}
+
+		/// <summary>
+		///   Initializes a new instance of the <see cref="TypeMatcherAttribute"/> class.
+		///   <para>
+		///     Use this constructor overload if the type on which this attribute is placed does not implement <see cref="ITypeMatcher"/>.
+		///     The specified type will instead provide the implementation of <see cref="ITypeMatcher"/>.
+		///   </para>
 		/// </summary>
 		/// <param name="type">The <see cref="Type"/> of a type that implements <see cref="ITypeMatcher"/>.</param>
 		public TypeMatcherAttribute(Type type)
@@ -33,18 +43,6 @@ namespace Moq
 			{
 				throw new ArgumentNullException(nameof(type));
 			}
-
-			if (typeof(ITypeMatcher).IsAssignableFrom(type) == false)
-			{
-				throw new ArgumentException(
-					string.Format(
-						CultureInfo.CurrentCulture,
-						Resources.TypeNotImplementInterface,
-						type.GetFormattedName(),
-						typeof(ITypeMatcher).GetFormattedName()));
-			}
-
-			Guard.CanCreateInstance(type);
 
 			this.type = type;
 		}

--- a/src/Moq/TypeMatcherAttribute.cs
+++ b/src/Moq/TypeMatcherAttribute.cs
@@ -1,0 +1,54 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.Globalization;
+
+using Moq.Properties;
+
+using TypeNameFormatter;
+
+namespace Moq
+{
+	/// <summary>
+	///   Marks a type as a type matcher, specifying another <see cref="ITypeMatcher"/> type that will perform the matching.
+	///   <para>
+	///     Type matchers preferably implement <see cref="ITypeMatcher"/> directly. Use this attribute only in situations
+	///     where this is not possible, such as when the type matcher needs to be a <see langword="delegate"/> or
+	///     <see langword="enum"/> type in order to satisfy generic type constraints of the method where it is used.
+	///   </para>
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Class | AttributeTargets.Delegate | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Struct, AllowMultiple = false, Inherited = true)]
+	public class TypeMatcherAttribute : Attribute
+	{
+		private readonly Type type;
+
+		/// <summary>
+		///   Initializes a new instance of the <see cref="TypeMatcherAttribute"/> class.
+		/// </summary>
+		/// <param name="type">The <see cref="Type"/> of a type that implements <see cref="ITypeMatcher"/>.</param>
+		public TypeMatcherAttribute(Type type)
+		{
+			if (type == null)
+			{
+				throw new ArgumentNullException(nameof(type));
+			}
+
+			if (typeof(ITypeMatcher).IsAssignableFrom(type) == false)
+			{
+				throw new ArgumentException(
+					string.Format(
+						CultureInfo.CurrentCulture,
+						Resources.TypeNotImplementInterface,
+						type.GetFormattedName(),
+						typeof(ITypeMatcher).GetFormattedName()));
+			}
+
+			Guard.HasDefaultConstructor(type);
+
+			this.type = type;
+		}
+
+		internal Type Type => this.type;
+	}
+}

--- a/tests/Moq.Tests/CustomTypeMatchersFixture.cs
+++ b/tests/Moq.Tests/CustomTypeMatchersFixture.cs
@@ -75,9 +75,26 @@ namespace Moq.Tests
 			mock.Verify(x => x.Method<PickyIntOrString>(), Times.Exactly(3));
 		}
 
+		[Fact]
+		public void Must_use_custom_type_matcher_when_type_constraints_present()
+		{
+			var mock = new Mock<IY>();
+			//mock.Setup(y => y.Method<It.IsAnyType>());  // wouldn't work because of the type constraint
+			mock.Setup(y => y.Method<AnyException>());
+
+			mock.Object.Method<ArgumentException>();
+
+			mock.VerifyAll();
+		}
+
 		public interface IX
 		{
 			void Method<T>();
+		}
+
+		public interface IY
+		{
+			void Method<TException>() where TException : Exception;
 		}
 
 		public sealed class IntOrString : ITypeMatcher
@@ -107,6 +124,14 @@ namespace Moq.Tests
 			public bool Matches(Type typeArgument)
 			{
 				return Array.IndexOf(this.types, typeArgument) >= 0;
+			}
+		}
+
+		public class AnyException : Exception, ITypeMatcher
+		{
+			public bool Matches(Type typeArgument)
+			{
+				return true;
 			}
 		}
 	}

--- a/tests/Moq.Tests/CustomTypeMatchersFixture.cs
+++ b/tests/Moq.Tests/CustomTypeMatchersFixture.cs
@@ -87,6 +87,19 @@ namespace Moq.Tests
 			mock.VerifyAll();
 		}
 
+		[Fact]
+		public void Must_use_TypeMatcherAttribute_when_type_constraints_present_that_prevents_direct_implementation_of_ITypeMatcher()
+		{
+			var mock = new Mock<IZ>();
+			mock.Setup(z => z.DelegateMethod<AnyDelegate>());
+			mock.Setup(z => z.EnumMethod<AnyEnum>());
+
+			mock.Object.DelegateMethod<Action>();
+			mock.Object.EnumMethod<AttributeTargets>();
+
+			mock.VerifyAll();
+		}
+
 		public interface IX
 		{
 			void Method<T>();
@@ -95,6 +108,12 @@ namespace Moq.Tests
 		public interface IY
 		{
 			void Method<TException>() where TException : Exception;
+		}
+
+		public interface IZ
+		{
+			void DelegateMethod<TDelegate>() where TDelegate : Delegate;
+			void EnumMethod<TEnum>() where TEnum : Enum;
 		}
 
 		public sealed class IntOrString : ITypeMatcher
@@ -134,5 +153,11 @@ namespace Moq.Tests
 				return true;
 			}
 		}
+
+		[TypeMatcher(typeof(It.IsAnyType))]
+		public enum AnyEnum { }
+
+		[TypeMatcher(typeof(It.IsAnyType))]
+		public delegate void AnyDelegate();
 	}
 }

--- a/tests/Moq.Tests/CustomTypeMatchersFixture.cs
+++ b/tests/Moq.Tests/CustomTypeMatchersFixture.cs
@@ -1,0 +1,83 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+
+using Xunit;
+
+namespace Moq.Tests
+{
+	public class CustomTypeMatchersFixture
+	{
+		[Fact]
+		public void Setup_with_custom_type_matcher()
+		{
+			var invocationCount = 0;
+			var mock = new Mock<IX>();
+			mock.Setup(x => x.Method<IntOrString>()).Callback(() => invocationCount++);
+
+			mock.Object.Method<bool>();
+			mock.Object.Method<int>();
+			mock.Object.Method<int>();
+			mock.Object.Method<object>();
+			mock.Object.Method<string>();
+
+			Assert.Equal(3, invocationCount);
+		}
+
+		[Fact]
+		public void Verify_with_custom_type_matcher()
+		{
+			var mock = new Mock<IX>();
+
+			mock.Object.Method<bool>();
+			mock.Object.Method<int>();
+			mock.Object.Method<int>();
+			mock.Object.Method<object>();
+			mock.Object.Method<string>();
+
+			mock.Verify(x => x.Method<IntOrString>(), Times.Exactly(3));
+		}
+
+		[Fact]
+		public void Cannot_use_type_matcher_with_parameterized_constructor_directly()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(x => x.Method<Picky>());
+
+			// TODO: Ideally, failure should occur as early as possible, i.e. during setup.
+			Action invocation = () => mock.Object.Method<object>();
+
+			var ex = Assert.Throws<ArgumentException>(invocation);
+			Assert.Contains("Picky does not have a default (public parameterless) constructor", ex.Message);
+		}
+
+		public interface IX
+		{
+			void Method<T>();
+		}
+
+		public sealed class IntOrString : ITypeMatcher
+		{
+			public bool Matches(Type typeArgument)
+			{
+				return typeArgument == typeof(int) || typeArgument == typeof(string);
+			}
+		}
+
+		public class Picky : ITypeMatcher
+		{
+			private readonly Type[] types;
+
+			public Picky(params Type[] types)
+			{
+				this.types = types;
+			}
+
+			public bool Matches(Type typeArgument)
+			{
+				return Array.IndexOf(this.types, typeArgument) >= 0;
+			}
+		}
+	}
+}

--- a/tests/Moq.Tests/CustomTypeMatchersFixture.cs
+++ b/tests/Moq.Tests/CustomTypeMatchersFixture.cs
@@ -2,6 +2,7 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
+using System.Linq;
 
 using Xunit;
 
@@ -107,9 +108,62 @@ namespace Moq.Tests
 			mock.VerifyAll();
 		}
 
+		[Fact]
+		public void It_IsAny_works_with_custom_matcher()
+		{
+			var invocationCount = 0;
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Method(It.IsAny<IntOrString>())).Callback((object arg) => invocationCount++);
+
+			mock.Object.Method(true);
+			mock.Object.Method(42);
+			mock.Object.Method("42");
+			mock.Object.Method(new Exception("42"));
+			mock.Object.Method((string)null);
+
+			Assert.Equal(3, invocationCount);
+		}
+
+		[Fact]
+		public void It_IsNotNull_works_with_custom_matcher()
+		{
+			var invocationCount = 0;
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Method(It.IsNotNull<IntOrString>())).Callback((object arg) => invocationCount++);
+
+			mock.Object.Method(true);
+			mock.Object.Method(42);
+			mock.Object.Method("42");
+			mock.Object.Method(new Exception("42"));
+			mock.Object.Method((string)null);
+
+			Assert.Equal(2, invocationCount);
+		}
+
+		[Fact]
+		public void It_Is_works_with_custom_matcher()
+		{
+			var acceptableArgs = new object[] { 42, "42" };
+
+			var invocationCount = 0;
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Method(It.Is<IntOrString>((arg, _) => acceptableArgs.Contains(arg))))
+			    .Callback((object arg) => invocationCount++);
+
+			mock.Object.Method(42);
+			mock.Object.Method(7);
+			Assert.Equal(1, invocationCount);
+
+			mock.Object.Method("42");
+			mock.Object.Method("7");
+			mock.Object.Method((string)null);
+			Assert.Equal(2, invocationCount);
+		}
+
 		public interface IX
 		{
 			void Method<T>();
+			void Method<T>(T arg);
 		}
 
 		public interface IY

--- a/tests/Moq.Tests/CustomTypeMatchersFixture.cs
+++ b/tests/Moq.Tests/CustomTypeMatchersFixture.cs
@@ -61,6 +61,20 @@ namespace Moq.Tests
 			Assert.Contains("Picky does not have a default (public parameterless) constructor", ex.Message);
 		}
 
+		[Fact]
+		public void Can_use_type_matcher_derived_from_one_having_a_parameterized_constructor()
+		{
+			var mock = new Mock<IX>();
+
+			mock.Object.Method<bool>();
+			mock.Object.Method<int>();
+			mock.Object.Method<object>();
+			mock.Object.Method<string>();
+			mock.Object.Method<string>();
+
+			mock.Verify(x => x.Method<PickyIntOrString>(), Times.Exactly(3));
+		}
+
 		public interface IX
 		{
 			void Method<T>();
@@ -71,6 +85,13 @@ namespace Moq.Tests
 			public bool Matches(Type typeArgument)
 			{
 				return typeArgument == typeof(int) || typeArgument == typeof(string);
+			}
+		}
+
+		public sealed class PickyIntOrString : Picky
+		{
+			public PickyIntOrString() : base(typeof(int), typeof(string))
+			{
 			}
 		}
 

--- a/tests/Moq.Tests/CustomTypeMatchersFixture.cs
+++ b/tests/Moq.Tests/CustomTypeMatchersFixture.cs
@@ -76,6 +76,13 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public void Can_use_struct_type_matchers()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Method<AnyStruct>());
+		}
+
+		[Fact]
 		public void Must_use_custom_type_matcher_when_type_constraints_present()
 		{
 			var mock = new Mock<IY>();
@@ -159,5 +166,10 @@ namespace Moq.Tests
 
 		[TypeMatcher(typeof(It.IsAnyType))]
 		public delegate void AnyDelegate();
+
+		public struct AnyStruct : ITypeMatcher
+		{
+			public bool Matches(Type typeArgument) => typeArgument.IsValueType;
+		}
 	}
 }

--- a/tests/Moq.Tests/CustomTypeMatchersFixture.cs
+++ b/tests/Moq.Tests/CustomTypeMatchersFixture.cs
@@ -177,6 +177,7 @@ namespace Moq.Tests
 			void EnumMethod<TEnum>() where TEnum : Enum;
 		}
 
+		[TypeMatcher]
 		public sealed class IntOrString : ITypeMatcher
 		{
 			public bool Matches(Type typeArgument)
@@ -192,6 +193,7 @@ namespace Moq.Tests
 			}
 		}
 
+		[TypeMatcher]
 		public class Picky : ITypeMatcher
 		{
 			private readonly Type[] types;
@@ -207,6 +209,7 @@ namespace Moq.Tests
 			}
 		}
 
+		[TypeMatcher]
 		public class AnyException : Exception, ITypeMatcher
 		{
 			public bool Matches(Type typeArgument)
@@ -221,6 +224,7 @@ namespace Moq.Tests
 		[TypeMatcher(typeof(It.IsAnyType))]
 		public delegate void AnyDelegate();
 
+		[TypeMatcher]
 		public struct AnyStruct : ITypeMatcher
 		{
 			public bool Matches(Type typeArgument) => typeArgument.IsValueType;

--- a/tests/Moq.Tests/CustomTypeMatchersFixture.cs
+++ b/tests/Moq.Tests/CustomTypeMatchersFixture.cs
@@ -40,15 +40,24 @@ namespace Moq.Tests
 		}
 
 		[Fact]
-		public void Cannot_use_type_matcher_with_parameterized_constructor_directly()
+		public void Cannot_use_type_matcher_with_parameterized_constructor_directly_in_Setup()
 		{
 			var mock = new Mock<IX>();
-			mock.Setup(x => x.Method<Picky>());
 
-			// TODO: Ideally, failure should occur as early as possible, i.e. during setup.
-			Action invocation = () => mock.Object.Method<object>();
+			Action setup = () => mock.Setup(x => x.Method<Picky>());
 
-			var ex = Assert.Throws<ArgumentException>(invocation);
+			var ex = Assert.Throws<ArgumentException>(setup);
+			Assert.Contains("Picky does not have a default (public parameterless) constructor", ex.Message);
+		}
+
+		[Fact]
+		public void Cannot_use_type_matcher_with_parameterized_constructor_directly_in_Verify()
+		{
+			var mock = new Mock<IX>();
+
+			Action verify = () => mock.Verify(x => x.Method<Picky>(), Times.Never);
+
+			var ex = Assert.Throws<ArgumentException>(verify);
 			Assert.Contains("Picky does not have a default (public parameterless) constructor", ex.Message);
 		}
 

--- a/tests/Moq.Tests/IsSubtypeFixture.cs
+++ b/tests/Moq.Tests/IsSubtypeFixture.cs
@@ -1,0 +1,49 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using Xunit;
+
+namespace Moq.Tests
+{
+	public class IsSubtypeFixture
+	{
+		[Fact]
+		public void It_IsSubtype_works_for_base_type_relationships()
+		{
+			var mock = new Mock<IX>();
+
+			mock.Object.Method<ArgumentOutOfRangeException>(); // should match
+			mock.Object.Method<Exception>();
+			mock.Object.Method<ArgumentException>(); // should match
+			mock.Object.Method<string>();
+			mock.Object.Method<ArgumentNullException>(); // should match
+			mock.Object.Method<InvalidOperationException>();
+			mock.Object.Method<bool>();
+
+			mock.Verify(m => m.Method<It.IsSubtype<ArgumentException>>(), Times.Exactly(3));
+		}
+
+		[Fact]
+		public void It_IsSubtype_works_for_interface_implementation_relationships()
+		{
+			var mock = new Mock<IX>();
+
+			mock.Object.Method<Stream>(); // should match
+			mock.Object.Method<string>();
+			mock.Object.Method<IEnumerator<int>>(); // should match
+			mock.Object.Method<Exception>();
+			mock.Object.Method<bool>();
+
+			mock.Verify(m => m.Method<It.IsSubtype<IDisposable>>(), Times.Exactly(2));
+		}
+
+		public interface IX
+		{
+			void Method<T>();
+		}
+	}
+}

--- a/tests/Moq.Tests/IsValueTypeFixture.cs
+++ b/tests/Moq.Tests/IsValueTypeFixture.cs
@@ -1,0 +1,46 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+
+using Xunit;
+
+namespace Moq.Tests
+{
+	public class IsValueTypeFixture
+	{
+		[Fact]
+		public void It_IsValueType_works_for_unconstrained_type_parameter()
+		{
+			var mock = new Mock<IX>();
+
+			mock.Object.Unconstrained(1); // should match
+			mock.Object.Unconstrained(true); // should match
+			mock.Object.Unconstrained("");
+			mock.Object.Unconstrained(new Exception());
+			mock.Object.Unconstrained(3.141f); // should match
+
+			mock.Verify(m => m.Unconstrained<It.IsValueType>(It.IsAny<It.IsValueType>()), Times.Exactly(3));
+		}
+
+		[Fact]
+		public void It_IsValueType_works_for_constrained_type_parameter()
+		{
+			var mock = new Mock<IX>();
+
+			mock.Object.Constrained(1); // should match
+			mock.Object.Constrained(true); // should match
+			//mock.Object.Constrained("");
+			//mock.Object.Constrained(new Exception());
+			mock.Object.Constrained(3.141f); // should match
+
+			mock.Verify(m => m.Constrained<It.IsValueType>(It.IsAny<It.IsValueType>()), Times.Exactly(3));
+		}
+
+		public interface IX
+		{
+			void Unconstrained<T>(T arg);
+			void Constrained<T>(T arg) where T : struct;
+		}
+	}
+}

--- a/tests/Moq.Tests/ItIsAnyTypeFixture.cs
+++ b/tests/Moq.Tests/ItIsAnyTypeFixture.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using System;
+
 using Xunit;
 
 namespace Moq.Tests
@@ -52,9 +54,25 @@ namespace Moq.Tests
 			mock.Verify(x => x.Method<It.IsAnyType>(), Times.Exactly(4));
 		}
 
+		[Fact]
+		public void Setup_with_It_IsAnyType_and_Returns()
+		{
+			var mock = new Mock<IY>();
+			mock.Setup(m => m.Method<It.IsAnyType>((It.IsAnyType)It.IsAny<object>()))
+			    .Returns(new Func<object, object>(arg => arg));
+
+			Assert.Equal(42, mock.Object.Method<int>(42));
+			Assert.Equal("42", mock.Object.Method<string>("42"));
+		}
+
 		public interface IX
 		{
 			void Method<T>();
+		}
+
+		public interface IY
+		{
+			T Method<T>(T arg);
 		}
 	}
 }

--- a/tests/Moq.Tests/ItIsAnyTypeFixture.cs
+++ b/tests/Moq.Tests/ItIsAnyTypeFixture.cs
@@ -1,0 +1,60 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using Xunit;
+
+namespace Moq.Tests
+{
+	public class ItIsAnyTypeFixture
+	{
+		[Fact]
+		public void Setup_without_It_IsAnyType()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(x => x.Method<bool>());
+			mock.Setup(x => x.Method<int>());
+			mock.Setup(x => x.Method<object>());
+			mock.Setup(x => x.Method<string>());
+
+			mock.Object.Method<bool>();
+			mock.Object.Method<int>();
+			mock.Object.Method<object>();
+			mock.Object.Method<string>();
+
+			mock.VerifyAll();
+		}
+
+		[Fact]
+		public void Setup_with_It_IsAnyType()
+		{
+			var invocationCount = 0;
+			var mock = new Mock<IX>();
+			mock.Setup(x => x.Method<It.IsAnyType>()).Callback(() => invocationCount++);
+
+			mock.Object.Method<bool>();
+			mock.Object.Method<int>();
+			mock.Object.Method<object>();
+			mock.Object.Method<string>();
+
+			Assert.Equal(4, invocationCount);
+		}
+
+		[Fact]
+		public void Verify_with_It_IsAnyType()
+		{
+			var mock = new Mock<IX>();
+
+			mock.Object.Method<bool>();
+			mock.Object.Method<int>();
+			mock.Object.Method<object>();
+			mock.Object.Method<string>();
+
+			mock.Verify(x => x.Method<It.IsAnyType>(), Times.Exactly(4));
+		}
+
+		public interface IX
+		{
+			void Method<T>();
+		}
+	}
+}

--- a/tests/Moq.Tests/ItIsAnyTypeFixture.cs
+++ b/tests/Moq.Tests/ItIsAnyTypeFixture.cs
@@ -95,6 +95,37 @@ namespace Moq.Tests
 			Assert.Empty((int[])result);
 		}
 
+		[Fact]
+		public void Type_arguments_can_be_discovered_in_Callback_through_a_InvocationAction_callback()
+		{
+			Type typeArgument = null;
+			var mock = new Mock<IZ>();
+			mock.Setup(z => z.Method<It.IsAnyType>()).Callback(new InvocationAction(invocation =>
+			{
+				typeArgument = invocation.Method.GetGenericArguments()[0];
+			}));
+
+			_ = mock.Object.Method<string>();
+
+			Assert.Equal(typeof(string), typeArgument);
+		}
+
+		[Fact]
+		public void Type_arguments_can_be_discovered_in_Returns_through_a_InvocationFunc_callback()
+		{
+			var mock = new Mock<IZ>();
+			mock.Setup(z => z.Method<It.IsAnyType>()).Returns(new InvocationFunc(invocation =>
+			{
+				var typeArgument = invocation.Method.GetGenericArguments()[0];
+				return Activator.CreateInstance(typeArgument);
+			}));
+
+			var result = mock.Object.Method<DateTime>();
+
+			Assert.IsType<DateTime>(result);
+			Assert.Equal(default(DateTime), result);
+		}
+
 		public interface IX
 		{
 			void Method<T>();
@@ -103,6 +134,11 @@ namespace Moq.Tests
 		public interface IY
 		{
 			T Method<T>(T arg);
+		}
+
+		public interface IZ
+		{
+			T Method<T>();
 		}
 	}
 }

--- a/tests/Moq.Tests/ItIsAnyTypeFixture.cs
+++ b/tests/Moq.Tests/ItIsAnyTypeFixture.cs
@@ -55,6 +55,19 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public void Setup_with_It_IsAnyType_and_Callback()
+		{
+			object received = null;
+			var mock = new Mock<IY>();
+			mock.Setup(m => m.Method<It.IsAnyType>((It.IsAnyType)It.IsAny<object>()))
+				.Callback((object arg) => received = arg);
+
+			_ = mock.Object.Method<int>(42);
+
+			Assert.Equal(42, received);
+		}
+
+		[Fact]
 		public void Setup_with_It_IsAnyType_and_Returns()
 		{
 			var mock = new Mock<IY>();

--- a/tests/Moq.Tests/ItIsAnyTypeFixture.cs
+++ b/tests/Moq.Tests/ItIsAnyTypeFixture.cs
@@ -126,6 +126,38 @@ namespace Moq.Tests
 			Assert.Equal(default(DateTime), result);
 		}
 
+		[Fact]
+		public void Setup_with_It_IsAny_It_IsAnyType()
+		{
+			object received = null;
+			var mock = new Mock<IY>();
+			mock.Setup(m => m.Method(It.IsAny<It.IsAnyType>()))
+			    .Callback((object arg) => received = arg);
+
+			_ = mock.Object.Method<int>(42);
+			Assert.Equal(42, received);
+
+			_ = mock.Object.Method<string>("42");
+			Assert.Equal("42", received);
+		}
+
+		[Fact]
+		public void Setup_with_It_Ref_It_IsAnyType_IsAny()
+		{
+			object received = null;
+			var mock = new Mock<IY>();
+			mock.Setup(m => m.ByRefMethod(ref It.Ref<It.IsAnyType>.IsAny))
+			    .Callback(new ByRefMethodCallback<object>((ref object arg) => received = arg));
+
+			var i = 42;
+			_ = mock.Object.ByRefMethod<int>(ref i);
+			Assert.Equal(42, received);
+
+			var s = "42";
+			_ = mock.Object.ByRefMethod<string>(ref s);
+			Assert.Equal("42", received);
+		}
+
 		public interface IX
 		{
 			void Method<T>();
@@ -134,7 +166,10 @@ namespace Moq.Tests
 		public interface IY
 		{
 			T Method<T>(T arg);
+			T ByRefMethod<T>(ref T arg);
 		}
+
+		public delegate void ByRefMethodCallback<T>(ref T arg);
 
 		public interface IZ
 		{

--- a/tests/Moq.Tests/ItIsAnyTypeFixture.cs
+++ b/tests/Moq.Tests/ItIsAnyTypeFixture.cs
@@ -65,6 +65,23 @@ namespace Moq.Tests
 			Assert.Equal("42", mock.Object.Method<string>("42"));
 		}
 
+		[Fact]
+		public void Setup_with_It_IsAnyType_default_return_value()
+		{
+			var mock = new Mock<IY>() { DefaultValue = DefaultValue.Empty };
+			mock.Setup(m => m.Method<It.IsAnyType>((It.IsAnyType)It.IsAny<object>()));
+
+			var result = mock.Object.Method<int[]>(null);
+
+			// Let's make sure that default value providers don't suddenly start producing `It.IsAnyType` instances:
+			Assert.IsNotType<It.IsAnyType>(result);
+
+			// Rather, we expect the usual behavior:
+			Assert.NotNull(result);
+			Assert.IsType<int[]>(result);
+			Assert.Empty((int[])result);
+		}
+
 		public interface IX
 		{
 			void Method<T>();

--- a/tests/Moq.Tests/MatcherObserverFixture.cs
+++ b/tests/Moq.Tests/MatcherObserverFixture.cs
@@ -131,7 +131,7 @@ namespace Moq.Tests
 				_ = It.IsRegex(".*");
 
 				Assert.True(observer.TryGetLastMatch(out var last));
-				Assert.True(last.Matches("abc"));
+				Assert.True(last.Matches("abc", typeof(string)));
 			}
 		}
 

--- a/tests/Moq.Tests/Matchers/AnyMatcherFixture.cs
+++ b/tests/Moq.Tests/Matchers/AnyMatcherFixture.cs
@@ -17,7 +17,7 @@ namespace Moq.Tests.Matchers
 
 			var (matcher, _) = MatcherFactory.CreateMatcher(expr);
 
-			Assert.True(matcher.Matches(null));
+			Assert.True(matcher.Matches(null, typeof(object)));
 		}
 
 		[Fact]
@@ -27,7 +27,7 @@ namespace Moq.Tests.Matchers
 
 			var (matcher, _) = MatcherFactory.CreateMatcher(expr);
 
-			Assert.True(matcher.Matches("foo"));
+			Assert.True(matcher.Matches("foo", typeof(object)));
 		}
 
 		[Fact]
@@ -37,7 +37,7 @@ namespace Moq.Tests.Matchers
 
 			var (matcher, _) = MatcherFactory.CreateMatcher(expr);
 
-			Assert.True(matcher.Matches(new Disposable()));
+			Assert.True(matcher.Matches(new Disposable(), typeof(IDisposable)));
 		}
 
 		[Fact]
@@ -47,7 +47,7 @@ namespace Moq.Tests.Matchers
 
 			var (matcher, _) = MatcherFactory.CreateMatcher(expr);
 
-			Assert.False(matcher.Matches("foo"));
+			Assert.False(matcher.Matches("foo", typeof(IFormatProvider)));
 		}
 
 		private LambdaExpression ToExpression<TResult>(Expression<Func<TResult>> expr)

--- a/tests/Moq.Tests/Matchers/ParamArrayMatcherFixture.cs
+++ b/tests/Moq.Tests/Matchers/ParamArrayMatcherFixture.cs
@@ -25,7 +25,7 @@ namespace Moq.Tests.Matchers
 
 			var (matcher, _) = MatcherFactory.CreateMatcher(expr, parameter);
 
-			Assert.Equal(shouldMatch, matcher.Matches(new object[] { first, second }));
+			Assert.Equal(shouldMatch, matcher.Matches(new object[] { first, second }, typeof(object[])));
 		}
 
 		[Fact]
@@ -38,7 +38,7 @@ namespace Moq.Tests.Matchers
 
 			var (matcher, _) = MatcherFactory.CreateMatcher(expr, parameter);
 
-			matcher.SetupEvaluatedSuccessfully(new object[] { 42, "" });
+			matcher.SetupEvaluatedSuccessfully(new object[] { 42, "" }, typeof(object[]));
 		}
 
 		private LambdaExpression ToExpression<T>(Expression<Action<T>> expr)

--- a/tests/Moq.Tests/MatchersFixture.cs
+++ b/tests/Moq.Tests/MatchersFixture.cs
@@ -263,8 +263,8 @@ namespace Moq.Tests
 			var b = new object();
 
 			var matcher = new RefMatcher(a);
-			Assert.True(matcher.Matches(a));
-			Assert.False(matcher.Matches(b));
+			Assert.True(matcher.Matches(a, typeof(object)));
+			Assert.False(matcher.Matches(b, typeof(object)));
 		}
 
 		[Fact]

--- a/tests/Moq.Tests/Moq.Tests.csproj
+++ b/tests/Moq.Tests/Moq.Tests.csproj
@@ -10,7 +10,7 @@
 		<DebugSymbols>True</DebugSymbols>
 		<DebugType>portable</DebugType>
 		<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-		<LangVersion>7.2</LangVersion>
+		<LangVersion>7.3</LangVersion>
 		<IsPackable>False</IsPackable>
 	</PropertyGroup>
 


### PR DESCRIPTION
These commits add support for generic type argument matching. 😎

For starters, the only built-in type matcher is `It.IsAnyType`:

```csharp
mock.Setup(m => m.Method<It.IsAnyType>(...))...
```

### Creating a custom type matcher:

The type matcher infrastructure is designed to be fully extensible:

```csharp
class Exceptions : ITypeMatcher
{
    public bool Matches(Type typeArgument) => typeof(Exception).IsAssignableFrom(typeArgument);
}

handler.Setup(h => h.Handle<Exceptions>())
       .Callback(() => Console.WriteLine("Handled an exception.");
```

This allows matchers to satisfy generic type contraints:

```csharp
public interface IJuggler
{
    void Juggle<TBall>() where TBall : Ball
}

class AnyBall : Ball, ITypeMatcher
{
    public bool Matches(Type typeArgument) => true;
}

new Mock<IJuggler>().Setup(j => j.Juggle<AnyBall>())...;
```

When the type is constrained to something that won't allow you to implement `ITypeMatcher`, there's `[TypeMatcher]`:

```csharp
public interface IRedirector
{
    void Redirect<TDelegate>(TDelegate handler) where TDelegate : Delegate;
}

[TypeMatcher(typeof(It.IsAnyType))]
public delegate void AnyDelegate();

var redirector = new Mock<IRedirector>();
redirector.Setup(r => r.Redirect<AnyDelegate>(...)))...
```

### Accessing the type arguments in `Callback` and `Returns`:

(@michal-ciechan, this one is for you: You requested that some "invocation context" be injected into `Callback` and `Returns` callbacks, it turns out Moq already has a suitable type for that: `IInvocation`.)

In order for `Callback` and `Returns` to be able to know which type arguments were used, there are two new overloads that accept a `InvocationAction` and `InvocationFunc`, respectively:

```csharp
public interface IFactory
{
    T Create<T>();
}

var factory = new Mock<IFactory>();
factory.Setup(f => f.Create<It.IsAnyType>())
       .Returns(new InvocationFunc(invocation =>
                {
                    var type = invocation.Method.GetGenericTypeArguments()[0];
                    return Activator.CreateInstance(type);
                });

var something = factory.Object.Create<Something>();
```

These two types are designed as delegate type look-alikes, however they aren't actually delegates. This was necessary to prevent the C# compiler from starting to pick the wrong `Callback` and `Returns` overloads in everyday use cases.

### Matching arguments of a generic type:</summary>

```csharp
interface IFrobbler
{
    void Frobble<T>(T arg);
}

var frobbler = new Mock<IFrobbler>();
frobbler.Setup(f => f.Frobble(It.IsAny<It.IsAnyType>()))
        .Callback((object arg) => ...);
```

### Things left to do:

* [X] Add support for `It.IsAny<It.IsAnyType>`. Or, more generally speaking: `It.IsAny<TTypeMatcher>`, `It.IsNotNull<TTypeMatcher>`, etc.

* [X] If some or all of the above is implemented, add tests for the `Capture` code paths. (More specifically, I am worrying about the type conversions `(T)` hidden inside the `Match` class. Those will generally fail when `T` is a type matcher.)

   **Update:** This is only partially fulfilled. While `Capture.*` shouldn't throw, `CaptureMatch<T>` won't work just yet. This is left as a TODO for another time.

* [ ] ~~Add support for composite types making use of type matchers, e.g. `It.IsAnyType?`, `It.IsAnyType[]`, `It.IsAnyType[,]`, `IEnumerable<It.IsAnyType>`, `ref`/`in`/`out It.IsAnyType`, etc. Same for custom matcher types. It's possible that this cannot be made to work with custom argument matchers.~~

   **Update:** While that would be great, it would also negatively affect performance as every type parameter would have to be decomposed just to discover whether it includes a type matcher. For now, we're going the opposite direction and try to make type matcher discovery as fast as possible.

Closes #343.

/cc @michal-ciechan, @oddbear, @kzu