### PR TITLE
`Mock.Of<Class>` shouldn't delete invocations made from `Class`' ctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 #### Fixed
 
  * Regression: Restored `Capture.In` use in `mock.Verify(expression, ...)` to extract arguments of previously recorded invocations. (@vgriph, #968; @stakx, #974)
-
+ * Consistency: When mocking a class `C` whose constructor invokes one of its virtual members, `Mock.Of<C>()` now operates like `new Mock<C>()`: a record of such invocations is retained in the mock's `Invocations` collection (@stakx, #980)
 
 ## 4.13.1 (2019-10-19)
 

--- a/src/Moq/Linq/Mock.cs
+++ b/src/Moq/Linq/Mock.cs
@@ -67,21 +67,7 @@ namespace Moq
 		[SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "By Design")]
 		public static T Of<T>(Expression<Func<T, bool>> predicate, MockBehavior behavior) where T : class
 		{
-			var mocked = Mocks.CreateMockQuery<T>(behavior).First(predicate);
-
-			// The current implementation of LINQ to Mocks creates mocks that already have recorded invocations.
-			// Because this interferes with `VerifyNoOtherCalls`, we recursively clear all invocations before
-			// anyone ever gets to see the new created mock.
-			//
-			// TODO: Make LINQ to Mocks set up mocks without causing invocations of its own, then remove this hack.
-			var mock = Mock.Get(mocked);
-			mock.Invocations.Clear();
-			foreach (var inner in mock.Setups.GetInnerMockSetups())
-			{
-				inner.GetInnerMock().Invocations.Clear();
-			}
-
-			return mocked;
+			return Mocks.CreateMockQuery<T>(behavior).First(predicate);
 		}
 	}
 }

--- a/tests/Moq.Tests/InvocationsFixture.cs
+++ b/tests/Moq.Tests/InvocationsFixture.cs
@@ -182,10 +182,41 @@ namespace Moq.Tests
 			Assert.Equal(MockExceptionReasons.MoreThanOneCall, ex.Reasons);
 		}
 
+		[Fact]
+		public void New_Mock_should_keep_record_of_invocations_caused_by_mocked_type_ctor()
+		{
+			var mock = new Mock<FlagInitiallySetToTrue>();
+			mock.Setup(m => m.Flag).Returns(false);
+			var mockObject = mock.Object;
+
+			Assert.Single(mock.Invocations);
+			Assert.False(mockObject.Flag);
+		}
+
+		[Fact]
+		public void Mock_Of_should_keep_record_of_invocations_caused_by_mocked_type_ctor()
+		{
+			var mockObject = Mock.Of<FlagInitiallySetToTrue>(m => m.Flag == false);
+			var mock = Mock.Get(mockObject);
+
+			Assert.Single(mock.Invocations);
+			Assert.False(mockObject.Flag);
+		}
+
 		public interface IX
 		{
 			IX Nested { get; }
 			void Do();
+		}
+
+		public class FlagInitiallySetToTrue
+		{
+			public FlagInitiallySetToTrue()
+			{
+				this.Flag = true;
+			}
+
+			public virtual bool Flag { get; set; }
 		}
 	}
 }


### PR DESCRIPTION
[This hack](https://github.com/moq/moq4/blob/0d913b9ba527e7b480b0ae3d47ac3016d9ec11e6/src/Moq/Linq/Mock.cs#L72-L82) introduced by yours truly in #543 has introduced inconsistent behavior between `new Mock<T>()` and `Mock.Of<T>()`: The latter will clear *all* invocations from the mock's `Invocations` collection &mdash; not just those caused by the library itself (as was intended), but also those caused by user code.

We can now safely remove that hack since we no longer use `FluentMockVisitor` (which was the component causing extraneous invocations).