### PR TITLE
Expose `Mock.Setups`, part 2: Match status of setups & invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,16 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 #### Added
 
- * A mock's setups can now be inspected via the new `Mock.Setups` collection property (@stakx, #984)
+ * A mock's setups can now be inspected via the new `Mock.Setups` collection property and `IInvocation.WasMatched` method (@stakx, #984, #985)
+
  * New `.Protected().Setup` and `Protected().Verify` method overloads to deal with generic methods (@JmlSaul, #967)
+
  * Two new public methods in `Times`: `bool Validate(int count)` and `string ToString()` (@stakx, 975)
 
 #### Fixed
 
  * Regression: Restored `Capture.In` use in `mock.Verify(expression, ...)` to extract arguments of previously recorded invocations. (@vgriph, #968; @stakx, #974)
+
  * Consistency: When mocking a class `C` whose constructor invokes one of its virtual members, `Mock.Of<C>()` now operates like `new Mock<C>()`: a record of such invocations is retained in the mock's `Invocations` collection (@stakx, #980)
 
 ## 4.13.1 (2019-10-19)

--- a/src/Moq/AutoImplementedPropertyGetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertyGetterSetup.cs
@@ -24,7 +24,7 @@ namespace Moq
 
 		public override bool IsVerifiable => true;
 
-		public override void Execute(Invocation invocation)
+		protected override void ExecuteCore(Invocation invocation)
 		{
 			invocation.Return(this.getter.Invoke());
 		}

--- a/src/Moq/AutoImplementedPropertySetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertySetterSetup.cs
@@ -23,7 +23,7 @@ namespace Moq
 
 		public override bool IsVerifiable => true;
 
-		public override void Execute(Invocation invocation)
+		protected override void ExecuteCore(Invocation invocation)
 		{
 			this.setter.Invoke(invocation.Arguments[0]);
 			invocation.Return();

--- a/src/Moq/IInvocation.cs
+++ b/src/Moq/IInvocation.cs
@@ -22,15 +22,15 @@ namespace Moq
 		IReadOnlyList<object> Arguments { get; }
 
 		/// <summary>
-		///   Gets whether this invocation matched a setup.
+		///   Gets whether this invocation was matched by a setup.
 		///   If so, the matching setup is returned via the <see langword="out"/> parameter <paramref name="matchingSetup"/>.
 		/// </summary>
 		/// <param name="matchingSetup">
-		///   If this invocation matched a setup,
+		///   If this invocation was matched by a setup,
 		///   this <see langword="out"/> parameter will be set to the matching setup.
 		/// </param>
 		/// <returns>
-		///   <see langword="true"/> if this invocation matched a setup;
+		///   <see langword="true"/> if this invocation was matched by a setup;
 		///   otherwise, <see langword="false"/>.
 		/// </returns>
 		bool WasMatched(out ISetup matchingSetup);

--- a/src/Moq/IInvocation.cs
+++ b/src/Moq/IInvocation.cs
@@ -20,5 +20,19 @@ namespace Moq
 		/// Gets the arguments of the invocation.
 		/// </summary>
 		IReadOnlyList<object> Arguments { get; }
+
+		/// <summary>
+		///   Gets whether this invocation matched a setup.
+		///   If so, the matching setup is returned via the <see langword="out"/> parameter <paramref name="matchingSetup"/>.
+		/// </summary>
+		/// <param name="matchingSetup">
+		///   If this invocation matched a setup,
+		///   this <see langword="out"/> parameter will be set to the matching setup.
+		/// </param>
+		/// <returns>
+		///   <see langword="true"/> if this invocation matched a setup;
+		///   otherwise, <see langword="false"/>.
+		/// </returns>
+		bool WasMatched(out ISetup matchingSetup);
 	}
 }

--- a/src/Moq/ISetup.cs
+++ b/src/Moq/ISetup.cs
@@ -28,5 +28,10 @@ namespace Moq
 		///   (that is, whether it is being shadowed by a more recent non-conditional setup with an equal expression).
 		/// </summary>
 		bool IsOverridden { get; }
+
+		/// <summary>
+		///   Gets whether this setup was matched by at least one invocation on the mock.
+		/// </summary>
+		bool WasMatched { get; }
 	}
 }

