### PR TITLE
Improve precision of event accessor method resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 * `Verify` throws `TargetInvocationException` instead of `MockException` when one of the recorded invocations was to an async method that threw. (@Cufeadir, #883)
 
+* Moq does not distinguish between distinct events if they have the same name (@stakx, #893)
+
 * Regression in 4.12.0: `SetupAllProperties` removes indexer setups. (@stakx, #901)
 
 * Parameter types are ignored when matching an invoked generic method against setups. (@stakx, #903)

--- a/src/Moq/EventHandlerCollection.cs
+++ b/src/Moq/EventHandlerCollection.cs
@@ -3,23 +3,24 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Moq
 {
 	internal sealed class EventHandlerCollection
 	{
-		private readonly Dictionary<string, Delegate> eventHandlers;
+		private readonly Dictionary<EventInfo, Delegate> eventHandlers;
 
 		public EventHandlerCollection()
 		{
-			this.eventHandlers = new Dictionary<string, Delegate>();
+			this.eventHandlers = new Dictionary<EventInfo, Delegate>();
 		}
 
-		public void Add(string eventName, Delegate eventHandler)
+		public void Add(EventInfo @event, Delegate eventHandler)
 		{
 			lock (this.eventHandlers)
 			{
-				this.eventHandlers[eventName] = Delegate.Combine(this.TryGet(eventName), eventHandler);
+				this.eventHandlers[@event] = Delegate.Combine(this.TryGet(@event), eventHandler);
 			}
 		}
 
@@ -31,25 +32,25 @@ namespace Moq
 			}
 		}
 
-		public void Remove(string eventName, Delegate eventHandler)
+		public void Remove(EventInfo @event, Delegate eventHandler)
 		{
 			lock (this.eventHandlers)
 			{
-				this.eventHandlers[eventName] = Delegate.Remove(this.TryGet(eventName), eventHandler);
+				this.eventHandlers[@event] = Delegate.Remove(this.TryGet(@event), eventHandler);
 			}
 		}
 
-		public bool TryGet(string eventName, out Delegate handlers)
+		public bool TryGet(EventInfo @event, out Delegate handlers)
 		{
 			lock (this.eventHandlers)
 			{
-				return this.eventHandlers.TryGetValue(eventName, out handlers) && handlers != null;
+				return this.eventHandlers.TryGetValue(@event, out handlers) && handlers != null;
 			}
 		}
 
-		private Delegate TryGet(string eventName)
+		private Delegate TryGet(EventInfo @event)
 		{
-			return this.eventHandlers.TryGetValue(eventName, out var handlers) ? handlers : null;
+			return this.eventHandlers.TryGetValue(@event, out var handlers) ? handlers : null;
 		}
 	}
 }

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2923,6 +2923,30 @@ namespace Moq.Tests.Regressions
 				Assert.Equal(1, beRaiseCount);
 			}
 
+			[Fact]
+			public void Method_resolution__Subscribe_to_class_event__Raise_interface_event__succeeds()
+			{
+				var raised = false;
+				var mock = new Mock<A>();
+				mock.Object.E += () => raised = true;
+
+				mock.As<IA>().Raise(m => m.E += null);
+
+				Assert.True(raised);
+			}
+
+			[Fact]
+			public void Method_resolution__Subscribe_to_interface_event__Raise_class_event__succeeds()
+			{
+				var raised = false;
+				var mock = new Mock<A>();
+				(mock.Object as IA).E += () => raised = true;
+
+				mock.Raise(m => m.E += null);
+
+				Assert.True(raised);
+			}
+
 			public interface IA
 			{
 				event Action E;
@@ -2931,6 +2955,11 @@ namespace Moq.Tests.Regressions
 			public interface IB
 			{
 				event Action E;
+			}
+
+			public class A : IA
+			{
+				public virtual event Action E;
 			}
 
 			public class AB : IA, IB

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -2875,6 +2875,89 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 893
+
+		public class Issue893
+		{
+			[Fact]
+			public void Csharp_can_distinguish_between_two_events_having_same_name()
+			{
+				var ab = new AB();
+				var a = (IA)ab;
+				var b = (IB)ab;
+
+				var aeRaiseCount = 0;
+				a.E += () => aeRaiseCount++;
+
+				var beRaiseCount = 0;
+				b.E += () => beRaiseCount++;
+
+				ab.RaiseAE();
+				Assert.Equal(1, aeRaiseCount);
+				Assert.Equal(0, beRaiseCount);
+
+				ab.RaiseBE();
+				Assert.Equal(1, aeRaiseCount);
+				Assert.Equal(1, beRaiseCount);
+			}
+
+			[Fact]
+			public void Moq_can_distinguish_between_two_events_having_same_name()
+			{
+				var ab = new Mock<object>();
+				var a = ab.As<IA>();
+				var b = ab.As<IB>();
+
+				var aeRaiseCount = 0;
+				(a.Object).E += () => aeRaiseCount++;
+
+				var beRaiseCount = 0;
+				(b.Object).E += () => beRaiseCount++;
+
+				a.Raise(m => m.E += null);
+				Assert.Equal(1, aeRaiseCount);
+				Assert.Equal(0, beRaiseCount);
+
+				b.Raise(m => m.E += null);
+				Assert.Equal(1, aeRaiseCount);
+				Assert.Equal(1, beRaiseCount);
+			}
+
+			public interface IA
+			{
+				event Action E;
+			}
+
+			public interface IB
+			{
+				event Action E;
+			}
+
+			public class AB : IA, IB
+			{
+				private Action ae;
+				private Action be;
+
+				event Action IA.E
+				{
+					add => this.ae = (Action)Delegate.Combine(this.ae, value);
+					remove => this.ae = (Action)Delegate.Combine(this.ae, value);
+				}
+
+				event Action IB.E
+				{
+					add => this.be = (Action)Delegate.Combine(this.be, value);
+					remove => this.be = (Action)Delegate.Combine(this.be, value);
+				}
+
+				public void RaiseAE() => this.ae?.Invoke();
+
+				public void RaiseBE() => this.be?.Invoke();
+			}
+		}
+
+		#endregion
+
 		#region 897
 
 		public class Issue897


### PR DESCRIPTION
With this PR, Moq starts identifying events by their full `EventInfo` instead of just by their name.

This was originally planned for version 4.13.1, but since we're adding functionality to setup & verify event subscription / unsubscription in 4.13.0, it will become possible (and more likely) that users work with events more often. Therefore event identification should be reasonably accurate, or we'll just receive unnecessary bug reports.

Fixes #893.