### PR TITLE
Expose `Mock.Setups`, part 4: Mock, fluent setup & inner mock discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 #### Added
 
- * A mock's setups can now be inspected and individually verified via the new `Mock.Setups` collection and `IInvocation.WasMatched` method (@stakx, #984-#987)
+ * A mock's setups can now be inspected and individually verified via the new `Mock.Setups` collection and `IInvocation.WasMatched` method (@stakx, #984-#987, #989)
 
  * New `.Protected().Setup` and `Protected().Verify` method overloads to deal with generic methods (@JmlSaul, #967)
 

--- a/src/Moq/AutoImplementedPropertyGetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertyGetterSetup.cs
@@ -17,7 +17,7 @@ namespace Moq
 		private Func<object> getter;
 
 		public AutoImplementedPropertyGetterSetup(Mock mock, LambdaExpression originalExpression, MethodInfo method, Func<object> getter)
-			: base(mock, new InvocationShape(originalExpression, method, noArguments))
+			: base(fluentSetup: null, mock, new InvocationShape(originalExpression, method, noArguments))
 		{
 			this.getter = getter;
 

--- a/src/Moq/AutoImplementedPropertySetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertySetterSetup.cs
@@ -16,7 +16,7 @@ namespace Moq
 		private Action<object> setter;
 
 		public AutoImplementedPropertySetterSetup(Mock mock, LambdaExpression originalExpression, MethodInfo method, Action<object> setter)
-			: base(mock, new InvocationShape(originalExpression, method, new Expression[] { It.IsAny(method.GetParameterTypes().Last()) }))
+			: base(fluentSetup: null, mock, new InvocationShape(originalExpression, method, new Expression[] { It.IsAny(method.GetParameterTypes().Last()) }))
 		{
 			this.setter = setter;
 

--- a/src/Moq/FluentSetup.cs
+++ b/src/Moq/FluentSetup.cs
@@ -1,0 +1,118 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+
+namespace Moq
+{
+	internal sealed class FluentSetup : IFluentSetup
+	{
+		private readonly LambdaExpression expression;
+		private List<ISetup> parts;
+#if DEBUG
+		private bool complete;
+#endif
+
+		public FluentSetup(LambdaExpression expression)
+		{
+			Debug.Assert(expression != null);
+
+			this.expression = expression;
+		}
+
+		public LambdaExpression Expression => this.expression;
+
+		public bool IsConditional => this.parts.First().IsConditional;
+
+		public bool IsOverridden => this.parts.Any(p => p.IsOverridden);
+
+		public bool IsVerifiable => this.parts.Last().IsVerifiable;
+
+		public IReadOnlyList<ISetup> Parts => this.parts;
+
+		public bool WasMatched => this.parts.All(p => p.WasMatched);
+
+		public void AddPart(ISetup part)
+		{
+#if DEBUG
+			// NOTE: This operation is not thread-safe, and it probably doesn't need to be.
+			// This `FluentSetup` instance shouldn't be accessible until `Mock.SetupRecursive` is done
+			// and the first part is added to the root mock's `Setup` collection. At that time,
+			// all setup parts should have been added to this instance. Let's verify this assumption
+			// with a debug-only 'complete' flag:
+			Debug.Assert(!this.complete);
+#endif
+
+			if (this.parts == null)
+			{
+				this.parts = new List<ISetup>();
+			}
+
+			this.parts.Add(part);
+		}
+
+#if DEBUG
+		public void MarkAsComplete()
+		{
+			this.complete = true;
+		}
+#endif
+
+		public bool IsPartOfFluentSetup(out IFluentSetup fluentSetup)
+		{
+			fluentSetup = null;
+			return false;
+		}
+
+		public bool? ReturnsMock(out Mock innerMock)
+		{
+			return this.parts.Last().ReturnsMock(out innerMock);
+		}
+
+		public override string ToString()
+		{
+			var mockedType = this.expression.Parameters[0].Type;
+
+			var builder = new StringBuilder();
+			builder.AppendNameOf(mockedType)
+			       .Append(' ')
+			       .Append(expression.PartialMatcherAwareEval().ToStringFixed());
+
+			return builder.ToString();
+		}
+
+		public void Verify(bool recursive = true)
+		{
+			this.Verify(lastPart => lastPart.Verify(recursive));
+		}
+
+		public void VerifyAll()
+		{
+			this.Verify(lastPart => lastPart.VerifyAll());
+		}
+
+		private void Verify(Action<ISetup> verifyLast)
+		{
+			Debug.Assert(verifyLast != null);
+			Debug.Assert(this.parts.Count > 1);
+
+			try
+			{
+				foreach (var part in this.parts.Take(this.parts.Count - 1))
+				{
+					part.Verify(recursive: false);
+				}
+				verifyLast(this.parts.Last());
+			}
+			catch (MockException error) when (error.IsVerificationError)
+			{
+				throw MockException.FromInnerMockOf(this, error);
+			}
+		}
+	}
+}

--- a/src/Moq/FluentSetup.cs
+++ b/src/Moq/FluentSetup.cs
@@ -33,6 +33,8 @@ namespace Moq
 
 		public bool IsVerifiable => this.parts.Last().IsVerifiable;
 
+		public Mock Mock => this.parts.First().Mock;
+
 		public IReadOnlyList<ISetup> Parts => this.parts;
 
 		public bool WasMatched => this.parts.All(p => p.WasMatched);

--- a/src/Moq/IFluentSetup.cs
+++ b/src/Moq/IFluentSetup.cs
@@ -1,0 +1,41 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.Collections.Generic;
+
+namespace Moq
+{
+	/// <summary>
+	///   A composite setup that spans across more than one mock.
+	///   <para>
+	///     Fluent setups result from setup expressions that involve member chaining,
+	///     such as <c>`parent => parent.Child.Member`</c>.
+	///   </para>
+	/// </summary>
+	/// <example>
+	///   The following statement will not create one, but two setups:
+	///   <code>
+	///     parentMock.Setup(parent => parent.Child.Member);
+	///   </code>
+	///   The setup expression is first split up such that each part refers to just one member:
+	///   <list type="number">
+	///     <item><c>`parent => parent.Child`</c>; and</item>
+	///     <item><c>`(child) => (child).Member`</c>.</item>
+	///   </list>
+	///   The first expression is set up on <c>`parentMock`</c>.
+	///   This setup is configured to return a <c>`Mock&lt;Child&gt;`</c> (<c>`parentMock`</c>'s so-called "inner mock").
+	///   The second expression is then set up on that inner mock.
+	/// </example>
+	public interface IFluentSetup : ISetup
+	{
+		/// <summary>
+		///   Gets the partial setups that together make up this fluent setup,
+		///   in left-to-right order (that is, setup for leftmost sub-expression first, setup for rightmost sub-expression last).
+		/// </summary>
+		/// <remarks>
+		///   Each setup in this collection will typically belong to a different mock.
+		///   Given two adjacent setups, the former is configured to return the mock to which the latter setup belongs.
+		/// </remarks>
+		IReadOnlyList<ISetup> Parts { get; }
+	}
+}

--- a/src/Moq/ISetup.cs
+++ b/src/Moq/ISetup.cs
@@ -43,6 +43,11 @@ namespace Moq
 		bool IsVerifiable { get; }
 
 		/// <summary>
+		///   Returns the <see cref="Mock"/> instance to which this setup belongs.
+		/// </summary>
+		Mock Mock { get; }
+
+		/// <summary>
 		///   Gets whether this setup was matched by at least one invocation on the mock.
 		/// </summary>
 		bool WasMatched { get; }

--- a/src/Moq/ISetup.cs
+++ b/src/Moq/ISetup.cs
@@ -48,6 +48,22 @@ namespace Moq
 		bool WasMatched { get; }
 
 		/// <summary>
+		///   Gets whether this setup is part of a "fluent" setup
+		///   (that is, one with a setup expression involving member chaining).
+		///   If so, the fluent setup of which this one is a part is returned via the <see langword="out"/> parameter <paramref name="fluentSetup"/>.
+		/// </summary>
+		/// <param name="fluentSetup">
+		///   If this setup is part of a fluent setup,
+		///   this <see langword="out"/> parameter will be set to the latter.
+		/// </param>
+		/// <returns>
+		///   <see langword="true"/> if this setup is part of a fluent setup;
+		///   otherwise, <see langword="false"/>.
+		/// </returns>
+		/// <seealso cref="IFluentSetup"/>
+		bool IsPartOfFluentSetup(out IFluentSetup fluentSetup);
+
+		/// <summary>
 		///   Gets whether this setup returns a mock object.
 		///   If so, the corresponding <see cref="Mock"/> instance is returned via the <see langword="out"/> parameter <paramref name="innerMock"/>.
 		/// </summary>

--- a/src/Moq/ISetup.cs
+++ b/src/Moq/ISetup.cs
@@ -48,6 +48,23 @@ namespace Moq
 		bool WasMatched { get; }
 
 		/// <summary>
+		///   Gets whether this setup returns a mock object.
+		///   If so, the corresponding <see cref="Mock"/> instance is returned via the <see langword="out"/> parameter <paramref name="innerMock"/>.
+		/// </summary>
+		/// <param name="innerMock">
+		///   If this setup returns a mock object,
+		///   this <see langword="out"/> parameter will be set to the corresponding <see cref="Mock"/> instance.
+		/// </param>
+		/// <returns>
+		///   <list type="bullet">
+		///     <item><see langword="true"/> if this setup returns a mock object;</item>
+		///     <item><see langword="false"/> if it does not return a mock object;</item>
+		///     <item><see langword="null"/> if the return value cannot be determined without risking any side effects.</item>
+		///   </list>
+		/// </returns>
+		bool? ReturnsMock(out Mock innerMock);
+
+		/// <summary>
 		///   Verifies this setup and optionally all verifiable setups of its inner mock (if present and known).
 		///   <para>
 		///     If <paramref name="recursive"/> is set to <see langword="true"/>,

--- a/src/Moq/InnerMockSetup.cs
+++ b/src/Moq/InnerMockSetup.cs
@@ -7,8 +7,8 @@ namespace Moq
 	{
 		private readonly object returnValue;
 
-		public InnerMockSetup(Mock mock, InvocationShape expectation, object returnValue)
-			: base(mock, expectation)
+		public InnerMockSetup(FluentSetup fluentSetup, Mock mock, InvocationShape expectation, object returnValue)
+			: base(fluentSetup, mock, expectation)
 		{
 			this.returnValue = returnValue;
 

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -27,8 +27,8 @@ namespace Moq
 
 		private string declarationSite;
 
-		public MethodCall(Mock mock, Condition condition, InvocationShape expectation)
-			: base(mock, expectation)
+		public MethodCall(FluentSetup fluentSetup, Mock mock, Condition condition, InvocationShape expectation)
+			: base(fluentSetup, mock, expectation)
 		{
 			this.condition = condition;
 			this.flags = expectation.Method.ReturnType != typeof(void) ? Flags.MethodIsNonVoid : 0;

--- a/src/Moq/MockException.cs
+++ b/src/Moq/MockException.cs
@@ -169,7 +169,7 @@ namespace Moq
 					setup));
 		}
 
-		internal static MockException FromInnerMockOf(Setup setup, MockException error)
+		internal static MockException FromInnerMockOf(ISetup setup, MockException error)
 		{
 			var message = new StringBuilder();
 

--- a/src/Moq/SequenceSetup.cs
+++ b/src/Moq/SequenceSetup.cs
@@ -15,8 +15,8 @@ namespace Moq
 		// contains the responses set up with the `CallBase`, `Pass`, `Returns`, and `Throws` verbs
 		private ConcurrentQueue<Response> responses;
 
-		public SequenceSetup(Mock mock, InvocationShape expectation)
-			: base(mock, expectation)
+		public SequenceSetup(FluentSetup fluentSetup, Mock mock, InvocationShape expectation)
+			: base(fluentSetup, mock, expectation)
 		{
 			this.responses = new ConcurrentQueue<Response>();
 		}

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -12,14 +12,16 @@ namespace Moq
 	internal abstract class Setup : ISetup
 	{
 		private readonly InvocationShape expectation;
+		private readonly FluentSetup fluentSetup;
 		private readonly Mock mock;
 		private Flags flags;
 
-		protected Setup(Mock mock, InvocationShape expectation)
+		protected Setup(FluentSetup fluentSetup, Mock mock, InvocationShape expectation)
 		{
 			Debug.Assert(mock != null);
 			Debug.Assert(expectation != null);
 
+			this.fluentSetup = fluentSetup;
 			this.expectation = expectation;
 			this.mock = mock;
 		}
@@ -41,6 +43,11 @@ namespace Moq
 		public Mock Mock => this.mock;
 
 		public bool WasMatched => (this.flags & Flags.Matched) != 0;
+
+		public bool IsPartOfFluentSetup(out IFluentSetup fluentSetup)
+		{
+			return (fluentSetup = this.fluentSetup) != null;
+		}
 
 		public void Execute(Invocation invocation)
 		{

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -94,15 +94,28 @@ namespace Moq
 
 		public bool ReturnsInnerMock(out Mock mock)
 		{
-			if (this.TryGetReturnValue(out var returnValue) && Unwrap.ResultIfCompletedTask(returnValue) is IMocked mocked)
+			return this.ReturnsMock(out mock) == true;
+		}
+
+		public bool? ReturnsMock(out Mock mock)
+		{
+			if (this.TryGetReturnValue(out var returnValue))
 			{
-				mock = mocked.Mock;
-				return true;
+				if (Unwrap.ResultIfCompletedTask(returnValue) is IMocked mocked)
+				{
+					mock = mocked.Mock;
+					return true;
+				}
+				else
+				{
+					mock = null;
+					return false;
+				}
 			}
 			else
 			{
 				mock = null;
-				return false;
+				return null;
 			}
 		}
 

--- a/src/Moq/SetupWithOutParameterSupport.cs
+++ b/src/Moq/SetupWithOutParameterSupport.cs
@@ -15,8 +15,8 @@ namespace Moq
 	{
 		private readonly List<KeyValuePair<int, object>> outValues;
 
-		protected SetupWithOutParameterSupport(Mock mock, InvocationShape expectation)
-			: base(mock, expectation)
+		protected SetupWithOutParameterSupport(FluentSetup fluentSetup, Mock mock, InvocationShape expectation)
+			: base(fluentSetup, mock, expectation)
 		{
 			Debug.Assert(expectation != null);
 

--- a/tests/Moq.Tests/SetupFixture.cs
+++ b/tests/Moq.Tests/SetupFixture.cs
@@ -1,7 +1,9 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using System;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 
 using Xunit;
@@ -107,6 +109,157 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public void IsPartOfFluentSetup_returns_false_for_simple_property_access()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inner);
+			var setup = mock.Setups.First();
+
+			Assert.False(setup.IsPartOfFluentSetup(out _));
+		}
+
+		[Fact]
+		public void IsPartOfFluentSetup_returns_false_for_simple_indexer_access()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m[1]);
+			var setup = mock.Setups.First();
+
+			Assert.False(setup.IsPartOfFluentSetup(out _));
+		}
+
+		[Fact]
+		public void IsPartOfFluentSetup_returns_false_for_simple_method_call()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.ToString());
+			var setup = mock.Setups.First();
+
+			Assert.False(setup.IsPartOfFluentSetup(out _));
+		}
+
+		[Fact]
+		public void IsPartOfFluentSetup_returns_false_for_simple_expression_in_Mock_Of()
+		{
+			var mockObject = Mock.Of<IX>(m => m.Property == null);
+			var setup = Mock.Get(mockObject).Setups.First();
+
+			Assert.False(setup.IsPartOfFluentSetup(out _));
+		}
+
+		[Fact]
+		public void IsPartOfFluentSetup_returns_true_for_multi_dot_expression()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inner.ToString());
+			var setup = mock.Setups.First();
+
+			Assert.True(setup.IsPartOfFluentSetup(out var fluentSetup));
+			Assert.NotNull(fluentSetup);
+		}
+
+		[Fact]
+		public void IsPartOfFluentSetup_returns_true_for_multi_dot_expression_in_Mock_Of()
+		{
+			var mockObject = Mock.Of<IX>(m => m.Inner.Property == null);
+			var setup = Mock.Get(mockObject).Setups.First();
+
+			Assert.True(setup.IsPartOfFluentSetup(out var fluentSetup));
+			Assert.NotNull(fluentSetup);
+		}
+
+		[Fact]
+		public void IsPartOfFluentSetup_returns_fluent_setup_for_whole_multi_dot_expression()
+		{
+			Expression<Func<IX, string>> setupExpression = m => m.Inner[1].ToString();
+			var mock = new Mock<IX>();
+			mock.Setup(setupExpression);
+			var setup = mock.Setups.First();
+
+			Assert.True(setup.IsPartOfFluentSetup(out var fluentSetup));
+			Assert.Equal(setupExpression, fluentSetup.Expression, ExpressionComparer.Default);
+		}
+
+		[Fact]
+		public void IsPartOfFluentSetup_returns_fluent_setup_for_multi_dot_expression_on_left_hand_side_in_Mock_Of()
+		{
+			Expression<Func<IX, bool>> mockSpecification = m => m.Inner[1].ToString() == "";
+			Expression<Func<IX, string>> setupExpression = m => m.Inner[1].ToString();
+			var mockObject = Mock.Of<IX>(mockSpecification);
+			var setup = Mock.Get(mockObject).Setups.First();
+
+			Assert.True(setup.IsPartOfFluentSetup(out var fluentSetup));
+			Assert.Equal(setupExpression, fluentSetup.Expression, ExpressionComparer.Default);
+		}
+
+		[Fact]
+		public void IsPartOfFluentSetup_returns_fluent_setup_where_each_part_belongs_to_it()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inner[1].ToString());
+			var setup = mock.Setups.First();
+
+			Assert.True(setup.IsPartOfFluentSetup(out var expectedFluentSetup));
+			Assert.All(expectedFluentSetup.Parts, part =>
+			{
+				Assert.True(part.IsPartOfFluentSetup(out var actualFluentSetup));
+				Assert.Same(expectedFluentSetup, actualFluentSetup);
+			});
+		}
+
+		[Fact]
+		public void IsPartOfFluentSetup_Verify_succeeds_if_all_parts_of_expression_were_matched_even_when_recursive_false()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inner[1].ToString());
+			_ = mock.Setups.First().IsPartOfFluentSetup(out var fluentSetup);
+
+			_ = mock.Object.Inner[1].ToString();
+
+			// `recursive` should not have any effect because `fluentSetup` is logically a single setup
+			// (even though internally it has several parts), so there is no inner mock to proceed to.
+			fluentSetup.Verify(recursive: false);
+		}
+
+		[Fact]
+		public void IsPartOfFluentSetup_Verify_fails_if_not_all_parts_of_expression_were_matched()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inner[1].ToString());
+			_ = mock.Setups.First().IsPartOfFluentSetup(out var fluentSetup);
+
+			_ = mock.Object.Inner[1];
+
+			Assert.Throws<MockException>(() => fluentSetup.Verify());
+		}
+
+		[Fact]
+		public void IsPartOfFluentSetup_Verify_with_recursive_true_fails_if_inner_mock_has_unmatched_setup()
+		{
+			var innerMock = new Mock<IX>();
+			innerMock.Setup(m => m.OtherProperty).Verifiable();
+
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inner[1].Property).Returns(innerMock.Object);
+			_ = mock.Setups.First().IsPartOfFluentSetup(out var fluentSetup);
+
+			_ = mock.Object.Inner[1].Property;
+
+			fluentSetup.Verify(recursive: false);  // it isn't the composite setup itself that should fail verification...
+			Assert.Throws<MockException>(() => fluentSetup.Verify(recursive: true));  // ...but its inner mock.
+		}
+
+		[Fact]
+		public void IsPartOfFluentSetup_of_fluent_setup_returns_false()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inner[1].Property);
+			_ = mock.Setups.First().IsPartOfFluentSetup(out var fluentSetup);
+
+			Assert.False(fluentSetup.IsPartOfFluentSetup(out _));
+		}
+
+		[Fact]
 		public void ReturnsMock_returns_null_if_return_value_cannot_be_determined_safely()
 		{
 			var mock = new Mock<IX>();
@@ -182,6 +335,29 @@ namespace Moq.Tests
 
 			Assert.True(setup.ReturnsMock(out var actualInnerMock));
 			Assert.Same(expectedInnerMock, actualInnerMock);
+		}
+
+		[Fact]
+		public void ReturnsMock_of_fluent_setup_without_inner_mock()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inner[1].Property);
+			_ = mock.Setups.First().IsPartOfFluentSetup(out var fluentSetup);
+
+			Assert.True(fluentSetup.ReturnsMock(out _) != true);  // sic! (three-valued logic)
+		}
+
+		[Fact]
+		public void ReturnsMock_of_fluent_setup_with_inner_mock()
+		{
+			var innerMock = new Mock<IX>();
+			innerMock.Setup(m => m.OtherProperty);
+
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inner[1].Property).Returns(innerMock.Object);
+			_ = mock.Setups.First().IsPartOfFluentSetup(out var fluentSetup);
+
+			Assert.True(fluentSetup.ReturnsMock(out _));
 		}
 
 		[Fact]
