### PR TITLE
Get `Capture.In` working again in `Verify` expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
  * New `.Protected().Setup` and `Protected().Verify` method overloads to deal with generic methods (@JmlSaul, #967)
 
+#### Fixed
+
+ * Regression: Restored `Capture.In` use in `mock.Verify(expression, ...)` to extract arguments of previously recorded invocations. (@vgriph, #968; @stakx, #974)
+
+
 ## 4.13.1 (2019-10-19)
 
 #### Fixed

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -349,8 +349,9 @@ namespace Moq
 
 			if (times.Verify(invocationCount))
 			{
-				foreach (var invocation in invocationsToBeMarkedAsVerified)
+				foreach (var (invocation, part) in invocationsToBeMarkedAsVerified)
 				{
+					part.SetupEvaluatedSuccessfully(invocation);
 					invocation.MarkAsVerified();
 				}
 			}
@@ -452,12 +453,12 @@ namespace Moq
 		private static int GetMatchingInvocationCount(
 			Mock mock,
 			LambdaExpression expression,
-			out List<Invocation> invocationsToBeMarkedAsVerified)
+			out List<Pair<Invocation, InvocationShape>> invocationsToBeMarkedAsVerified)
 		{
 			Debug.Assert(mock != null);
 			Debug.Assert(expression != null);
 
-			invocationsToBeMarkedAsVerified = new List<Invocation>();
+			invocationsToBeMarkedAsVerified = new List<Pair<Invocation, InvocationShape>>();
 			return Mock.GetMatchingInvocationCount(
 				mock,
 				new ImmutablePopOnlyStack<InvocationShape>(expression.Split()),
@@ -469,7 +470,7 @@ namespace Moq
 			Mock mock,
 			in ImmutablePopOnlyStack<InvocationShape> parts,
 			HashSet<Mock> visitedInnerMocks,
-			List<Invocation> invocationsToBeMarkedAsVerified)
+			List<Pair<Invocation, InvocationShape>> invocationsToBeMarkedAsVerified)
 		{
 			Debug.Assert(mock != null);
 			Debug.Assert(!parts.Empty);
@@ -488,7 +489,7 @@ namespace Moq
 			var count = 0;
 			foreach (var matchingInvocation in mock.MutableInvocations.ToArray().Where(part.IsMatch))
 			{
-				invocationsToBeMarkedAsVerified.Add(matchingInvocation);
+				invocationsToBeMarkedAsVerified.Add(new Pair<Invocation, InvocationShape>(matchingInvocation, part));
 
 				if (remainingParts.Empty)
 				{

--- a/tests/Moq.Tests/CaptureFixture.cs
+++ b/tests/Moq.Tests/CaptureFixture.cs
@@ -76,6 +76,20 @@ namespace Moq.Tests
 			Assert.Empty(captures);
 		}
 
+		[Fact]
+		public void Can_be_used_with_Verify_to_replay_arguments()
+		{
+			var mock = new Mock<IFoo>();
+			mock.Object.DoSomething("1");
+			mock.Object.DoSomething("2");
+			mock.Object.DoSomething("3");
+
+			var args = new List<string>();
+			mock.Verify(m => m.DoSomething(Capture.In(args)), Times.Exactly(3));
+
+			Assert.Equal(new[] { "1", "2", "3" }, args);
+		}
+
 		public interface IFoo
 		{
 			void DoSomething(string s);


### PR DESCRIPTION
Fixes #968.

Perhaps that's not exactly what `Capture.In` was meant to do, but since it used to work, and it's fairly easy to get working again, why not.