### PR TITLE
Expose `Mock.Setups`, part 3: Individual setup verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 #### Added
 
- * A mock's setups can now be inspected via the new `Mock.Setups` collection property and `IInvocation.WasMatched` method (@stakx, #984, #985)
+ * A mock's setups can now be inspected and individually verified via the new `Mock.Setups` collection and `IInvocation.WasMatched` method (@stakx, #984-#987)
 
  * New `.Protected().Setup` and `Protected().Verify` method overloads to deal with generic methods (@JmlSaul, #967)
 

--- a/src/Moq/AutoImplementedPropertyGetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertyGetterSetup.cs
@@ -20,9 +20,9 @@ namespace Moq
 			: base(new InvocationShape(originalExpression, method, noArguments))
 		{
 			this.getter = getter;
-		}
 
-		public override bool IsVerifiable => true;
+			this.MarkAsVerifiable();
+		}
 
 		protected override void ExecuteCore(Invocation invocation)
 		{

--- a/src/Moq/AutoImplementedPropertyGetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertyGetterSetup.cs
@@ -16,8 +16,8 @@ namespace Moq
 
 		private Func<object> getter;
 
-		public AutoImplementedPropertyGetterSetup(LambdaExpression originalExpression, MethodInfo method, Func<object> getter)
-			: base(new InvocationShape(originalExpression, method, noArguments))
+		public AutoImplementedPropertyGetterSetup(Mock mock, LambdaExpression originalExpression, MethodInfo method, Func<object> getter)
+			: base(mock, new InvocationShape(originalExpression, method, noArguments))
 		{
 			this.getter = getter;
 

--- a/src/Moq/AutoImplementedPropertySetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertySetterSetup.cs
@@ -15,8 +15,8 @@ namespace Moq
 	{
 		private Action<object> setter;
 
-		public AutoImplementedPropertySetterSetup(LambdaExpression originalExpression, MethodInfo method, Action<object> setter)
-			: base(new InvocationShape(originalExpression, method, new Expression[] { It.IsAny(method.GetParameterTypes().Last()) }))
+		public AutoImplementedPropertySetterSetup(Mock mock, LambdaExpression originalExpression, MethodInfo method, Action<object> setter)
+			: base(mock, new InvocationShape(originalExpression, method, new Expression[] { It.IsAny(method.GetParameterTypes().Last()) }))
 		{
 			this.setter = setter;
 

--- a/src/Moq/AutoImplementedPropertySetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertySetterSetup.cs
@@ -19,9 +19,9 @@ namespace Moq
 			: base(new InvocationShape(originalExpression, method, new Expression[] { It.IsAny(method.GetParameterTypes().Last()) }))
 		{
 			this.setter = setter;
-		}
 
-		public override bool IsVerifiable => true;
+			this.MarkAsVerifiable();
+		}
 
 		protected override void ExecuteCore(Invocation invocation)
 		{

--- a/src/Moq/IInvocation.cs
+++ b/src/Moq/IInvocation.cs
@@ -34,5 +34,10 @@ namespace Moq
 		///   otherwise, <see langword="false"/>.
 		/// </returns>
 		bool WasMatched(out ISetup matchingSetup);
+
+		/// <summary>
+		///   Gets whether this invocation was successfully verified by any of the various <c>`Verify`</c> methods.
+		/// </summary>
+		bool WasVerified { get; }
 	}
 }

--- a/src/Moq/ISetup.cs
+++ b/src/Moq/ISetup.cs
@@ -46,5 +46,39 @@ namespace Moq
 		///   Gets whether this setup was matched by at least one invocation on the mock.
 		/// </summary>
 		bool WasMatched { get; }
+
+		/// <summary>
+		///   Verifies this setup and optionally all verifiable setups of its inner mock (if present and known).
+		///   <para>
+		///     If <paramref name="recursive"/> is set to <see langword="true"/>,
+		///     the semantics of this method are essentially the same as those of <see cref="Mock.Verify()"/>,
+		///     except that this setup (instead of a mock) is used as the starting point for verification,
+		///     and will always be verified itself (even if not flagged as verifiable).
+		///   </para>
+		/// </summary>
+		/// <param name="recursive">
+		///   Specifies whether recursive verification should be performed.
+		/// </param>
+		/// <exception cref="MockException">
+		///   Verification failed due to one or more unmatched setups.
+		/// </exception>
+		/// <seealso cref="VerifyAll()"/>
+		/// <seealso cref="Mock.Verify()"/>
+		void Verify(bool recursive = true);
+
+		/// <summary>
+		///   Verifies this setup and all setups of its inner mock (if present and known),
+		///   regardless of whether they have been flagged as verifiable.
+		///   <para>
+		///     The semantics of this method are essentially the same as those of <see cref="Mock.VerifyAll()"/>,
+		///     except that this setup (instead of a mock) is used as the starting point for verification.
+		///   </para>
+		/// </summary>
+		/// <exception cref="MockException">
+		///   Verification failed due to one or more unmatched setups.
+		/// </exception>
+		/// <seealso cref="Verify(bool)"/>
+		/// <seealso cref="Mock.VerifyAll()"/>
+		void VerifyAll();
 	}
 }