--- a/src/Moq/InnerMockSetup.cs
+++ b/src/Moq/InnerMockSetup.cs
@@ -15,7 +15,7 @@ namespace Moq
 
 		public override bool IsVerifiable => true;
 
-		public override void Execute(Invocation invocation)
+		protected override void ExecuteCore(Invocation invocation)
 		{
 			invocation.Return(this.returnValue);
 		}

--- a/src/Moq/InnerMockSetup.cs
+++ b/src/Moq/InnerMockSetup.cs
@@ -26,7 +26,7 @@ namespace Moq
 			return true;
 		}
 
-		public override void Reset()
+		protected override void ResetCore()
 		{
 			if (this.ReturnsInnerMock(out var innerMock))
 			{

--- a/src/Moq/InnerMockSetup.cs
+++ b/src/Moq/InnerMockSetup.cs
@@ -26,11 +26,11 @@ namespace Moq
 			return true;
 		}
 
-		public override void Uninvoke()
+		public override void Reset()
 		{
 			if (this.ReturnsInnerMock(out var innerMock))
 			{
-				innerMock.MutableSetups.UninvokeAll();
+				innerMock.MutableSetups.Reset();
 			}
 		}
 	}

--- a/src/Moq/Interception/InterceptionAspects.cs
+++ b/src/Moq/Interception/InterceptionAspects.cs
@@ -100,18 +100,10 @@ namespace Moq
 	{
 		public static bool Handle(Invocation invocation, Mock mock)
 		{
-			var matchedSetup = mock.MutableSetups.FindMatchFor(invocation);
-			if (matchedSetup != null)
+			var matchingSetup = mock.MutableSetups.FindMatchFor(invocation);
+			if (matchingSetup != null)
 			{
-				matchedSetup.EvaluatedSuccessfully(invocation);
-				invocation.MarkAsMatchedBy(matchedSetup);
-
-				matchedSetup.SetOutParameters(invocation);
-
-				// We first execute, as there may be a Throws 
-				// and therefore we might never get to the 
-				// next line.
-				matchedSetup.Execute(invocation);
+				matchingSetup.Execute(invocation);
 				return true;
 			}
 			else

--- a/src/Moq/Invocation.cs
+++ b/src/Moq/Invocation.cs
@@ -171,5 +171,10 @@ namespace Moq
 
 			return builder.ToString();
 		}
+
+		public bool WasMatched(out ISetup matchingSetup)
+		{
+			return (matchingSetup = this.matchingSetup) != null;
+		}
 	}
 }

--- a/src/Moq/InvocationCollection.cs
+++ b/src/Moq/InvocationCollection.cs
@@ -77,7 +77,7 @@ namespace Moq
 				this.count = 0;
 				this.capacity = 0;
 
-				this.owner.MutableSetups.UninvokeAll();
+				this.owner.MutableSetups.Reset();
 				// ^ TODO: Currently this could cause a deadlock as another lock will be taken inside this one!
 			}
 		}

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -329,12 +329,6 @@ namespace Moq
 			this.returnOrThrowResponse = new ThrowExceptionResponse(exception);
 		}
 
-		protected override bool TryVerifySelf(out MockException error)
-		{
-			error = this.WasMatched ? null : MockException.UnmatchedSetup(this);
-			return error == null;
-		}
-
 		protected override void ResetCore()
 		{
 			this.limitInvocationCountResponse?.Reset();

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -89,10 +89,8 @@ namespace Moq
 			return null;
 		}
 
