### PR TITLE
Make verification API more generic than `Verify()`, `VerifyAll()`

### DIFF
--- a/src/Moq/AutoImplementedPropertyGetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertyGetterSetup.cs
@@ -32,15 +32,5 @@ namespace Moq
 			returnValue = this.getter.Invoke();
 			return true;
 		}
-
-		public override MockException TryVerify()
-		{
-			return this.TryVerifyInnerMock(innerMock => innerMock.TryVerify());
-		}
-
-		public override MockException TryVerifyAll()
-		{
-			return this.TryVerifyInnerMock(innerMock => innerMock.TryVerifyAll());
-		}
 	}
 }

--- a/src/Moq/AutoImplementedPropertySetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertySetterSetup.cs
@@ -26,7 +26,5 @@ namespace Moq
 			this.setter.Invoke(invocation.Arguments[0]);
 			invocation.Return();
 		}
-
-		public override MockException TryVerifyAll() => null;
 	}
 }

--- a/src/Moq/InnerMockSetup.cs
+++ b/src/Moq/InnerMockSetup.cs
@@ -24,16 +24,6 @@ namespace Moq
 			return true;
 		}
 
-		public override MockException TryVerify()
-		{
-			return this.TryVerifyInnerMock(innerMock => innerMock.TryVerify());
-		}
-
-		public override MockException TryVerifyAll()
-		{
-			return this.TryVerifyInnerMock(innerMock => innerMock.TryVerifyAll());
-		}
-
 		public override void Uninvoke()
 		{
 			if (this.ReturnsInnerMock(out var innerMock))

--- a/src/Moq/Interception/InterceptionAspects.cs
+++ b/src/Moq/Interception/InterceptionAspects.cs
@@ -104,15 +104,7 @@ namespace Moq
 			if (matchedSetup != null)
 			{
 				matchedSetup.EvaluatedSuccessfully(invocation);
-
-				if (matchedSetup.IsVerifiable)
-				{
-					invocation.MarkAsMatchedByVerifiableSetup();
-				}
-				else
-				{
-					invocation.MarkAsMatchedBySetup();
-				}
+				invocation.MarkAsMatchedBy(matchedSetup);
 
 				matchedSetup.SetOutParameters(invocation);
 

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -331,9 +331,10 @@ namespace Moq
 			this.returnOrThrowResponse = new ThrowExceptionResponse(exception);
 		}
 
-		protected override MockException TryVerifySelf()
+		protected override bool TryVerifySelf(out MockException error)
 		{
-			return (this.flags & Flags.Invoked) != 0 ? null : MockException.UnmatchedSetup(this);
+			error = (this.flags & Flags.Invoked) != 0 ? null : MockException.UnmatchedSetup(this);
+			return error == null;
 		}
 
 		public override void Uninvoke()

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -331,9 +331,9 @@ namespace Moq
 			this.returnOrThrowResponse = new ThrowExceptionResponse(exception);
 		}
 
-		public override MockException TryVerifyAll()
+		protected override MockException TryVerifySelf()
 		{
-			return (this.flags & Flags.Invoked) == 0 ? MockException.UnmatchedSetup(this) : null;
+			return (this.flags & Flags.Invoked) != 0 ? null : MockException.UnmatchedSetup(this);
 		}
 
 		public override void Uninvoke()

--- a/src/Moq/SequenceSetup.cs
+++ b/src/Moq/SequenceSetup.cs
@@ -93,9 +93,10 @@ namespace Moq
 			}
 		}
 
-		protected override MockException TryVerifySelf()
+		protected override bool TryVerifySelf(out MockException error)
 		{
-			return this.invoked ? null : MockException.UnmatchedSetup(this);
+			error = this.invoked ? null : MockException.UnmatchedSetup(this);
+			return error == null;
 		}
 
 		public override void Uninvoke()

--- a/src/Moq/SequenceSetup.cs
+++ b/src/Moq/SequenceSetup.cs
@@ -93,7 +93,7 @@ namespace Moq
 			}
 		}
 
