### PR TITLE
AmbiguousMatchException when setting up the property, that hides another one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+#### Fixed
+
+* AmbiguousMatchException when setting up the property, that hides another one (@ishatalkin, #939)
 
 ## 4.13.0 (2019-08-31)
 

--- a/src/Moq/ExpressionExtensions.cs
+++ b/src/Moq/ExpressionExtensions.cs
@@ -321,8 +321,9 @@ namespace Moq
 			if (property.DeclaringType != expression.Expression.Type)
 			{
 				var derivedProperty = expression.Expression.Type
-					.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-					.SingleOrDefault(p => p.Name == property.Name && p.PropertyType == property.PropertyType);
+					.GetMember(property.Name, MemberTypes.Property, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+					.Cast<PropertyInfo>()
+					.SingleOrDefault(p => p.PropertyType == property.PropertyType);
 				if (derivedProperty != null && derivedProperty.GetMethod.GetBaseDefinition() == property.GetMethod)
 				{
 					return derivedProperty;

--- a/src/Moq/ExpressionExtensions.cs
+++ b/src/Moq/ExpressionExtensions.cs
@@ -320,7 +320,9 @@ namespace Moq
 			// we "upgrade" to the derived property.
 			if (property.DeclaringType != expression.Expression.Type)
 			{
-				var derivedProperty = expression.Expression.Type.GetProperty(property.Name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+				var derivedProperty = expression.Expression.Type
+					.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+					.SingleOrDefault(p => p.Name == property.Name && p.PropertyType == property.PropertyType);
 				if (derivedProperty != null && derivedProperty.GetMethod.GetBaseDefinition() == property.GetMethod)
 				{
 					return derivedProperty;

--- a/tests/Moq.Tests/HidePropertyFixture.cs
+++ b/tests/Moq.Tests/HidePropertyFixture.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using Xunit;
+
+namespace Moq.Tests
+{
+	public class HidePropertyFixture
+	{
+		public class A
+		{
+			public string Prop { get; }
+		}
+
+		public class B : A
+		{
+			public new virtual int Prop { get; }
+		}
+
+		public class C : B
+		{
+
+		}
+
+		[Fact]
+		public void SetupsDerivedProperty()
+		{
+			var mock = new Mock<C>();
+			var value = 5;
+
+			mock.Setup(m => m.Prop).Returns(value);
+
+			Assert.Equal(value, mock.Object.Prop);
+		}
+	}
+}

--- a/tests/Moq.Tests/HidePropertyFixture.cs
+++ b/tests/Moq.Tests/HidePropertyFixture.cs
@@ -19,7 +19,6 @@ namespace Moq.Tests
 
 		public class C : B
 		{
-
 		}
 
 		[Fact]


### PR DESCRIPTION
mock.Setup(m => m.Prop) throws AmbiguousMatchException in case that:
* Prop hides the property with *new* keyword;
* the hidden and the derived properties have different types;
* mocked object has the child class of the class, where the property was hidden.

You can repropduce the exception with the following code:

	public class HidePropertyFixture
	{
		public class A
		{
			public string Prop { get; }
		}

		public class B : A
		{
			// consider new keyword and the different type of property
			public new virtual int Prop { get; }
		}

		public class C : B
		{

		}

		[Fact]
		public void SetupsDerivedProperty()
		{
			// create the mock of C; mock of B works correct
			var mock = new Mock<C>();
			// the next line will throw AmbiguousMatchException 
			mock.Setup(m => m.Prop);
		}
	}

Stacktrace:

    System.Reflection.AmbiguousMatchException
       в System.RuntimeType.GetPropertyImpl(String name, BindingFlags bindingAttr, Binder binder, Type returnType, Type[] types, ParameterModifier[] modifiers)
       в System.Type.GetProperty(String name, BindingFlags bindingAttr)
       в Moq.ExpressionExtensions.GetReboundProperty(MemberExpression expression) в C:\Projects\github_moq\src\Moq\ExpressionExtensions.cs:строка 323
       в Moq.ExpressionExtensions.<Split>g__Split|4_1(Expression e, Expression& r, InvocationShape& p) в C:\Projects\github_moq\src\Moq\ExpressionExtensions.cs:строка 286
       в Moq.ExpressionExtensions.Split(LambdaExpression expression) в C:\Projects\github_moq\src\Moq\ExpressionExtensions.cs:строка 107
       в Moq.Mock.SetupRecursive[TSetup](Mock mock, LambdaExpression expression, Func`3 setupLast) в C:\Projects\github_moq\src\Moq\Mock.cs:строка 590
       в Moq.Mock.Setup(Mock mock, LambdaExpression expression, Condition condition) в C:\Projects\github_moq\src\Moq\Mock.cs:строка 527
       в Moq.Mock`1.Setup[TResult](Expression`1 expression) в C:\Projects\github_moq\src\Moq\Mock.Generic.cs:строка 407

Here is pull request that fixes the bug.

This bug is somewhat similar with #930, but here is the problem of Moq.