### PR TITLE
Add special handling for `.ReturnsAsync(null)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 * Parameter types are ignored when matching an invoked generic method against setups. (@stakx, #903)
 
+* For `[Value]Task<object>`, `.ReturnsAsync(null)` throws `NullReferenceException` instead of producing a completed task with result `null` (@voroninp, #909)
 
 ## 4.12.0 (2019-06-20)
 

--- a/src/Moq/ReturnsExtensions.Generated.cs
+++ b/src/Moq/ReturnsExtensions.Generated.cs
@@ -26,6 +26,11 @@ namespace Moq
 		/// <param name="valueFunction">The function that will calculate the return value.</param>
 		public static IReturnsResult<TMock> ReturnsAsync<T, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T, TResult> valueFunction) where TMock : class
 		{
+			if (ReturnsExtensions.IsNullResult(valueFunction, typeof(TResult)))
+			{
+				return mock.ReturnsAsync(() => default);
+			}
+
 			return mock.Returns((T t) => Task.FromResult(valueFunction(t)));
 		}	
 		 
@@ -36,6 +41,11 @@ namespace Moq
 		/// <param name="valueFunction">The function that will calculate the return value.</param>
 		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, TResult> valueFunction) where TMock : class
 		{
+			if (ReturnsExtensions.IsNullResult(valueFunction, typeof(TResult)))
+			{
+				return mock.ReturnsAsync(() => default);
+			}
+
 			return mock.Returns((T1 t1, T2 t2) => Task.FromResult(valueFunction(t1, t2)));
 		}
  
@@ -46,6 +56,11 @@ namespace Moq
 		/// <param name="valueFunction">The function that will calculate the return value.</param>
 		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, TResult> valueFunction) where TMock : class
 		{
+			if (ReturnsExtensions.IsNullResult(valueFunction, typeof(TResult)))
+			{
+				return mock.ReturnsAsync(() => default);
+			}
+
 			return mock.Returns((T1 t1, T2 t2, T3 t3) => Task.FromResult(valueFunction(t1, t2, t3)));
 		}
  
@@ -56,6 +71,11 @@ namespace Moq
 		/// <param name="valueFunction">The function that will calculate the return value.</param>
 		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, TResult> valueFunction) where TMock : class
 		{
+			if (ReturnsExtensions.IsNullResult(valueFunction, typeof(TResult)))
+			{
+				return mock.ReturnsAsync(() => default);
+			}
+
 			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4) => Task.FromResult(valueFunction(t1, t2, t3, t4)));
 		}
  
@@ -66,6 +86,11 @@ namespace Moq
 		/// <param name="valueFunction">The function that will calculate the return value.</param>
 		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, TResult> valueFunction) where TMock : class
 		{
+			if (ReturnsExtensions.IsNullResult(valueFunction, typeof(TResult)))
+			{
+				return mock.ReturnsAsync(() => default);
+			}
+
 			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5)));
 		}
  
@@ -76,6 +101,11 @@ namespace Moq
 		/// <param name="valueFunction">The function that will calculate the return value.</param>
 		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, TResult> valueFunction) where TMock : class
 		{
+			if (ReturnsExtensions.IsNullResult(valueFunction, typeof(TResult)))
+			{
+				return mock.ReturnsAsync(() => default);
+			}
+
 			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6)));
 		}
  
@@ -86,6 +116,11 @@ namespace Moq
 		/// <param name="valueFunction">The function that will calculate the return value.</param>
 		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, TResult> valueFunction) where TMock : class
 		{
+			if (ReturnsExtensions.IsNullResult(valueFunction, typeof(TResult)))
+			{
+				return mock.ReturnsAsync(() => default);
+			}
+
 			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7)));
 		}
  
@@ -96,6 +131,11 @@ namespace Moq
 		/// <param name="valueFunction">The function that will calculate the return value.</param>
 		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, TResult> valueFunction) where TMock : class
 		{
+			if (ReturnsExtensions.IsNullResult(valueFunction, typeof(TResult)))
+			{
+				return mock.ReturnsAsync(() => default);
+			}
+
 			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8)));
 		}
  
@@ -106,6 +146,11 @@ namespace Moq
 		/// <param name="valueFunction">The function that will calculate the return value.</param>
 		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TResult> valueFunction) where TMock : class
 		{
+			if (ReturnsExtensions.IsNullResult(valueFunction, typeof(TResult)))
+			{
+				return mock.ReturnsAsync(() => default);
+			}
+
 			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9)));
 		}
  
@@ -116,6 +161,11 @@ namespace Moq
 		/// <param name="valueFunction">The function that will calculate the return value.</param>
 		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TResult> valueFunction) where TMock : class
 		{
+			if (ReturnsExtensions.IsNullResult(valueFunction, typeof(TResult)))
+			{
+				return mock.ReturnsAsync(() => default);
+			}
+
 			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10)));
 		}
  
@@ -126,6 +176,11 @@ namespace Moq
 		/// <param name="valueFunction">The function that will calculate the return value.</param>
 		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TResult> valueFunction) where TMock : class
 		{
+			if (ReturnsExtensions.IsNullResult(valueFunction, typeof(TResult)))
+			{
+				return mock.ReturnsAsync(() => default);
+			}
+
 			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11)));
 		}
  
@@ -136,6 +191,11 @@ namespace Moq
 		/// <param name="valueFunction">The function that will calculate the return value.</param>
 		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TResult> valueFunction) where TMock : class
 		{
+			if (ReturnsExtensions.IsNullResult(valueFunction, typeof(TResult)))
+			{
+				return mock.ReturnsAsync(() => default);
+			}
+
 			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12)));
 		}
  
@@ -146,6 +206,11 @@ namespace Moq
 		/// <param name="valueFunction">The function that will calculate the return value.</param>
 		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TResult> valueFunction) where TMock : class
 		{
+			if (ReturnsExtensions.IsNullResult(valueFunction, typeof(TResult)))
+			{
+				return mock.ReturnsAsync(() => default);
+			}
+
 			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13)));
 		}
  
@@ -156,6 +221,11 @@ namespace Moq
 		/// <param name="valueFunction">The function that will calculate the return value.</param>
 		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TResult> valueFunction) where TMock : class
 		{
+			if (ReturnsExtensions.IsNullResult(valueFunction, typeof(TResult)))
+			{
+				return mock.ReturnsAsync(() => default);
+			}
+
 			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14)));
 		}
  
@@ -166,6 +236,11 @@ namespace Moq
 		/// <param name="valueFunction">The function that will calculate the return value.</param>
 		public static IReturnsResult<TMock> ReturnsAsync<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TResult> valueFunction) where TMock : class
 		{
+			if (ReturnsExtensions.IsNullResult(valueFunction, typeof(TResult)))
+			{
+				return mock.ReturnsAsync(() => default);
+			}
+
 			return mock.Returns((T1 t1, T2 t2, T3 t3, T4 t4, T5 t5, T6 t6, T7 t7, T8 t8, T9 t9, T10 t10, T11 t11, T12 t12, T13 t13, T14 t14, T15 t15) => Task.FromResult(valueFunction(t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15)));
 		}
 

--- a/src/Moq/ReturnsExtensions.cs
+++ b/src/Moq/ReturnsExtensions.cs
@@ -49,6 +49,11 @@ namespace Moq
 		/// <param name="valueFunction">The function that will calculate the return value.</param>
 		public static IReturnsResult<TMock> ReturnsAsync<TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<TResult> valueFunction) where TMock : class
 		{
+			if (IsNullResult(valueFunction, typeof(TResult)))
+			{
+				return mock.ReturnsAsync(() => default);
+			}
+
 			return mock.Returns(() => Task.FromResult(valueFunction()));
 		}
 
@@ -61,6 +66,11 @@ namespace Moq
 		/// <param name="valueFunction">The function that will calculate the return value.</param>
 		public static IReturnsResult<TMock> ReturnsAsync<TMock, TResult>(this IReturns<TMock, ValueTask<TResult>> mock, Func<TResult> valueFunction) where TMock : class
 		{
+			if (IsNullResult(valueFunction, typeof(TResult)))
+			{
+				return mock.ReturnsAsync(() => default);
+			}
+
 			return mock.Returns(() => new ValueTask<TResult>(valueFunction()));
 		}
 
@@ -254,6 +264,18 @@ namespace Moq
 			var delay = GetDelay(minDelay, maxDelay, random);
 
 			return DelayedException(mock, exception, delay);
+		}
+
+		internal static bool IsNullResult(Delegate valueFunction, Type resultType)
+		{
+			if (valueFunction == null)
+			{
+				return !resultType.IsValueType || Nullable.GetUnderlyingType(resultType) != null;
+			}
+			else
+			{
+				return false;
+			}
 		}
 
 		private static TimeSpan GetDelay(TimeSpan minDelay, TimeSpan maxDelay, Random random)

--- a/src/Moq/ReturnsExtensions.tt
+++ b/src/Moq/ReturnsExtensions.tt
@@ -30,6 +30,11 @@ namespace Moq
 		/// <param name="valueFunction">The function that will calculate the return value.</param>
 		public static IReturnsResult<TMock> ReturnsAsync<T, TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<T, TResult> valueFunction) where TMock : class
 		{
+			if (ReturnsExtensions.IsNullResult(valueFunction, typeof(TResult)))
+			{
+				return mock.ReturnsAsync(() => default);
+			}
+
 			return mock.Returns((T t) => Task.FromResult(valueFunction(t)));
 		}	
 		<# 
@@ -50,6 +55,11 @@ namespace Moq
 				#>T<#=i#>, <#
 			}#>TResult> valueFunction) where TMock : class
 		{
+			if (ReturnsExtensions.IsNullResult(valueFunction, typeof(TResult)))
+			{
+				return mock.ReturnsAsync(() => default);
+			}
+
 			return mock.Returns((<#
 			for (var i = 1; i <= argumentCount; ++i)
 			{ #>T<#=i#> t<#=i#><#

--- a/tests/Moq.Tests/ReturnsExtensionsFixture.cs
+++ b/tests/Moq.Tests/ReturnsExtensionsFixture.cs
@@ -27,6 +27,12 @@ namespace Moq.Tests
 			Task<int> ValueParameterValueReturnType(int value);
 
 			Task<Guid> NewGuidAsync();
+
+			Task<object> NoParametersObjectReturnType();
+
+			Task<object> OneParameterObjectReturnType(string value);
+
+			Task<object> ManyParametersObjectReturnType(string arg1, bool arg2, float arg3);
 		}
 
 		public interface IValueTaskAsyncInterface
@@ -44,6 +50,12 @@ namespace Moq.Tests
 			ValueTask<int> ValueParameterValueReturnType(int value);
 
 			ValueTask<Guid> NewGuidAsync();
+
+			ValueTask<object> NoParametersObjectReturnType();
+
+			ValueTask<object> OneParameterObjectReturnType(string value);
+
+			ValueTask<object> ManyParametersObjectReturnType(string arg1, bool arg2, float arg3);
 		}
 
 		[Fact]
@@ -896,6 +908,72 @@ namespace Moq.Tests
 
 			var paramName = Assert.Throws<ArgumentNullException>(setup).ParamName;
 			Assert.Equal("random", paramName);
+		}
+
+		[Fact]
+		public async void No_parameters_object_return_type__ReturnsAsync_null__returns_completed_Task_with_null_result()
+		{
+			var mock = new Mock<IAsyncInterface>();
+			mock.Setup(m => m.NoParametersObjectReturnType()).ReturnsAsync(null);
+
+			var result = await mock.Object.NoParametersObjectReturnType();
+
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public async void One_parameter_object_return_type__ReturnsAsync_null__returns_completed_Task_with_null_result()
+		{
+			var mock = new Mock<IAsyncInterface>();
+			mock.Setup(m => m.OneParameterObjectReturnType("")).ReturnsAsync(null);
+
+			var result = await mock.Object.OneParameterObjectReturnType("");
+
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public async void Many_parameters_object_return_type__ReturnsAsync_null__returns_completed_Task_with_null_result()
+		{
+			var mock = new Mock<IAsyncInterface>();
+			mock.Setup(m => m.ManyParametersObjectReturnType("", false, 0f)).ReturnsAsync(null);
+
+			var result = await mock.Object.ManyParametersObjectReturnType("", false, 0f);
+
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public async void No_parameters_object_return_type__ReturnsAsync_null__returns_completed_ValueTask_with_null_result()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			mock.Setup(m => m.NoParametersObjectReturnType()).ReturnsAsync(null);
+
+			var result = await mock.Object.NoParametersObjectReturnType();
+
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public async void One_parameter_object_return_type__ReturnsAsync_null__returns_completed_ValueTask_with_null_result()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			mock.Setup(m => m.OneParameterObjectReturnType("")).ReturnsAsync(null);
+
+			var result = await mock.Object.OneParameterObjectReturnType("");
+
+			Assert.Null(result);
+		}
+
+		[Fact]
+		public async void Many_parameters_object_return_type__ReturnsAsync_null__returns_completed_ValueTask_with_null_result()
+		{
+			var mock = new Mock<IValueTaskAsyncInterface>();
+			mock.Setup(m => m.ManyParametersObjectReturnType("", false, 0f)).ReturnsAsync(null);
+
+			var result = await mock.Object.ManyParametersObjectReturnType("", false, 0f);
+
+			Assert.Null(result);
 		}
 	}
 }


### PR DESCRIPTION
... so `null` is treated as the intended result, not as a lambda function null reference.

Resolves #909.