-		public override MockException TryVerifyAll()
+		protected override MockException TryVerifySelf()
 		{
 			return this.invoked ? null : MockException.UnmatchedSetup(this);
 		}

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -89,6 +89,20 @@ namespace Moq
 			return builder.ToString();
 		}
 
+		/// <summary>
+		///   Verifies this setup and/or those of its inner mock (if present and known).
+		/// </summary>
+		/// <param name="predicate">
+		///   Specifies which setups should be verified.
+		/// </param>
+		/// <param name="error">
+		///   If this setup and/or any of its inner mock (if present and known) failed verification,
+		///   this <see langword="out"/> parameter will receive a <see cref="MockException"/> describing the verification error(s).
+		/// </param>
+		/// <returns>
+		///   <see langword="true"/> if verification succeeded without any errors;
+		///   otherwise, <see langword="false"/>.
+		/// </returns>
 		public bool TryVerify(Func<Setup, bool> predicate, out MockException error)
 		{
 			if (predicate(this))
@@ -103,6 +117,21 @@ namespace Moq
 			return this.TryVerifyInnerMock(predicate, out error);
 		}
 
+		/// <summary>
+		///   Verifies all setups of this setup's inner mock (if present and known).
+		///   Multiple verification errors are aggregated into a single <see cref="MockException"/>.
+		/// </summary>
+		/// <param name="predicate">
+		///   Specifies which setups should be verified.
+		/// </param>
+		/// <param name="error">
+		///   If one or more setups of this setup's inner mock (if present and known) failed verification,
+		///   this <see langword="out"/> parameter will receive a <see cref="MockException"/> describing the verification error(s).
+		/// </param>
+		/// <returns>
+		///   <see langword="true"/> if verification succeeded without any errors;
+		///   otherwise, <see langword="false"/>.
+		/// </returns>
 		protected virtual bool TryVerifyInnerMock(Func<Setup, bool> predicate, out MockException error)
 		{
 			if (this.ReturnsInnerMock(out var innerMock))
@@ -118,6 +147,17 @@ namespace Moq
 			return true;
 		}
 
+		/// <summary>
+		///   Verifies only this setup, excluding those of its inner mock (if present and known).
+		/// </summary>
+		/// <param name="error">
+		///   If this setup failed verification,
+		///   this <see langword="out"/> parameter will receive a <see cref="MockException"/> describing the verification error.
+		/// </param>
+		/// <returns>
+		///   <see langword="true"/> if verification succeeded without any errors;
+		///   otherwise, <see langword="false"/>.
+		/// </returns>
 		protected virtual bool TryVerifySelf(out MockException error)
 		{
 			error = null;

--- a/tests/Moq.Tests/VerifyFixture.cs
+++ b/tests/Moq.Tests/VerifyFixture.cs
@@ -1486,6 +1486,23 @@ namespace Moq.Tests
 				mock.Verify(m => m.InvokePopulate(ref It.Ref<ChildDto>.IsAny), Times.Never));
 		}
 
+		[Fact]
+		public void Verification_marks_invocations_of_inner_mocks_as_verified()
+		{
+			var mock = new Mock<IFoo>() { DefaultValue = DefaultValue.Mock };
+			mock.Setup(m => m.Value).Returns(1);
+			mock.Setup(m => m.Bar.Value).Returns(2);
+
+			// Invoke everything that has been set up, and verify everything:
+			_ = mock.Object.Value;
+			_ = mock.Object.Bar.Value;
+			mock.VerifyAll();
+
+			// The above call to `VerifyAll` should have marked all invocations as verified,
+			// including those on the inner `Bar` mock:
+			Mock.Get(mock.Object.Bar).VerifyNoOtherCalls();
+		}
+
 		public class Exclusion_of_unreachable_inner_mocks
 		{
 			[Fact]


### PR DESCRIPTION
This is a prerequisite to #976, as it gets the setup verification API ready for publication.

Besides simplifying existing code, it also opens doors to new future forms of verification besides just `mock.Verify()` and `mock.VerifyAll()`&mdash;think `mock.Verify(setup => setup.State.Contains(<some tag>)`.

/cc @ashmind