@@ -364,8 +540,10 @@ namespace Moq.Tests
 
 		public interface IX
 		{
+			IX this[int index] { get; }
 			IX Inner { get; }
 			object Property { get; set; }
+			object OtherProperty { get; set; }
 			Task<IX> GetInnerTaskAsync();
 			ValueTask<IX> GetInnerValueTaskAsync();
 		}

--- a/tests/Moq.Tests/SetupFixture.cs
+++ b/tests/Moq.Tests/SetupFixture.cs
@@ -2,6 +2,7 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System.Linq;
+using System.Threading.Tasks;
 
 using Xunit;
 
@@ -103,6 +104,84 @@ namespace Moq.Tests
 			setupBuilder.Verifiable(failMessage: "...");
 
 			Assert.True(setup.IsVerifiable);
+		}
+
+		[Fact]
+		public void ReturnsMock_returns_null_if_return_value_cannot_be_determined_safely()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inner).Returns(() => Mock.Of<IX>());
+			var setup = mock.Setups.First();
+
+			Assert.Null(setup.ReturnsMock(out _));
+		}
+
+		[Fact]
+		public void ReturnsMock_returns_false_if_return_value_can_be_determined_but_is_not_a_mock()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inner).Returns((IX)null);
+			var setup = mock.Setups.First();
+
+			Assert.False(setup.ReturnsMock(out _));
+		}
+
+		[Fact]
+		public void ReturnsMock_returns_true_if_return_value_can_be_determined_and_is_a_mock()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inner).Returns(Mock.Of<IX>());
+			var setup = mock.Setups.First();
+
+			Assert.True(setup.ReturnsMock(out var innerMock));
+			Assert.IsAssignableFrom<Mock<IX>>(innerMock);
+		}
+
+		[Fact]
+		public void ReturnsMock_returns_true_if_Task_async_return_value_can_be_determined_and_is_a_mock()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.GetInnerTaskAsync()).Returns(Task.FromResult<IX>(Mock.Of<IX>()));
+			var setup = mock.Setups.First();
+
+			Assert.True(setup.ReturnsMock(out var innerMock));
+			Assert.IsAssignableFrom<Mock<IX>>(innerMock);
+		}
+
+		[Fact]
+		public void ReturnsMock_returns_true_if_ValueTask_async_return_value_can_be_determined_and_is_a_mock()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.GetInnerValueTaskAsync()).Returns(new ValueTask<IX>(Mock.Of<IX>()));
+			var setup = mock.Setups.First();
+
+			Assert.True(setup.ReturnsMock(out var innerMock));
+			Assert.IsAssignableFrom<Mock<IX>>(innerMock);
+		}
+
+		[Fact]
+		public void ReturnsMock_returns_correct_inner_mock_explicitly_setup_up()
+		{
+			var expectedInnerMock = new Mock<IX>();
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inner).Returns(expectedInnerMock.Object);
+			var setup = mock.Setups.First();
+
+			Assert.True(setup.ReturnsMock(out var actualInnerMock));
+			Assert.Same(expectedInnerMock, actualInnerMock);
+		}
+
+		[Fact]
+		public void ReturnsMock_returns_correct_inner_mock_implicitly_setup_up_via_multi_dot_expression()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inner.Property);
+			var setup = mock.Setups.First();
+
+			var expectedInnerMock = Mock.Get(mock.Object.Inner);
+
+			Assert.True(setup.ReturnsMock(out var actualInnerMock));
+			Assert.Same(expectedInnerMock, actualInnerMock);
 		}
 
 		[Fact]
@@ -287,6 +366,8 @@ namespace Moq.Tests
 		{
 			IX Inner { get; }
 			object Property { get; set; }
+			Task<IX> GetInnerTaskAsync();
+			ValueTask<IX> GetInnerValueTaskAsync();
 		}
 	}
 }


### PR DESCRIPTION
This adds one new property and two new methods to `ISetup`:

* `Mock Mock { get; }` to find the mock to which a setup belongs;

* `bool? ReturnsMock(out Mock innerMock)` to get at a setup's inner mock (e.g. when doing recursive verification);

* `bool IsPartOfFluentSetup(out IFluentSetup fluentSetup)` to get at the original "fluent" setup expression for those setups that have been split apart into many setups on several mocks.

This will very likely conclude this series of PRs.