-		public override void Execute(Invocation invocation)
+		protected override void ExecuteCore(Invocation invocation)
 		{
-			this.MarkAsMatched();
-
 			this.limitInvocationCountResponse?.RespondTo(invocation);
 
 			this.callbackResponse?.RespondTo(invocation);

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -91,7 +91,7 @@ namespace Moq
 
 		public override void Execute(Invocation invocation)
 		{
-			this.flags |= Flags.Invoked;
+			this.flags |= Flags.Matched;
 
 			this.limitInvocationCountResponse?.RespondTo(invocation);
 
@@ -333,13 +333,13 @@ namespace Moq
 
 		protected override bool TryVerifySelf(out MockException error)
 		{
-			error = (this.flags & Flags.Invoked) != 0 ? null : MockException.UnmatchedSetup(this);
+			error = (this.flags & Flags.Matched) != 0 ? null : MockException.UnmatchedSetup(this);
 			return error == null;
 		}
 
-		public override void Uninvoke()
+		public override void Reset()
 		{
-			this.flags &= ~Flags.Invoked;
+			this.flags &= ~Flags.Matched;
 			this.limitInvocationCountResponse?.Reset();
 		}
 
@@ -382,7 +382,7 @@ namespace Moq
 		private enum Flags : byte
 		{
 			CallBase = 1,
-			Invoked = 2,
+			Matched = 2,
 			MethodIsNonVoid = 4,
 			Verifiable = 8,
 		}

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -91,7 +91,7 @@ namespace Moq
 
 		public override void Execute(Invocation invocation)
 		{
-			this.flags |= Flags.Matched;
+			this.MarkAsMatched();
 
 			this.limitInvocationCountResponse?.RespondTo(invocation);
 
@@ -333,13 +333,13 @@ namespace Moq
 
 		protected override bool TryVerifySelf(out MockException error)
 		{
-			error = (this.flags & Flags.Matched) != 0 ? null : MockException.UnmatchedSetup(this);
+			error = this.WasMatched ? null : MockException.UnmatchedSetup(this);
 			return error == null;
 		}
 
 		public override void Reset()
 		{
-			this.flags &= ~Flags.Matched;
+			this.MarkAsUnmatched();
 			this.limitInvocationCountResponse?.Reset();
 		}
 
@@ -382,9 +382,8 @@ namespace Moq
 		private enum Flags : byte
 		{
 			CallBase = 1,
-			Matched = 2,
-			MethodIsNonVoid = 4,
-			Verifiable = 8,
+			MethodIsNonVoid = 2,
+			Verifiable = 4,
 		}
 
 		private sealed class LimitInvocationCountResponse

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -335,9 +335,8 @@ namespace Moq
 			return error == null;
 		}
 
-		public override void Reset()
+		protected override void ResetCore()
 		{
-			this.MarkAsUnmatched();
 			this.limitInvocationCountResponse?.Reset();
 		}
 

--- a/src/Moq/MockException.cs
+++ b/src/Moq/MockException.cs
@@ -39,7 +39,7 @@ namespace Moq
 	public class MockException : Exception
 	{
 		/// <summary>
-		///   Returns the exception to be thrown when a setup limited by <see cref="IOccurrence.AtMostOnce()"/> is invoked more often than once.
+		///   Returns the exception to be thrown when a setup limited by <see cref="IOccurrence.AtMostOnce()"/> is matched more often than once.
 		/// </summary>
 		internal static MockException MoreThanOneCall(MethodCall setup, int invocationCount)
 		{
@@ -52,7 +52,7 @@ namespace Moq
 		}
 
 		/// <summary>
-		///   Returns the exception to be thrown when a setup limited by <see cref="IOccurrence.AtMost(int)"/> is invoked more often than the specified maximum number of times.
+		///   Returns the exception to be thrown when a setup limited by <see cref="IOccurrence.AtMost(int)"/> is matched more often than the specified maximum number of times.
 		/// </summary>
 		internal static MockException MoreThanNCalls(MethodCall setup, int maxInvocationCount, int invocationCount)
 		{
@@ -157,7 +157,7 @@ namespace Moq
 		}
 
 		/// <summary>
-		///   Returns the exception to be thrown when a setup has not been invoked.
+		///   Returns the exception to be thrown when a setup was not matched.
 		/// </summary>
 		internal static MockException UnmatchedSetup(Setup setup)
 		{

--- a/src/Moq/SequenceSetup.cs
+++ b/src/Moq/SequenceSetup.cs
@@ -14,7 +14,6 @@ namespace Moq
 	{
 		// contains the responses set up with the `CallBase`, `Pass`, `Returns`, and `Throws` verbs
 		private ConcurrentQueue<Response> responses;
-		private bool matched;
 
 		public SequenceSetup(InvocationShape expectation)
 			: base(expectation)
@@ -49,7 +48,7 @@ namespace Moq
 
 		public override void Execute(Invocation invocation)
 		{
-			this.matched = true;
+			this.MarkAsMatched();
 
 			if (this.responses.TryDequeue(out var response))
 			{
@@ -95,13 +94,13 @@ namespace Moq
 
 		protected override bool TryVerifySelf(out MockException error)
 		{
-			error = this.matched ? null : MockException.UnmatchedSetup(this);
+			error = this.WasMatched ? null : MockException.UnmatchedSetup(this);
 			return error == null;
 		}
 
 		public override void Reset()
 		{
-			this.matched = false;
+			this.MarkAsUnmatched();
 		}
 
 		private readonly struct Response

--- a/src/Moq/SequenceSetup.cs
+++ b/src/Moq/SequenceSetup.cs
@@ -46,10 +46,8 @@ namespace Moq
 			this.responses.Enqueue(new Response(ResponseKind.Throws, exception));
 		}
 
-		public override void Execute(Invocation invocation)
+		protected override void ExecuteCore(Invocation invocation)
 		{
-			this.MarkAsMatched();
-
 			if (this.responses.TryDequeue(out var response))
 			{
 				var (kind, arg) = response;

--- a/src/Moq/SequenceSetup.cs
+++ b/src/Moq/SequenceSetup.cs
@@ -90,12 +90,6 @@ namespace Moq
 			}
 		}
 
-		protected override bool TryVerifySelf(out MockException error)
-		{
-			error = this.WasMatched ? null : MockException.UnmatchedSetup(this);
-			return error == null;
-		}
-
 		private readonly struct Response
 		{
 			private readonly ResponseKind kind;

--- a/src/Moq/SequenceSetup.cs
+++ b/src/Moq/SequenceSetup.cs
@@ -14,7 +14,7 @@ namespace Moq
 	{
 		// contains the responses set up with the `CallBase`, `Pass`, `Returns`, and `Throws` verbs
 		private ConcurrentQueue<Response> responses;
-		private bool invoked;
+		private bool matched;
 
 		public SequenceSetup(InvocationShape expectation)
 			: base(expectation)
@@ -49,7 +49,7 @@ namespace Moq
 
 		public override void Execute(Invocation invocation)
 		{
-			this.invoked = true;
+			this.matched = true;
 
 			if (this.responses.TryDequeue(out var response))
 			{
@@ -95,13 +95,13 @@ namespace Moq
 
 		protected override bool TryVerifySelf(out MockException error)
 		{
-			error = this.invoked ? null : MockException.UnmatchedSetup(this);
+			error = this.matched ? null : MockException.UnmatchedSetup(this);
 			return error == null;
 		}
 
-		public override void Uninvoke()
+		public override void Reset()
 		{
-			this.invoked = false;
+			this.matched = false;
 		}
 
 		private readonly struct Response

--- a/src/Moq/SequenceSetup.cs
+++ b/src/Moq/SequenceSetup.cs
@@ -96,11 +96,6 @@ namespace Moq
 			return error == null;
 		}
 
-		public override void Reset()
-		{
-			this.MarkAsUnmatched();
-		}
-
 		private readonly struct Response
 		{
 			private readonly ResponseKind kind;

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -191,8 +191,8 @@ namespace Moq
 		/// </returns>
 		protected virtual bool TryVerifySelf(out MockException error)
 		{
-			error = null;
-			return true;
+			error = this.WasMatched ? null : MockException.UnmatchedSetup(this);
+			return error == null;
 		}
 
 		public void Reset()

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -210,7 +210,14 @@ namespace Moq
 			return true;
 		}
 
-		public virtual void Reset()
+		public void Reset()
+		{
+			this.MarkAsUnmatched();
+
+			this.ResetCore();
+		}
+
+		protected virtual void ResetCore()
 		{
 		}
 

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -37,7 +37,14 @@ namespace Moq
 
 		public bool WasMatched => (this.flags & Flags.Matched) != 0;
 
-		public abstract void Execute(Invocation invocation);
+		public void Execute(Invocation invocation)
+		{
+			this.MarkAsMatched();
+
+			this.ExecuteCore(invocation);
+		}
+
+		protected abstract void ExecuteCore(Invocation invocation);
 
 		public Mock GetInnerMock()
 		{

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -183,7 +183,7 @@ namespace Moq
 			return true;
 		}
 
-		public virtual void Uninvoke()
+		public virtual void Reset()
 		{
 		}
 

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -40,14 +40,15 @@ namespace Moq
 		public void Execute(Invocation invocation)
 		{
 			// update this setup:
-			this.MarkAsMatched();
+			this.flags |= Flags.Matched;
 
 			// update invocation:
 			invocation.MarkAsMatchedBy(this);
 			this.SetOutParameters(invocation);
 
 			// update condition (important for `MockSequence`) and matchers (important for `Capture`):
-			this.EvaluatedSuccessfully(invocation);
+			this.Condition?.SetupEvaluatedSuccessfully();
+			this.expectation.SetupEvaluatedSuccessfully(invocation);
 
 			this.ExecuteCore(invocation);
 		}
@@ -69,21 +70,11 @@ namespace Moq
 			return false;
 		}
 
-		public void MarkAsMatched()
-		{
-			this.flags |= Flags.Matched;
-		}
-
 		public void MarkAsOverridden()
 		{
 			Debug.Assert(!this.IsOverridden);
 
 			this.flags |= Flags.Overridden;
-		}
-
-		public void MarkAsUnmatched()
-		{
-			this.flags &= ~Flags.Matched;
 		}
 
 		public bool Matches(Invocation invocation)
@@ -103,12 +94,6 @@ namespace Moq
 				mock = null;
 				return false;
 			}
-		}
-
-		public void EvaluatedSuccessfully(Invocation invocation)
-		{
-			this.Condition?.SetupEvaluatedSuccessfully();
-			this.expectation.SetupEvaluatedSuccessfully(invocation);
 		}
 
 		public virtual void SetOutParameters(Invocation invocation)
@@ -212,7 +197,7 @@ namespace Moq
 
 		public void Reset()
 		{
-			this.MarkAsUnmatched();
+			this.flags &= ~Flags.Matched;
 
 			this.ResetCore();
 		}

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -35,6 +35,8 @@ namespace Moq
 
 		public MethodInfo Method => this.expectation.Method;
 
+		public bool WasMatched => (this.flags & Flags.Matched) != 0;
+
 		public abstract void Execute(Invocation invocation);
 
 		public Mock GetInnerMock()
@@ -52,11 +54,21 @@ namespace Moq
 			return false;
 		}
 
+		public void MarkAsMatched()
+		{
+			this.flags |= Flags.Matched;
+		}
+
 		public void MarkAsOverridden()
 		{
 			Debug.Assert(!this.IsOverridden);
 
 			this.flags |= Flags.Overridden;
+		}
+
+		public void MarkAsUnmatched()
+		{
+			this.flags &= ~Flags.Matched;
 		}
 
 		public bool Matches(Invocation invocation)
@@ -190,7 +202,8 @@ namespace Moq
 		[Flags]
 		private enum Flags : byte
 		{
-			Overridden = 1,
+			Matched = 1,
+			Overridden = 2,
 		}
 	}
 }

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -39,7 +39,15 @@ namespace Moq
 
 		public void Execute(Invocation invocation)
 		{
+			// update this setup:
 			this.MarkAsMatched();
+
+			// update invocation:
+			invocation.MarkAsMatchedBy(this);
+			this.SetOutParameters(invocation);
+
+			// update condition (important for `MockSequence`) and matchers (important for `Capture`):
+			this.EvaluatedSuccessfully(invocation);
 
 			this.ExecuteCore(invocation);
 		}

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -164,13 +164,13 @@ namespace Moq
 			return this.ToArray(setup => !setup.IsOverridden && !setup.IsConditional && setup.ReturnsInnerMock(out _));
 		}
 
-		public void UninvokeAll()
+		public void Reset()
 		{
 			lock (this.setups)
 			{
 				foreach (var setup in this.setups)
 				{
-					setup.Uninvoke();
+					setup.Reset();
 				}
 			}
 		}

--- a/tests/Moq.Tests/InvocationsFixture.cs
+++ b/tests/Moq.Tests/InvocationsFixture.cs
@@ -2,6 +2,7 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
+using System.Linq;
 
 using Xunit;
 
@@ -201,6 +202,32 @@ namespace Moq.Tests
 
 			Assert.Single(mock.Invocations);
 			Assert.False(mockObject.Flag);
+		}
+
+		[Fact]
+		public void WasMatched_returns_false_if_there_was_no_matching_setup()
+		{
+			var mock = new Mock<IX>();
+
+			mock.Object.Do();
+			var invocation = mock.Invocations.First();
+
+			Assert.False(invocation.WasMatched(out var matchingSetup));
+			Assert.Null(matchingSetup);
+		}
+
+		[Fact]
+		public void WasMatched_returns_true_if_there_was_a_matching_setup()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Do());
+			var setup = mock.Setups.First();
+
+			mock.Object.Do();
+			var invocation = mock.Invocations.First();
+
+			Assert.True(invocation.WasMatched(out var matchingSetup));
+			Assert.Same(setup, matchingSetup);
 		}
 
 		public interface IX

