### PR TITLE
Naive first attempt to fix #946.

### DIFF
--- a/src/Moq/ExpressionComparer.cs
+++ b/src/Moq/ExpressionComparer.cs
@@ -143,6 +143,17 @@ namespace Moq
 
 		private static bool EqualsConstant(ConstantExpression x, ConstantExpression y)
 		{
+			if (x.Value is Array array1 && y.Value is Array array2 && array1.Length == array2.Length)
+			{
+				for (var index = 0; index < array1.Length; index++)
+				{
+					if (!object.Equals(array1.GetValue(index), array2.GetValue(index)))
+						return false;
+				}
+
+				return true;
+			}
+
 			return object.Equals(x.Value, y.Value);
 		}
 

--- a/tests/Moq.Tests/RecursiveMocksFixture.cs
+++ b/tests/Moq.Tests/RecursiveMocksFixture.cs
@@ -315,6 +315,19 @@ namespace Moq.Tests
 			Assert.Equal(5, fooMock.Object.Bar.GetBaz("foo").Value);
 		}
 
+		[Fact]
+		public void ParamsAreMatchedInSecondSetup()
+		{
+			string expected = "1";
+
+			var target = new Mock<IFoo>();
+			target.Setup(x => x.Params(1).Do("1")).Returns("1");
+			target.Setup(x => x.Params(1).Do("2")).Returns("2");
+
+			string ret = target.Object.Params(1).Do("1");
+			Assert.Equal(expected, ret);
+		}
+
 		public class Verify_can_tell_apart_different_arguments_in_intermediate_part_of_fluent_expressions
 		{
 			[Fact]
@@ -417,6 +430,7 @@ namespace Moq.Tests
 		{
 			public IBar BarField;
 			public IBar Bar { get; set; }
+			public IBar Params(params int[] ints){ return null; }
 			public IBar GetBar() { return null; }
 			public IBar this[int index] { get { return null; } set { } }
 
@@ -431,6 +445,7 @@ namespace Moq.Tests
 			IBar Bar { get; set; }
 			IBar this[int index] { get; set; }
 			string Do(string command);
+			IBar Params(params int[] ints);
 			IBar GetBar();
 		}
 


### PR DESCRIPTION
Compares arrays to match a previous recursive mock setup where params have been used.

Fixes #946.