### PR TITLE
Expose `Mock.Setups`, part 1: Basics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 #### Added
 
+ * A mock's setups can now be inspected via the new `Mock.Setups` collection property (@stakx, #984)
  * New `.Protected().Setup` and `Protected().Verify` method overloads to deal with generic methods (@JmlSaul, #967)
  * Two new public methods in `Times`: `bool Validate(int count)` and `string ToString()` (@stakx, 975)
 

--- a/src/Moq/AsInterface.cs
+++ b/src/Moq/AsInterface.cs
@@ -61,7 +61,7 @@ namespace Moq
 			get { return this.owner.Object as TInterface; }
 		}
 
-		internal override SetupCollection Setups => this.owner.Setups;
+		internal override SetupCollection MutableSetups => this.owner.MutableSetups;
 
 		public override Switches Switches
 		{

--- a/src/Moq/ISetup.cs
+++ b/src/Moq/ISetup.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.Linq.Expressions;
+
+namespace Moq
+{
+	/// <summary>
+	///   A setup configured on a mock.
+	/// </summary>
+	/// <seealso cref="Mock.Setups"/>
+	public interface ISetup
+	{
+	}
+}

--- a/src/Moq/ISetup.cs
+++ b/src/Moq/ISetup.cs
@@ -11,5 +11,9 @@ namespace Moq
 	/// <seealso cref="Mock.Setups"/>
 	public interface ISetup
 	{
+		/// <summary>
+		///   The setup expression.
+		/// </summary>
+		LambdaExpression Expression { get; }
 	}
 }

--- a/src/Moq/ISetup.cs
+++ b/src/Moq/ISetup.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using System;
 using System.Linq.Expressions;
 
 namespace Moq
@@ -15,5 +16,17 @@ namespace Moq
 		///   The setup expression.
 		/// </summary>
 		LambdaExpression Expression { get; }
+
+		/// <summary>
+		///   Gets whether this setup is conditional.
+		/// </summary>
+		/// <seealso cref="Mock{T}.When(Func{bool})"/>
+		bool IsConditional { get; }
+
+		/// <summary>
+		///   Gets whether this setup has been overridden
+		///   (that is, whether it is being shadowed by a more recent non-conditional setup with an equal expression).
+		/// </summary>
+		bool IsOverridden { get; }
 	}
 }

--- a/src/Moq/ISetupList.cs
+++ b/src/Moq/ISetupList.cs
@@ -9,7 +9,7 @@ namespace Moq
 	///   A list of setups that have been configured on a mock,
 	///   in chronological order (that is, oldest setup first, most recent setup last).
 	/// </summary>
-	public interface ISetupList : IEnumerable<ISetup>
+	public interface ISetupList : IReadOnlyList<ISetup>
 	{
 	}
 }

--- a/src/Moq/ISetupList.cs
+++ b/src/Moq/ISetupList.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.Collections.Generic;
+
+namespace Moq
+{
+	/// <summary>
+	///   A list of setups that have been configured on a mock,
+	///   in chronological order (that is, oldest setup first, most recent setup last).
+	/// </summary>
+	public interface ISetupList : IEnumerable<ISetup>
+	{
+	}
+}

--- a/src/Moq/InnerMockSetup.cs
+++ b/src/Moq/InnerMockSetup.cs
@@ -30,7 +30,7 @@ namespace Moq
 		{
 			if (this.ReturnsInnerMock(out var innerMock))
 			{
-				innerMock.Setups.UninvokeAll();
+				innerMock.MutableSetups.UninvokeAll();
 			}
 		}
 	}