--- a/tests/Moq.Tests/InvocationsFixture.cs
+++ b/tests/Moq.Tests/InvocationsFixture.cs
@@ -230,6 +230,34 @@ namespace Moq.Tests
 			Assert.Same(setup, matchingSetup);
 		}
 
+		[Fact]
+		public void WasMatched_returns_true_if_there_was_a_matching_setup_implicitly_created_by_SetupAllProperties()
+		{
+			var mock = new Mock<IX>();
+			mock.SetupAllProperties();
+
+			_ = mock.Object.Nested;
+			var invocation = mock.Invocations.First();
+			var setup = mock.Setups.First();
+
+			Assert.True(invocation.WasMatched(out var matchingSetup));
+			Assert.Same(setup, matchingSetup);
+		}
+
+		[Fact]
+		public void WasMatched_returns_true_if_there_was_a_matching_setup_implicitly_created_by_multi_dot_expression()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Nested.Do());
+			var setup = mock.Setups.First();
+
+			_ = mock.Object.Nested;
+			var invocation = mock.Invocations.First();
+
+			Assert.True(invocation.WasMatched(out var matchingSetup));
+			Assert.Same(setup, matchingSetup);
+		}
+
 		public interface IX
 		{
 			IX Nested { get; }

--- a/tests/Moq.Tests/SetupFixture.cs
+++ b/tests/Moq.Tests/SetupFixture.cs
@@ -24,6 +24,32 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public void IsMatched_of_setup_implicitly_created_by_SetupAllProperties_becomes_true_as_soon_as_matching_invocation_is_made()
+		{
+			var mock = new Mock<IX>();
+			mock.SetupAllProperties();
+
+			_ = mock.Object.Property;
+			var setup = mock.Setups.First();
+
+			Assert.True(setup.WasMatched);
+		}
+
+		[Fact]
+		public void IsMatched_of_setup_implicitly_created_by_multi_dot_expression_becomes_true_as_soon_as_matching_invocation_is_made()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inner.Property);
+			var setup = mock.Setups.First();
+
+			Assert.False(setup.WasMatched);
+
+			_ = mock.Object.Inner;
+
+			Assert.True(setup.WasMatched);
+		}
+
+		[Fact]
 		public void IsOverridden_does_not_become_true_if_another_setup_with_a_different_expression_is_added_to_the_mock()
 		{
 			var mock = new Mock<object>();
@@ -49,6 +75,12 @@ namespace Moq.Tests
 			mock.Setup(m => m.Equals(1));
 
 			Assert.True(setup.IsOverridden);
+		}
+
+		public interface IX
+		{
+			IX Inner { get; }
+			object Property { get; set; }
 		}
 	}
 }

--- a/tests/Moq.Tests/SetupFixture.cs
+++ b/tests/Moq.Tests/SetupFixture.cs
@@ -10,6 +10,20 @@ namespace Moq.Tests
 	public class SetupFixture
 	{
 		[Fact]
+		public void IsMatched_becomes_true_as_soon_as_a_matching_invocation_is_made()
+		{
+			var mock = new Mock<object>();
+			mock.Setup(m => m.ToString());
+			var setup = mock.Setups.First();
+
+			Assert.False(setup.WasMatched);
+
+			_ = mock.Object.ToString();
+
+			Assert.True(setup.WasMatched);
+		}
+
+		[Fact]
 		public void IsOverridden_does_not_become_true_if_another_setup_with_a_different_expression_is_added_to_the_mock()
 		{
 			var mock = new Mock<object>();


### PR DESCRIPTION
This allows you...

* to distinguish between unmatched setups and those that were matched by at least one invocation via the `ISetup.WasMatched { get; }` boolean property; and

* to find out whether an invocation matched a setup (and which one) via the `IInvocation.WasMatched(out ISetup matchingSetup)` method.