### PR TITLE
Fix regression when verifying `SetupAllProperties`' setups

### DIFF
--- a/src/Moq/AutoImplementedPropertyGetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertyGetterSetup.cs
@@ -34,5 +34,11 @@ namespace Moq
 			returnValue = this.getter.Invoke();
 			return true;
 		}
+
+		protected override bool TryVerifySelf(Func<Setup, bool> predicate, out MockException error)
+		{
+			error = null;
+			return true;
+		}
 	}
 }

--- a/src/Moq/AutoImplementedPropertySetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertySetterSetup.cs
@@ -28,5 +28,11 @@ namespace Moq
 			this.setter.Invoke(invocation.Arguments[0]);
 			invocation.Return();
 		}
+
+		protected override bool TryVerifySelf(Func<Setup, bool> predicate, out MockException error)
+		{
+			error = null;
+			return true;
+		}
 	}
 }

--- a/tests/Moq.Tests/VerifyFixture.cs
+++ b/tests/Moq.Tests/VerifyFixture.cs
@@ -1643,6 +1643,36 @@ namespace Moq.Tests
 			}
 		}
 
+		[Fact]
+		public void Property_getter_setup_created_by_SetupAllProperties_should_not_fail_verification_even_when_not_matched()
+		{
+			var mock = new Mock<IFoo>();
+			mock.SetupAllProperties();
+
+			// Due to `SetupAllProperties` working in a lazy fashion,
+			// this should create two setups (one for the getter, one for the setter).
+			// Only invoke the setter:
+			mock.Object.Value = default;
+
+			// The getter hasn't been matched, but verification should still pass:
+			mock.VerifyAll();
+		}
+
+		[Fact]
+		public void Property_setter_setup_created_by_SetupAllProperties_should_not_fail_verification_even_when_not_matched()
+		{
+			var mock = new Mock<IFoo>();
+			mock.SetupAllProperties();
+
+			// Due to `SetupAllProperties` working in a lazy fashion,
+			// this should create two setups (one for the getter, one for the setter).
+			// Only invoke the getter:
+			_ = mock.Object.Value;
+
+			// The setter hasn't been matched, but verification should still pass:
+			mock.VerifyAll();
+		}
+
 		public interface IBar
 		{
 			int? Value { get; set; }


### PR DESCRIPTION
(The two unit tests wouldn't have failed in Moq version 4.13.1. Strange we didn't have any tests for this scenario.)