--- a/src/Moq/ISetup.cs
+++ b/src/Moq/ISetup.cs
@@ -30,6 +30,19 @@ namespace Moq
 		bool IsOverridden { get; }
 
 		/// <summary>
+		///   Gets whether this setup is "verifiable".
+		/// </summary>
+		/// <remarks>
+		///   This property gets sets by the <c>`.Verifiable()`</c> setup verb.
+		///   <para>
+		///     Note that setups can be verified even if this property is <see langword="false"/>:
+		///     <see cref="Mock.VerifyAll()"/> completely ignores this property.
+		///     <see cref="Mock.Verify()"/>, however, will only verify setups where this property is <see langword="true"/>.
+		///   </para>
+		/// </remarks>
+		bool IsVerifiable { get; }
+
+		/// <summary>
 		///   Gets whether this setup was matched by at least one invocation on the mock.
 		/// </summary>
 		bool WasMatched { get; }

--- a/src/Moq/InnerMockSetup.cs
+++ b/src/Moq/InnerMockSetup.cs
@@ -7,8 +7,8 @@ namespace Moq
 	{
 		private readonly object returnValue;
 
-		public InnerMockSetup(InvocationShape expectation, object returnValue)
-			: base(expectation)
+		public InnerMockSetup(Mock mock, InvocationShape expectation, object returnValue)
+			: base(mock, expectation)
 		{
 			this.returnValue = returnValue;
 

--- a/src/Moq/InnerMockSetup.cs
+++ b/src/Moq/InnerMockSetup.cs
@@ -11,9 +11,9 @@ namespace Moq
 			: base(expectation)
 		{
 			this.returnValue = returnValue;
-		}
 
-		public override bool IsVerifiable => true;
+			this.MarkAsVerifiable();
+		}
 
 		protected override void ExecuteCore(Invocation invocation)
 		{

--- a/src/Moq/Interception/InterceptionAspects.cs
+++ b/src/Moq/Interception/InterceptionAspects.cs
@@ -303,7 +303,7 @@ namespace Moq
 					if (ProxyFactory.Instance.IsMethodVisible(getter, out _))
 					{
 						propertyValue = CreateInitialPropertyValue(mock, getter);
-						getterSetup = new AutoImplementedPropertyGetterSetup(expression, getter, () => propertyValue);
+						getterSetup = new AutoImplementedPropertyGetterSetup(mock, expression, getter, () => propertyValue);
 						mock.MutableSetups.Add(getterSetup);
 					}
 
@@ -323,7 +323,7 @@ namespace Moq
 				{
 					if (ProxyFactory.Instance.IsMethodVisible(setter, out _))
 					{
-						setterSetup = new AutoImplementedPropertySetterSetup(expression, setter, (newValue) =>
+						setterSetup = new AutoImplementedPropertySetterSetup(mock, expression, setter, (newValue) =>
 						{
 							propertyValue = newValue;
 						});

--- a/src/Moq/Invocation.cs
+++ b/src/Moq/Invocation.cs
@@ -69,7 +69,7 @@ namespace Moq
 
 		public object ReturnValue => this.returnValue;
 
-		internal bool Verified => this.verified;
+		public bool WasVerified => this.verified;
 
 		/// <summary>
 		/// Ends the invocation as if a <see langword="return"/> statement occurred.

--- a/src/Moq/Language/Flow/SetupPhrase.cs
+++ b/src/Moq/Language/Flow/SetupPhrase.cs
@@ -161,12 +161,13 @@ namespace Moq.Language.Flow
 
 		public void Verifiable()
 		{
-			this.setup.Verifiable();
+			this.setup.MarkAsVerifiable();
 		}
 
 		public void Verifiable(string failMessage)
 		{
-			this.setup.Verifiable(failMessage);
+			this.setup.MarkAsVerifiable();
+			this.setup.SetFailMessage(failMessage);
 		}
 
 		public override string ToString()

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -22,18 +22,16 @@ namespace Moq
 		private Condition condition;
 		private string failMessage;
 		private Flags flags;
-		private Mock mock;
 		private RaiseEventResponse raiseEventResponse;
 		private Response returnOrThrowResponse;
 
 		private string declarationSite;
 
 		public MethodCall(Mock mock, Condition condition, InvocationShape expectation)
-			: base(expectation)
+			: base(mock, expectation)
 		{
 			this.condition = condition;
 			this.flags = expectation.Method.ReturnType != typeof(void) ? Flags.MethodIsNonVoid : 0;
-			this.mock = mock;
 
 			if ((mock.Switches & Switches.CollectDiagnosticFileInfoForSetups) != 0)
 			{
@@ -45,8 +43,6 @@ namespace Moq
 		{
 			get => this.failMessage;
 		}
-
-		public Mock Mock => this.mock;
 
 		public override Condition Condition => this.condition;
 
@@ -208,11 +204,11 @@ namespace Moq
 		{
 			Guard.NotNull(eventExpression, nameof(eventExpression));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(eventExpression, this.mock.ConstructorArguments);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(eventExpression, this.Mock.ConstructorArguments);
 
 			// TODO: validate that expression is for event subscription or unsubscription
 
-			this.raiseEventResponse = new RaiseEventResponse(this.mock, expression, func, null);
+			this.raiseEventResponse = new RaiseEventResponse(this.Mock, expression, func, null);
 		}
 
 		public void SetRaiseEventResponse<TMock>(Action<TMock> eventExpression, params object[] args)
@@ -220,11 +216,11 @@ namespace Moq
 		{
 			Guard.NotNull(eventExpression, nameof(eventExpression));
 
-			var expression = ExpressionReconstructor.Instance.ReconstructExpression(eventExpression, this.mock.ConstructorArguments);
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(eventExpression, this.Mock.ConstructorArguments);
 
 			// TODO: validate that expression is for event subscription or unsubscription
 
-			this.raiseEventResponse = new RaiseEventResponse(this.mock, expression, null, args);
+			this.raiseEventResponse = new RaiseEventResponse(this.Mock, expression, null, args);
 		}
 
 		public void SetEagerReturnsResponse(object value)

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -50,8 +50,6 @@ namespace Moq
 
 		public override Condition Condition => this.condition;
 
-		public override bool IsVerifiable => (this.flags & Flags.Verifiable) != 0;
-
 		private static string GetUserCodeCallSite()
 		{
 			try
@@ -200,6 +198,11 @@ namespace Moq
 			}
 		}
 
+		public void SetFailMessage(string failMessage)
+		{
+			this.failMessage = failMessage;
+		}
+
 		public void SetRaiseEventResponse<TMock>(Action<TMock> eventExpression, Delegate func)
 			where TMock : class
 		{
@@ -334,17 +337,6 @@ namespace Moq
 			this.limitInvocationCountResponse?.Reset();
 		}
 
-		public void Verifiable()
-		{
-			this.flags |= Flags.Verifiable;
-		}
-
-		public void Verifiable(string failMessage)
-		{
-			this.flags |= Flags.Verifiable;
-			this.failMessage = failMessage;
-		}
-
 		public void AtMost(int count)
 		{
 			this.limitInvocationCountResponse = new LimitInvocationCountResponse(this, count);
@@ -374,7 +366,6 @@ namespace Moq
 		{
 			CallBase = 1,
 			MethodIsNonVoid = 2,
-			Verifiable = 4,
 		}
 
 		private sealed class LimitInvocationCountResponse

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -294,7 +294,7 @@ namespace Moq
 			this.Verify(setup => !setup.IsOverridden && !setup.IsConditional);
 		}
 
-		private void Verify(Func<Setup, bool> predicate)
+		private void Verify(Func<ISetup, bool> predicate)
 		{
 			if (!this.TryVerify(predicate, out var error) && error.IsVerificationError)
 			{
@@ -302,7 +302,7 @@ namespace Moq
 			}
 		}
 
-		internal bool TryVerify(Func<Setup, bool> predicate, out MockException error)
+		internal bool TryVerify(Func<ISetup, bool> predicate, out MockException error)
 		{
 			foreach (Invocation invocation in this.MutableInvocations)
 			{

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -313,7 +313,7 @@ namespace Moq
 
 			foreach (var setup in this.MutableSetups.ToArray(predicate))
 			{
-				if (!setup.TryVerify(predicate, out var e) && e.IsVerificationError)
+				if (predicate(setup) && !setup.TryVerify(recursive: true, predicate, out var e) && e.IsVerificationError)
 				{
 					errors.Add(e);
 				}

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -399,7 +399,7 @@ namespace Moq
 		{
 			if (!verifiedMocks.Add(mock)) return;
 
-			var unverifiedInvocations = mock.MutableInvocations.ToArray(invocation => !invocation.Verified);
+			var unverifiedInvocations = mock.MutableInvocations.ToArray(invocation => !invocation.WasVerified);
 
 			var innerMockSetups = mock.MutableSetups.GetInnerMockSetups();
 

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -568,7 +568,7 @@ namespace Moq
 
 			return Mock.SetupRecursive(mock, expression, setupLast: (part, targetMock) =>
 			{
-				var setup = new SequenceSetup(expectation: part);
+				var setup = new SequenceSetup(targetMock, expectation: part);
 				targetMock.MutableSetups.Add(setup);
 				return setup;
 			});
@@ -607,7 +607,7 @@ namespace Moq
 								Resources.UnsupportedExpression,
 								expr.ToStringFixed() + " in " + expression.ToStringFixed() + ":\n" + Resources.TypeNotMockable));
 					}
-					setup = new InnerMockSetup(expectation: part, returnValue);
+					setup = new InnerMockSetup(mock, expectation: part, returnValue);
 					mock.MutableSetups.Add((Setup)setup);
 				}
 				Debug.Assert(innerMock != null);
@@ -804,7 +804,7 @@ namespace Moq
 				Debug.Assert(property.CanRead(out var getter) && invocation.Method == getter);
 			}
 
-			this.MutableSetups.Add(new InnerMockSetup(new InvocationShape(expression, invocation.Method, arguments, exactGenericTypeArguments: true), returnValue));
+			this.MutableSetups.Add(new InnerMockSetup(this, new InvocationShape(expression, invocation.Method, arguments, exactGenericTypeArguments: true), returnValue));
 		}
 
 		#endregion

--- a/src/Moq/SequenceSetup.cs
+++ b/src/Moq/SequenceSetup.cs
@@ -15,8 +15,8 @@ namespace Moq
 		// contains the responses set up with the `CallBase`, `Pass`, `Returns`, and `Throws` verbs
 		private ConcurrentQueue<Response> responses;
 
-		public SequenceSetup(InvocationShape expectation)
-			: base(expectation)
+		public SequenceSetup(Mock mock, InvocationShape expectation)
+			: base(mock, expectation)
 		{
 			this.responses = new ConcurrentQueue<Response>();
 		}

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -132,7 +132,7 @@ namespace Moq
 		///   <see langword="true"/> if verification succeeded without any errors;
 		///   otherwise, <see langword="false"/>.
 		/// </returns>
-		public bool TryVerify(Func<Setup, bool> predicate, out MockException error)
+		public bool TryVerify(Func<ISetup, bool> predicate, out MockException error)
 		{
 			if (predicate(this))
 			{

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -31,7 +31,7 @@ namespace Moq
 
 		public bool IsOverridden => (this.flags & Flags.Overridden) != 0;
 
-		public virtual bool IsVerifiable => false;
+		public bool IsVerifiable => (this.flags & Flags.Verifiable) != 0;
 
 		public MethodInfo Method => this.expectation.Method;
 
@@ -75,6 +75,11 @@ namespace Moq
 			Debug.Assert(!this.IsOverridden);
 
 			this.flags |= Flags.Overridden;
+		}
+
+		public void MarkAsVerifiable()
+		{
+			this.flags |= Flags.Verifiable;
 		}
 
 		public bool Matches(Invocation invocation)
@@ -174,6 +179,7 @@ namespace Moq
 		{
 			Matched = 1,
 			Overridden = 2,
+			Verifiable = 4,
 		}
 	}
 }

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -191,6 +191,11 @@ namespace Moq
 
 		private void Verify(bool recursive, Func<ISetup, bool> predicate)
 		{
+			foreach (Invocation invocation in this.mock.MutableInvocations)
+			{
+				invocation.MarkAsVerifiedIfMatchedBy(setup => setup == this);
+			}
+
 			if (!this.TryVerify(recursive, predicate, out var error) && error.IsVerificationError)
 			{
 				throw error;

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -12,13 +12,16 @@ namespace Moq
 	internal abstract class Setup : ISetup
 	{
 		private readonly InvocationShape expectation;
+		private readonly Mock mock;
 		private Flags flags;
 
-		protected Setup(InvocationShape expectation)
+		protected Setup(Mock mock, InvocationShape expectation)
 		{
+			Debug.Assert(mock != null);
 			Debug.Assert(expectation != null);
 
 			this.expectation = expectation;
+			this.mock = mock;
 		}
 
 		public virtual Condition Condition => null;
@@ -34,6 +37,8 @@ namespace Moq
 		public bool IsVerifiable => (this.flags & Flags.Verifiable) != 0;
 
 		public MethodInfo Method => this.expectation.Method;
+
+		public Mock Mock => this.mock;
 
 		public bool WasMatched => (this.flags & Flags.Matched) != 0;
 

--- a/src/Moq/SetupWithOutParameterSupport.cs
+++ b/src/Moq/SetupWithOutParameterSupport.cs
@@ -15,8 +15,8 @@ namespace Moq
 	{
 		private readonly List<KeyValuePair<int, object>> outValues;
 
-		protected SetupWithOutParameterSupport(InvocationShape expectation)
-			: base(expectation)
+		protected SetupWithOutParameterSupport(Mock mock, InvocationShape expectation)
+			: base(mock, expectation)
 		{
 			Debug.Assert(expectation != null);
 

--- a/tests/Moq.Tests/SetupFixture.cs
+++ b/tests/Moq.Tests/SetupFixture.cs
@@ -209,6 +209,80 @@ namespace Moq.Tests
 			Assert.Throws<MockException>(() => setup.VerifyAll());
 		}
 
+		[Fact]
+		public void Verify_marks_invocations_matched_by_setup_as_verified()
+		{
+			var mock = new Mock<object>();
+			mock.Setup(m => m.ToString());
+			var setup = mock.Setups.First();
+
+			_ = mock.Object.ToString();
+			_ = mock.Object.ToString();
+
+			Assert.All(mock.Invocations, i => Assert.False(i.WasVerified));
+
+			setup.Verify();
+
+			Assert.All(mock.Invocations, i => Assert.True(i.WasVerified));
+			mock.VerifyNoOtherCalls();
+		}
+
+		[Fact]
+		public void VerifyAll_marks_invocations_matched_by_setup_as_verified()
+		{
+			var mock = new Mock<object>();
+			mock.Setup(m => m.ToString());
+			var setup = mock.Setups.First();
+
+			_ = mock.Object.ToString();
+			_ = mock.Object.ToString();
+
+			Assert.All(mock.Invocations, i => Assert.False(i.WasVerified));
+
+			setup.VerifyAll();
+
+			Assert.All(mock.Invocations, i => Assert.True(i.WasVerified));
+			mock.VerifyNoOtherCalls();
+		}
+
+		[Fact]
+		public void Verify_marks_invocation_matched_by_verifiable_inner_mock_setup_as_verified()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inner.Property).Verifiable();
+			var setup = mock.Setups.First();
+
+			var innerMock = mock.Object.Inner;
+			_ = innerMock.Property;
+			var innerMockInvocation = Mock.Get(innerMock).Invocations.First();
+
+			Assert.False(innerMockInvocation.WasVerified);
+
+			setup.Verify();
+
+			Assert.True(innerMockInvocation.WasVerified);
+			mock.VerifyNoOtherCalls();
+		}
+
+		[Fact]
+		public void VerifyAll_marks_invocation_matched_by_inner_mock_setup_as_verified()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inner.Property);
+			var setup = mock.Setups.First();
+
+			var innerMock = mock.Object.Inner;
+			_ = innerMock.Property;
+			var innerMockInvocation = Mock.Get(innerMock).Invocations.First();
+
+			Assert.False(innerMockInvocation.WasVerified);
+
+			setup.VerifyAll();
+
+			Assert.True(innerMockInvocation.WasVerified);
+			mock.VerifyNoOtherCalls();
+		}
+
 		public interface IX
 		{
 			IX Inner { get; }

--- a/tests/Moq.Tests/SetupFixture.cs
+++ b/tests/Moq.Tests/SetupFixture.cs
@@ -77,6 +77,34 @@ namespace Moq.Tests
 			Assert.True(setup.IsOverridden);
 		}
 
+		[Fact]
+		public void IsVerifiable_becomes_true_if_parameterless_Verifiable_setup_method_is_called()
+		{
+			var mock = new Mock<object>();
+			var setupBuilder = mock.Setup(m => m.ToString());
+			var setup = mock.Setups.First();
+
+			Assert.False(setup.IsVerifiable);
+
+			setupBuilder.Verifiable();
+
+			Assert.True(setup.IsVerifiable);
+		}
+
+		[Fact]
+		public void IsVerifiable_becomes_true_if_parameterized_Verifiable_setup_method_is_called()
+		{
+			var mock = new Mock<object>();
+			var setupBuilder = mock.Setup(m => m.ToString());
+			var setup = mock.Setups.First();
+
+			Assert.False(setup.IsVerifiable);
+
+			setupBuilder.Verifiable(failMessage: "...");
+
+			Assert.True(setup.IsVerifiable);
+		}
+
 		public interface IX
 		{
 			IX Inner { get; }

--- a/tests/Moq.Tests/SetupFixture.cs
+++ b/tests/Moq.Tests/SetupFixture.cs
@@ -105,6 +105,110 @@ namespace Moq.Tests
 			Assert.True(setup.IsVerifiable);
 		}
 
+		[Fact]
+		public void Verify_fails_on_unmatched_setup_even_when_not_flagged_as_verifiable()
+		{
+			var mock = new Mock<object>();
+			mock.Setup(m => m.ToString());
+			var setup = mock.Setups.First();
+
+			Assert.False(setup.IsVerifiable);  // the root setup should be verified despite this
+			Assert.False(setup.WasMatched);
+			Assert.Throws<MockException>(() => setup.Verify());
+		}
+
+		[Fact]
+		public void Verify_succeeds_on_matched_setup()
+		{
+			var mock = new Mock<object>();
+			mock.Setup(m => m.ToString());
+			var setup = mock.Setups.First();
+
+			_ = mock.Object.ToString();
+
+			Assert.False(setup.IsVerifiable);
+			Assert.True(setup.WasMatched);
+			setup.Verify();
+		}
+
+		[Fact]
+		public void Verify_fails_on_matched_setup_having_unmatched_verifiable_setup_on_inner_mock()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inner.Property).Verifiable();
+			var setup = mock.Setups.First();
+
+			var innerMock = mock.Object.Inner;
+			var innerMockSetup = Mock.Get(innerMock).Setups.First();
+
+			Assert.True(setup.WasMatched);
+			Assert.True(innerMockSetup.IsVerifiable);
+			Assert.False(innerMockSetup.WasMatched);  // this should make recursive verification fail
+			Assert.Throws<MockException>(() => setup.Verify());
+		}
+
+		[Fact]
+		public void Verify_succeeds_on_matched_setup_having_unmatched_setup_on_inner_mock()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inner.Property);
+			var setup = mock.Setups.First();
+
+			var innerMock = mock.Object.Inner;
+			var innerMockSetup = Mock.Get(innerMock).Setups.First();
+
+			Assert.True(setup.WasMatched);
+			Assert.False(innerMockSetup.IsVerifiable);  // which means that the inner mock setup will be ignored
+			Assert.False(innerMockSetup.WasMatched);  // this would make verification fail if that setup were not ignored
+			setup.Verify();
+		}
+
+		[Fact]
+		public void Verify_succeeds_on_matched_setup_having_unmatched_verifiable_setup_on_inner_mock_if_recursive_set_to_false()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inner.Property).Verifiable();
+			var setup = mock.Setups.First();
+
+			var innerMock = mock.Object.Inner;
+			var innerMockSetup = Mock.Get(innerMock).Setups.First();
+
+			Assert.True(setup.WasMatched);
+			Assert.True(innerMockSetup.IsVerifiable);
+			Assert.False(innerMockSetup.WasMatched);
+			setup.Verify(recursive: false);  // which means that verification will never get to `innerMockSetup`
+		}
+
+		[Fact]
+		public void VerifyAll_is_always_recursive()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inner.Property).Verifiable();
+			var setup = mock.Setups.First();
+
+			var innerMock = mock.Object.Inner;
+			var innerMockSetup = Mock.Get(innerMock).Setups.First();
+
+			Assert.True(setup.WasMatched);
+			Assert.False(innerMockSetup.WasMatched);  // this will make verification fail only if it is recursive
+			Assert.Throws<MockException>(() => setup.VerifyAll());
+		}
+
+		[Fact]
+		public void VerifyAll_includes_non_verifiable_setups()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inner.Property);
+			var setup = mock.Setups.First();
+
+			var innerMock = mock.Object.Inner;
+			var innerMockSetup = Mock.Get(innerMock).Setups.First();
+
+			Assert.True(setup.WasMatched);
+			Assert.False(innerMockSetup.IsVerifiable);  // this should not exclude the inner mock setup from verification
+			Assert.Throws<MockException>(() => setup.VerifyAll());
+		}
+
 		public interface IX
 		{
 			IX Inner { get; }

--- a/tests/Moq.Tests/VerifyFixture.cs
+++ b/tests/Moq.Tests/VerifyFixture.cs
@@ -1117,10 +1117,10 @@ namespace Moq.Tests
 			mock.Object.Submit();
 
 			var invocation = mock.MutableInvocations.ToArray()[0];
-			Assert.False(invocation.Verified);
+			Assert.False(invocation.WasVerified);
 
 			mock.Verify(m => m.Submit());
-			Assert.True(invocation.Verified);
+			Assert.True(invocation.WasVerified);
 		}
 
 		[Fact]