--- a/src/Moq/Interception/InterceptionAspects.cs
+++ b/src/Moq/Interception/InterceptionAspects.cs
@@ -29,7 +29,7 @@ namespace Moq
 
 		private static bool HandleEquals(Invocation invocation, Mock mock)
 		{
-			if (IsObjectMethod(invocation.Method) && !mock.Setups.Any(c => IsObjectMethod(c.Method, "Equals")))
+			if (IsObjectMethod(invocation.Method) && !mock.MutableSetups.Any(c => IsObjectMethod(c.Method, "Equals")))
 			{
 				invocation.Return(ReferenceEquals(invocation.Arguments.First(), mock.Object));
 				return true;
@@ -48,7 +48,7 @@ namespace Moq
 		private static bool HandleGetHashCode(Invocation invocation, Mock mock)
 		{
 			// Only if there is no corresponding setup for `GetHashCode()`
-			if (IsObjectMethod(invocation.Method) && !mock.Setups.Any(c => IsObjectMethod(c.Method, "GetHashCode")))
+			if (IsObjectMethod(invocation.Method) && !mock.MutableSetups.Any(c => IsObjectMethod(c.Method, "GetHashCode")))
 			{
 				invocation.Return(mock.GetHashCode());
 				return true;
@@ -62,7 +62,7 @@ namespace Moq
 		private static bool HandleToString(Invocation invocation, Mock mock)
 		{
 			// Only if there is no corresponding setup for `ToString()`
-			if (IsObjectMethod(invocation.Method) && !mock.Setups.Any(c => IsObjectMethod(c.Method, "ToString")))
+			if (IsObjectMethod(invocation.Method) && !mock.MutableSetups.Any(c => IsObjectMethod(c.Method, "ToString")))
 			{
 				invocation.Return(mock.ToString() + ".Object");
 				return true;
@@ -100,7 +100,7 @@ namespace Moq
 	{
 		public static bool Handle(Invocation invocation, Mock mock)
 		{
-			var matchedSetup = mock.Setups.FindMatchFor(invocation);
+			var matchedSetup = mock.MutableSetups.FindMatchFor(invocation);
 			if (matchedSetup != null)
 			{
 				matchedSetup.EvaluatedSuccessfully(invocation);
@@ -139,7 +139,7 @@ namespace Moq
 					var @event = implementingMethod.DeclaringType.GetEvents(bindingFlags).SingleOrDefault(e => e.GetAddMethod(true) == implementingMethod);
 					if (@event != null)
 					{
-						bool doesntHaveEventSetup = !mock.Setups.HasEventSetup;
+						bool doesntHaveEventSetup = !mock.MutableSetups.HasEventSetup;
 
 						if (mock.CallBase && !invocation.Method.IsAbstract)
 						{
@@ -167,7 +167,7 @@ namespace Moq
 					var @event = implementingMethod.DeclaringType.GetEvents(bindingFlags).SingleOrDefault(e => e.GetRemoveMethod(true) == implementingMethod);
 					if (@event != null)
 					{
-						bool doesntHaveEventSetup = !mock.Setups.HasEventSetup;
+						bool doesntHaveEventSetup = !mock.MutableSetups.HasEventSetup;
 
 						if (mock.CallBase && !invocation.Method.IsAbstract)
 						{
@@ -312,7 +312,7 @@ namespace Moq
 					{
 						propertyValue = CreateInitialPropertyValue(mock, getter);
 						getterSetup = new AutoImplementedPropertyGetterSetup(expression, getter, () => propertyValue);
-						mock.Setups.Add(getterSetup);
+						mock.MutableSetups.Add(getterSetup);
 					}
 
 					// If we wanted to optimise for speed, we'd probably be forgiven
@@ -335,7 +335,7 @@ namespace Moq
 						{
 							propertyValue = newValue;
 						});
-						mock.Setups.Add(setterSetup);
+						mock.MutableSetups.Add(setterSetup);
 					}
 				}
 

--- a/src/Moq/InvocationCollection.cs
+++ b/src/Moq/InvocationCollection.cs
@@ -77,7 +77,7 @@ namespace Moq
 				this.count = 0;
 				this.capacity = 0;
 
-				this.owner.Setups.UninvokeAll();
+				this.owner.MutableSetups.UninvokeAll();
 				// ^ TODO: Currently this could cause a deadlock as another lock will be taken inside this one!
 			}
 		}

--- a/src/Moq/Mock.Generic.cs
+++ b/src/Moq/Mock.Generic.cs
@@ -345,7 +345,7 @@ namespace Moq
 			get { return typeof(T); }
 		}
 
-		internal override SetupCollection Setups => this.setups;
+		internal override SetupCollection MutableSetups => this.setups;
 
 		internal override Type TargetType => typeof(T);
 

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -266,7 +266,7 @@ namespace Moq
 		/// </example>
 		public void Verify()
 		{
-			this.Verify(setup => setup.IsVerifiable);
+			this.Verify(setup => !setup.IsOverridden && !setup.IsConditional && setup.IsVerifiable);
 		}
 
 		/// <summary>
@@ -291,7 +291,7 @@ namespace Moq
 		/// </example>
 		public void VerifyAll()
 		{
-			this.Verify(setup => true);
+			this.Verify(setup => !setup.IsOverridden && !setup.IsConditional);
 		}
 
 		private void Verify(Func<Setup, bool> predicate)
@@ -311,7 +311,7 @@ namespace Moq
 
 			var errors = new List<MockException>();
 
-			foreach (var setup in this.MutableSetups.ToArrayLive(_ => true))
+			foreach (var setup in this.MutableSetups.ToArray(predicate))
 			{
 				if (!setup.TryVerify(predicate, out var e) && e.IsVerificationError)
 				{

--- a/src/Moq/MockExtensions.cs
+++ b/src/Moq/MockExtensions.cs
@@ -18,7 +18,7 @@ namespace Moq
 		public static void Reset(this Mock mock)
 		{
 			mock.ConfiguredDefaultValues.Clear();
-			mock.Setups.Clear();
+			mock.MutableSetups.Clear();
 			mock.EventHandlers.Clear();
 			mock.Invocations.Clear();
 		}

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -9,7 +9,7 @@ using System.Text;
 
 namespace Moq
 {
-	internal abstract class Setup
+	internal abstract class Setup : ISetup
 	{
 		private readonly InvocationShape expectation;
 

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -12,6 +12,7 @@ namespace Moq
 	internal abstract class Setup : ISetup
 	{
 		private readonly InvocationShape expectation;
+		private Flags flags;
 
 		protected Setup(InvocationShape expectation)
 		{
@@ -22,9 +23,13 @@ namespace Moq
 
 		public virtual Condition Condition => null;
 
+		public bool IsConditional => this.Condition != null;
+
 		public InvocationShape Expectation => this.expectation;
 
 		public LambdaExpression Expression => this.expectation.Expression;
+
+		public bool IsOverridden => (this.flags & Flags.Overridden) != 0;
 
 		public virtual bool IsVerifiable => false;
 
@@ -45,6 +50,13 @@ namespace Moq
 		{
 			returnValue = default;
 			return false;
+		}
+
+		public void MarkAsOverridden()
+		{
+			Debug.Assert(!this.IsOverridden);
+
+			this.flags |= Flags.Overridden;
 		}
 
 		public bool Matches(Invocation invocation)
@@ -173,6 +185,12 @@ namespace Moq
 
 		public virtual void Uninvoke()
 		{
+		}
+
+		[Flags]
+		private enum Flags : byte
+		{
+			Overridden = 1,
 		}
 	}
 }

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -139,7 +139,7 @@ namespace Moq
 
 		public IEnumerable<Setup> GetInnerMockSetups()
 		{
-			return this.ToArrayLive(setup => setup.ReturnsInnerMock(out _));
+			return this.ToArray(setup => !setup.IsOverridden && !setup.IsConditional && setup.ReturnsInnerMock(out _));
 		}
 
 		public void UninvokeAll()
@@ -153,7 +153,7 @@ namespace Moq
 			}
 		}
 
-		public IReadOnlyList<Setup> ToArrayLive(Func<Setup, bool> predicate)
+		public IReadOnlyList<Setup> ToArray(Func<Setup, bool> predicate)
 		{
 			var matchingSetups = new Stack<Setup>();
 
@@ -163,8 +163,6 @@ namespace Moq
 				for (int i = this.setups.Count - 1; i >= 0; --i)
 				{
 					var setup = this.setups[i];
-					if (setup.IsOverridden || setup.IsConditional) continue;
-
 					if (predicate(setup))
 					{
 						matchingSetups.Push(setup);
@@ -177,7 +175,7 @@ namespace Moq
 
 		public IEnumerator<ISetup> GetEnumerator()
 		{
-			return this.ToArrayLive(_ => true).GetEnumerator();
+			return this.ToArray(setup => !setup.IsOverridden && !setup.IsConditional).GetEnumerator();
 		}
 
 		IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -153,6 +153,14 @@ namespace Moq
 			}
 		}
 
+		public IReadOnlyList<Setup> ToArray()
+		{
+			lock (this.setups)
+			{
+				return this.setups.ToArray();
+			}
+		}
+
 		public IReadOnlyList<Setup> ToArray(Func<Setup, bool> predicate)
 		{
 			var matchingSetups = new Stack<Setup>();
@@ -175,7 +183,11 @@ namespace Moq
 
 		public IEnumerator<ISetup> GetEnumerator()
 		{
-			return this.ToArray(setup => !setup.IsOverridden && !setup.IsConditional).GetEnumerator();
+			return this.ToArray().GetEnumerator();
+			//         ^^^^^^^^^^
+			// TODO: This is somewhat inefficient. We could avoid this array allocation by converting
+			// this class to something like `InvocationCollection`, however this won't be trivial due to
+			// the presence of a removal operation in `RemoveAllPropertyAccessorSetups`.
 		}
 
 		IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -2,12 +2,13 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Moq
 {
-	internal sealed class SetupCollection
+	internal sealed class SetupCollection : ISetupList
 	{
 		private List<Setup> setups;
 		private uint overridden;  // bit mask for the first 32 setups flagging those known to be overridden
@@ -130,7 +131,7 @@ namespace Moq
 			}
 		}
 
-		public Setup[] ToArrayLive(Func<Setup, bool> predicate)
+		public IReadOnlyList<Setup> ToArrayLive(Func<Setup, bool> predicate)
 		{
 			var matchingSetups = new Stack<Setup>();
 			var visitedSetups = new HashSet<InvocationShape>();
@@ -166,5 +167,12 @@ namespace Moq
 
 			return matchingSetups.ToArray();
 		}
+
+		public IEnumerator<ISetup> GetEnumerator()
+		{
+			return this.ToArrayLive(_ => true).GetEnumerator();
+		}
+
+		IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
 	}
 }

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -19,11 +19,33 @@ namespace Moq
 			this.hasEventSetup = false;
 		}
 
+		public int Count
+		{
+			get
+			{
+				lock (this.setups)
+				{
+					return this.setups.Count;
+				}
+			}
+		}
+
 		public bool HasEventSetup
 		{
 			get
 			{
 				return this.hasEventSetup;
+			}
+		}
+
+		public ISetup this[int index]
+		{
+			get
+			{
+				lock (this.setups)
+				{
+					return this.setups[index];
+				}
 			}
 		}
 

--- a/tests/Moq.Tests/MockFixture.cs
+++ b/tests/Moq.Tests/MockFixture.cs
@@ -1285,9 +1285,9 @@ namespace Moq.Tests
 			var mock = new Mock<IFoo>();
 			mock.SetupAdd(m => m.EventHandler += It.IsAny<EventHandler>());
 
-			var before = mock.Setups.HasEventSetup;
+			var before = mock.MutableSetups.HasEventSetup;
 			mock.Reset();
-			var after = mock.Setups.HasEventSetup;
+			var after = mock.MutableSetups.HasEventSetup;
 
 			Assert.True(before, "Before reset");
 			Assert.False(after, "After reset");

--- a/tests/Moq.Tests/SetupFixture.cs
+++ b/tests/Moq.Tests/SetupFixture.cs
@@ -1,0 +1,40 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.Linq;
+
+using Xunit;
+
+namespace Moq.Tests
+{
+	public class SetupFixture
+	{
+		[Fact]
+		public void IsOverridden_does_not_become_true_if_another_setup_with_a_different_expression_is_added_to_the_mock()
+		{
+			var mock = new Mock<object>();
+			mock.Setup(m => m.Equals(1));
+			var setup = mock.Setups.First();
+
+			Assert.False(setup.IsOverridden);
+
+			mock.Setup(m => m.Equals(2));
+
+			Assert.False(setup.IsOverridden);
+		}
+
+		[Fact]
+		public void IsOverridden_becomes_true_as_soon_as_another_setup_with_an_equal_expression_is_added_to_the_mock()
+		{
+			var mock = new Mock<object>();
+			mock.Setup(m => m.Equals(1));
+			var setup = mock.Setups.First();
+
+			Assert.False(setup.IsOverridden);
+
+			mock.Setup(m => m.Equals(1));
+
+			Assert.True(setup.IsOverridden);
+		}
+	}
+}

--- a/tests/Moq.Tests/SetupsFixture.cs
+++ b/tests/Moq.Tests/SetupsFixture.cs
@@ -1,7 +1,8 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
-using System.Linq;
+using System;
+using System.Linq.Expressions;
 
 using Xunit;
 
@@ -25,19 +26,28 @@ namespace Moq.Tests
 		}
 
 		[Fact]
-		public void Setup_adds_one_item_to_Setups()
+		public void Setup_adds_one_setup_with_same_expression_to_Setups()
 		{
+			Expression<Func<object, string>> setupExpression = m => m.ToString();
+
 			var mock = new Mock<object>();
-			mock.Setup(m => m.ToString());
-			Assert.Single(mock.Setups);
+			mock.Setup(setupExpression);
+
+			var setup = Assert.Single(mock.Setups);
+			Assert.Equal(setupExpression, setup.Expression, ExpressionComparer.Default);
 		}
 
 		[Fact]
-		public void Mock_Of_with_expression_for_a_single_member_adds_one_item_to_Setups()
+		public void Mock_Of_with_expression_for_a_single_member_adds_one_setup_with_same_but_only_partial_expression_to_Setups()
 		{
-			var mockObject = Mock.Of<object>(m => m.ToString() == default(string));
+			Expression<Func<object, bool>> mockSpecification = m => m.ToString() == default(string);
+			Expression<Func<object, string>> setupExpression = m => m.ToString();
+
+			var mockObject = Mock.Of<object>(mockSpecification);
 			var mock = Mock.Get(mockObject);
-			Assert.Single(mock.Setups);
+
+			var setup = Assert.Single(mock.Setups);
+			Assert.Equal(setupExpression, setup.Expression, ExpressionComparer.Default);
 		}
 
 		[Fact]

--- a/tests/Moq.Tests/SetupsFixture.cs
+++ b/tests/Moq.Tests/SetupsFixture.cs
@@ -2,6 +2,7 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
+using System.Linq;
 using System.Linq.Expressions;
 
 using Xunit;
@@ -61,22 +62,26 @@ namespace Moq.Tests
 		}
 
 		[Fact]
-		public void Setups_does_not_report_conditional_setups()
+		public void Setups_includes_conditional_setups()
 		{
 			var mock = new Mock<object>();
 			mock.When(() => true).Setup(m => m.ToString());
-			Assert.Empty(mock.Setups);
+
+			var setup = Assert.Single(mock.Setups);
+			Assert.True(setup.IsConditional);
 		}
 
 		[Fact]
-		public void Setups_does_not_report_overridden_setups()
+		public void Setups_includes_overridden_setups()
 		{
 			var mock = new Mock<object>();
 			mock.Setup(m => m.ToString());
-			var setupBeforeOverride = Assert.Single(mock.Setups);
 			mock.Setup(m => m.ToString());
-			var setupAfterOverride = Assert.Single(mock.Setups);
-			Assert.NotSame(setupBeforeOverride, setupAfterOverride);
+
+			var setups = mock.Setups.ToArray();
+			Assert.Equal(2, setups.Length);
+			Assert.True(setups[0].IsOverridden);
+			Assert.False(setups[1].IsOverridden);
 		}
 	}
 }

--- a/tests/Moq.Tests/SetupsFixture.cs
+++ b/tests/Moq.Tests/SetupsFixture.cs
@@ -1,0 +1,72 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.Linq;
+
+using Xunit;
+
+namespace Moq.Tests
+{
+	public class SetupsFixture
+	{
+		[Fact]
+		public void Mock_made_with_new_operator_initially_has_no_setups()
+		{
+			var mock = new Mock<object>();
+			Assert.Empty(mock.Setups);
+		}
+
+		[Fact]
+		public void Mock_made_with_Mock_Of_without_an_expression_initially_has_no_setups()
+		{
+			var mockObject = Mock.Of<object>();
+			var mock = Mock.Get(mockObject);
+			Assert.Empty(mock.Setups);
+		}
+
+		[Fact]
+		public void Setup_adds_one_item_to_Setups()
+		{
+			var mock = new Mock<object>();
+			mock.Setup(m => m.ToString());
+			Assert.Single(mock.Setups);
+		}
+
+		[Fact]
+		public void Mock_Of_with_expression_for_a_single_member_adds_one_item_to_Setups()
+		{
+			var mockObject = Mock.Of<object>(m => m.ToString() == default(string));
+			var mock = Mock.Get(mockObject);
+			Assert.Single(mock.Setups);
+		}
+
+		[Fact]
+		public void Mock_Reset_results_in_empty_Setups()
+		{
+			var mock = new Mock<object>();
+			mock.Setup(m => m.ToString());
+			Assert.NotEmpty(mock.Setups);
+			mock.Reset();
+			Assert.Empty(mock.Setups);
+		}
+
+		[Fact]
+		public void Setups_does_not_report_conditional_setups()
+		{
+			var mock = new Mock<object>();
+			mock.When(() => true).Setup(m => m.ToString());
+			Assert.Empty(mock.Setups);
+		}
+
+		[Fact]
+		public void Setups_does_not_report_overridden_setups()
+		{
+			var mock = new Mock<object>();
+			mock.Setup(m => m.ToString());
+			var setupBeforeOverride = Assert.Single(mock.Setups);
+			mock.Setup(m => m.ToString());
+			var setupAfterOverride = Assert.Single(mock.Setups);
+			Assert.NotSame(setupBeforeOverride, setupAfterOverride);
+		}
+	}
+}


### PR DESCRIPTION
This exposes a mock's `Setups` collection in the public API. Setups accessible via that (for now read-only) collection are of type `ISetup` and (for now) have three properties that describe some basic aspects of each setup:

* `Expression`
* `IsConditional`
* `IsOverridden`

This PR will be followed by a couple more that add more advanced functionality, e.g. to navigate the mock-setup or setup-setup object graph, and to perform custom verification.