@@ -1132,14 +1132,14 @@ namespace Moq.Tests
 			mock.Object.Echo(3);
 
 			var invocations = mock.MutableInvocations.ToArray();
-			Assert.False(invocations[0].Verified);
-			Assert.False(invocations[1].Verified);
-			Assert.False(invocations[2].Verified);
+			Assert.False(invocations[0].WasVerified);
+			Assert.False(invocations[1].WasVerified);
+			Assert.False(invocations[2].WasVerified);
 
 			mock.Verify(m => m.Echo(It.Is<int>(i => i != 2)));
-			Assert.True(invocations[0].Verified);
-			Assert.False(invocations[1].Verified);
-			Assert.True(invocations[2].Verified);
+			Assert.True(invocations[0].WasVerified);
+			Assert.False(invocations[1].WasVerified);
+			Assert.True(invocations[2].WasVerified);
 		}
 
 		[Fact]
@@ -1151,14 +1151,14 @@ namespace Moq.Tests
 			mock.Object.Echo(3);
 
 			var invocations = mock.MutableInvocations.ToArray();
-			Assert.False(invocations[0].Verified);
-			Assert.False(invocations[1].Verified);
-			Assert.False(invocations[2].Verified);
+			Assert.False(invocations[0].WasVerified);
+			Assert.False(invocations[1].WasVerified);
+			Assert.False(invocations[2].WasVerified);
 
 			Assert.Throws<MockException>(() => mock.Verify(m => m.Echo(It.Is<int>(i => i != 2)), Times.Exactly(1)));
-			Assert.False(invocations[0].Verified);
-			Assert.False(invocations[1].Verified);
-			Assert.False(invocations[2].Verified);
+			Assert.False(invocations[0].WasVerified);
+			Assert.False(invocations[1].WasVerified);
+			Assert.False(invocations[2].WasVerified);
 		}
 
 		[Fact]


### PR DESCRIPTION
This adds `void Verify(bool recursive = true)` and `void VerifyAll()` methods to `ISetup`.