### PR TITLE
Behavior-driven setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
  * A mock's setups can now be inspected and individually verified via the new `Mock.Setups` collection and `IInvocation.MatchingSetup` property (@stakx, #984-#987, #989, #995, #999)
 
+ * Setups with customizable behavior: Import the new `Moq.Behaviors` namespace to gain access to a few additional `Setup` methods, all of which accept a set of `Behavior` instances that together define how the created setups will react to invocations. Some core predefined `Behavior` classes are available from the same namespace. **Note:** This is an advanced feature for those wishing to extend Moq. It shouldn't be used casually in regular test code. Prefer the standard fluent API whenever possible! (@stakx, #1002)
+
  * New `.Protected().Setup` and `Protected().Verify` method overloads to deal with generic methods (@JmlSaul, #967)
 
  * Two new public methods in `Times`: `bool Validate(int count)` and `string ToString()` (@stakx, 975)

--- a/src/Moq/Behaviors/Behavior.cs
+++ b/src/Moq/Behaviors/Behavior.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.ComponentModel;
+
+namespace Moq.Behaviors
+{
+	/// <todo/>
+	[EditorBrowsable(EditorBrowsableState.Advanced)]
+	public abstract class Behavior
+	{
+		/// <todo/>
+		protected Behavior()
+		{
+		}
+
+		/// <todo/>
+		public abstract BehaviorExecution Execute(IInvocation invocation, in BehaviorExecutionContext context);
+	}
+}

--- a/src/Moq/Behaviors/Behavior.cs
+++ b/src/Moq/Behaviors/Behavior.cs
@@ -5,16 +5,32 @@ using System.ComponentModel;
 
 namespace Moq.Behaviors
 {
-	/// <todo/>
+	/// <summary>
+	///   Defines an aspect of how a setup reacts to invocations.
+	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Advanced)]
 	public abstract class Behavior
 	{
-		/// <todo/>
+		/// <summary>
+		///   Initializes a new instance of the <see cref="Behavior"/> class.
+		/// </summary>
 		protected Behavior()
 		{
 		}
 
-		/// <todo/>
+		/// <summary>
+		///   Executes the behavior.
+		/// </summary>
+		/// <param name="invocation">
+		///   The <see cref="IInvocation"/> to which this behavior should react.
+		/// </param>
+		/// <param name="context">
+		///   The context in which the invocation is occurring.
+		/// </param>
+		/// <returns>
+		///   A value specifying whether (and how) the setup should proceed with the current invocation.
+		///   See the static factory methods on <see cref="BehaviorExecution"/> for available options.
+		/// </returns>
 		public abstract BehaviorExecution Execute(IInvocation invocation, in BehaviorExecutionContext context);
 	}
 }

--- a/src/Moq/Behaviors/BehaviorExecution.cs
+++ b/src/Moq/Behaviors/BehaviorExecution.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.ComponentModel;
+
+namespace Moq.Behaviors
+{
+	/// <todo/>
+	[EditorBrowsable(EditorBrowsableState.Advanced)]
+	public readonly struct BehaviorExecution
+	{
+		/// <todo/>
+		public static BehaviorExecution Continue() => default;
+
+		/// <todo/>
+		public static BehaviorExecution Return() => new BehaviorExecution(BehaviorExecutionKind.Return);
+
+		/// <todo/>
+		public static BehaviorExecution ReturnBase() => new BehaviorExecution(BehaviorExecutionKind.ReturnBase);
+
+		/// <todo/>
+		public static BehaviorExecution ReturnValue(object value) => new BehaviorExecution(BehaviorExecutionKind.ReturnValue, value);
+
+		/// <todo/>
+		public static BehaviorExecution ThrowException(Exception exception) => new BehaviorExecution(BehaviorExecutionKind.ThrowException, exception);
+
+		internal readonly BehaviorExecutionKind Kind;
+		internal readonly object Argument;
+
+		private BehaviorExecution(BehaviorExecutionKind kind, object argument = null)
+		{
+			this.Kind = kind;
+			this.Argument = argument;
+		}
+	}
+}

--- a/src/Moq/Behaviors/BehaviorExecution.cs
+++ b/src/Moq/Behaviors/BehaviorExecution.cs
@@ -6,23 +6,42 @@ using System.ComponentModel;
 
 namespace Moq.Behaviors
 {
-	/// <todo/>
+	/// <summary>
+	///   Returned by <see cref="Behavior"/>s to specify whether (and how) the setup should proceed with an invocation.
+	///   Values of this type can be created using any of the static factory methods.
+	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Advanced)]
 	public readonly struct BehaviorExecution
 	{
-		/// <todo/>
+		/// <summary>
+		///   The setup should proceed with the next behavior in line.
+		/// </summary>
 		public static BehaviorExecution Continue() => default;
 
-		/// <todo/>
+		/// <summary>
+		///   The setup should terminate the invocation as if a <see langword="return"/> statement had occurred.
+		/// </summary>
 		public static BehaviorExecution Return() => new BehaviorExecution(BehaviorExecutionKind.Return);
 
-		/// <todo/>
+		/// <summary>
+		///   The setup should terminate by delegating to the invoked method's <see langword="base"/> implementation.
+		/// </summary>
 		public static BehaviorExecution ReturnBase() => new BehaviorExecution(BehaviorExecutionKind.ReturnBase);
 
-		/// <todo/>
+		/// <summary>
+		///   The setup should terminate the invocation as if a <see langword="return"/> statement with a return value had occurred.
+		/// </summary>
+		/// <param name="value">
+		///   The value that should be returned from the invoked method.
+		/// </param>
 		public static BehaviorExecution ReturnValue(object value) => new BehaviorExecution(BehaviorExecutionKind.ReturnValue, value);
 
-		/// <todo/>
+		/// <summary>
+		///   The setup should terminate the invocation by <see langword="throw"/>-ing the specified exception.
+		/// </summary>
+		/// <param name="exception">
+		///   The exception that should be thrown.
+		/// </param>
 		public static BehaviorExecution ThrowException(Exception exception) => new BehaviorExecution(BehaviorExecutionKind.ThrowException, exception);
 
 		internal readonly BehaviorExecutionKind Kind;

--- a/src/Moq/Behaviors/BehaviorExecutionContext.cs
+++ b/src/Moq/Behaviors/BehaviorExecutionContext.cs
@@ -6,7 +6,9 @@ using System.Diagnostics;
 
 namespace Moq.Behaviors
 {
-	/// <todo/>
+	/// <summary>
+	///   Describes the context in which an <see cref="IInvocation"/> is occurring.
+	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Advanced)]
 	public readonly ref struct BehaviorExecutionContext
 	{
@@ -19,7 +21,9 @@ namespace Moq.Behaviors
 			this.mock = mock;
 		}
 
-		/// <todo/>
+		/// <summary>
+		///   The <see cref="Mock"/> on which an invocation is occurring.
+		/// </summary>
 		public Mock Mock => this.mock;
 	}
 }

--- a/src/Moq/Behaviors/BehaviorExecutionContext.cs
+++ b/src/Moq/Behaviors/BehaviorExecutionContext.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.ComponentModel;
+using System.Diagnostics;
+
+namespace Moq.Behaviors
+{
+	/// <todo/>
+	[EditorBrowsable(EditorBrowsableState.Advanced)]
+	public readonly ref struct BehaviorExecutionContext
+	{
+		private readonly Mock mock;
+
+		internal BehaviorExecutionContext(Mock mock)
+		{
+			Debug.Assert(mock != null);
+
+			this.mock = mock;
+		}
+
+		/// <todo/>
+		public Mock Mock => this.mock;
+	}
+}

--- a/src/Moq/Behaviors/BehaviorExecutionKind.cs
+++ b/src/Moq/Behaviors/BehaviorExecutionKind.cs
@@ -1,0 +1,24 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+namespace Moq.Behaviors
+{
+	/// <todo/>
+	internal enum BehaviorExecutionKind
+	{
+		/// <todo/>
+		Continue = default,
+
+		/// <todo/>
+		Return,
+
+		/// <todo/>
+		ReturnBase,
+
+		/// <todo/>
+		ReturnValue,
+
+		/// <todo/>
+		ThrowException,
+	}
+}

--- a/src/Moq/Behaviors/BehaviorExecutionKind.cs
+++ b/src/Moq/Behaviors/BehaviorExecutionKind.cs
@@ -3,22 +3,21 @@
 
 namespace Moq.Behaviors
 {
-	/// <todo/>
 	internal enum BehaviorExecutionKind
 	{
-		/// <todo/>
+		/// <seealso cref="BehaviorExecution.Continue"/>
 		Continue = default,
 
-		/// <todo/>
+		/// <seealso cref="BehaviorExecution.Return"/>
 		Return,
 
-		/// <todo/>
+		/// <seealso cref="BehaviorExecution.ReturnBase"/>
 		ReturnBase,
 
-		/// <todo/>
+		/// <seealso cref="BehaviorExecution.ReturnValue"/>
 		ReturnValue,
 
-		/// <todo/>
+		/// <seealso cref="BehaviorExecution.ThrowException(System.Exception)"/>
 		ThrowException,
 	}
 }

--- a/src/Moq/Behaviors/BehaviorSetup.cs
+++ b/src/Moq/Behaviors/BehaviorSetup.cs
@@ -1,0 +1,77 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+
+using Moq.Behaviors;
+
+namespace Moq
+{
+	internal sealed class BehaviorSetup : SetupWithOutParameterSupport
+	{
+		private readonly Behavior[] behaviors;
+		private string failMessage;
+
+		public BehaviorSetup(Expression originalExpression, Mock mock, InvocationShape expectation, IReadOnlyList<Behavior> behaviors)
+			: base(originalExpression, mock, expectation)
+		{
+			this.behaviors = behaviors.ToArray();
+		}
+
+		protected override void ExecuteCore(Invocation invocation)
+		{
+			var context = new BehaviorExecutionContext(this.Mock);
+
+			for (int i = 0, n = this.behaviors.Length; i < n; ++i)
+			{
+				var result = this.behaviors[i].Execute(invocation, in context);
+
+				invocation.Apply(result);
+
+				if (result.Kind != BehaviorExecutionKind.Continue)
+				{
+					return;
+				}
+			}
+
+			if (this.Mock.Behavior == MockBehavior.Strict && invocation.Method.ReturnType != typeof(void))
+			{
+				throw MockException.ReturnValueRequired(invocation);
+			}
+			else
+			{
+				invocation.Apply(ReturnBaseOrDefaultValue.Instance.Execute(invocation, in context));
+			}
+		}
+
+		public void SetFailMessage(string failMessage)
+		{
+			this.failMessage = failMessage;
+		}
+
+		public override string ToString()
+		{
+			var message = new StringBuilder();
+
+			if (this.failMessage != null)
+			{
+				message.Append(this.failMessage).Append(": ");
+			}
+
+			message.Append(base.ToString());
+
+			return message.ToString().Trim();
+		}
+
+		public override bool TryGetReturnValue(out object returnValue)
+		{
+			var behavior = this.behaviors.OfType<ReturnValue>().FirstOrDefault();
+			returnValue = behavior?.Value;
+			return behavior != null;
+		}
+	}
+}

--- a/src/Moq/Behaviors/Language/BehaviorSetupPhrase.cs
+++ b/src/Moq/Behaviors/Language/BehaviorSetupPhrase.cs
@@ -1,0 +1,33 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.Diagnostics;
+
+namespace Moq.Behaviors.Language
+{
+	internal sealed class BehaviorSetupPhrase : IBehaviorSetupResult
+	{
+		private readonly BehaviorSetup setup;
+
+		public BehaviorSetupPhrase(BehaviorSetup setup)
+		{
+			Debug.Assert(setup != null);
+
+			this.setup = setup;
+		}
+
+		public void Verifiable()
+		{
+			setup.MarkAsVerifiable();
+		}
+
+		public void Verifiable(string failMessage)
+		{
+			Guard.NotNull(failMessage, nameof(failMessage));
+
+			setup.MarkAsVerifiable();
+			setup.SetFailMessage(failMessage);
+		}
+	}
+}

--- a/src/Moq/Behaviors/Language/IBehaviorSetupResult.cs
+++ b/src/Moq/Behaviors/Language/IBehaviorSetupResult.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.ComponentModel;
+
+using Moq.Language;
+
+namespace Moq.Behaviors.Language
+{
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public interface IBehaviorSetupResult : IVerifies
+	{
+	}
+}

--- a/src/Moq/Behaviors/Language/IBehaviorSetupResult.cs
+++ b/src/Moq/Behaviors/Language/IBehaviorSetupResult.cs
@@ -7,6 +7,9 @@ using Moq.Language;
 
 namespace Moq.Behaviors.Language
 {
+	/// <summary>
+	///   Implements the fluent API.
+	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public interface IBehaviorSetupResult : IVerifies
 	{

--- a/src/Moq/Behaviors/MockExtensions.cs
+++ b/src/Moq/Behaviors/MockExtensions.cs
@@ -1,0 +1,105 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Linq.Expressions;
+using Moq.Behaviors.Language;
+
+namespace Moq.Behaviors
+{
+	/// <todo/>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public static class MockExtensions
+	{
+		/// <todo/>
+		public static IBehaviorSetupResult Setup(this Mock mock, LambdaExpression expression, IEnumerable<Behavior> behaviors)
+		{
+			Guard.NotNull(expression, nameof(expression));
+			Guard.NotNull(behaviors, nameof(behaviors));
+
+			var parts = expression.Split();
+
+			var setup = Mock.SetupRecursive(mock, expression, setupLast: (targetMock, originalExpression, part) =>
+			{
+				var lastSetup = new BehaviorSetup(originalExpression, targetMock, part, behaviors.ToArray());
+				targetMock.MutableSetups.Add(lastSetup);
+				return lastSetup;
+			});
+
+			return new BehaviorSetupPhrase(setup);
+		}
+
+		/// <todo/>
+		public static IBehaviorSetupResult Setup<T>(this Mock<T> mock, Expression<Action<T>> action, IEnumerable<Behavior> behaviors)
+			where T : class
+		{
+			Guard.NotNull(action, nameof(action));
+			Guard.NotNull(behaviors, nameof(behaviors));
+
+			return mock.Setup((LambdaExpression)action, behaviors);
+		}
+
+		/// <todo/>
+		public static IBehaviorSetupResult Setup<T, TResult>(this Mock<T> mock, Expression<Func<T, TResult>> expression, IEnumerable<Behavior> behaviors)
+			where T : class
+		{
+			Guard.NotNull(expression, nameof(expression));
+			Guard.NotNull(behaviors, nameof(behaviors));
+
+			return mock.Setup((LambdaExpression)expression, behaviors);
+		}
+
+		/// <todo/>
+		public static IBehaviorSetupResult SetupAdd<T>(this Mock<T> mock, Action<T> addExpression, IEnumerable<Behavior> behaviors)
+			where T : class
+		{
+			Guard.NotNull(addExpression, nameof(addExpression));
+			Guard.NotNull(behaviors, nameof(behaviors));
+
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(addExpression, mock.ConstructorArguments);
+			Guard.IsEventAdd(expression, nameof(expression));
+
+			return mock.Setup((LambdaExpression)expression, behaviors);
+		}
+
+		/// <todo/>
+		public static IBehaviorSetupResult SetupGet<T, TProperty>(this Mock<T> mock, Expression<Func<T, TProperty>> getterExpression, IEnumerable<Behavior> behaviors)
+			where T : class
+		{
+			Guard.NotNull(getterExpression, nameof(getterExpression));
+			Guard.IsPropertyOrIndexer(getterExpression, nameof(getterExpression));
+			Guard.NotNull(behaviors, nameof(behaviors));
+
+			return mock.Setup((LambdaExpression)getterExpression, behaviors);
+		}
+
+		/// <todo/>
+		public static IBehaviorSetupResult SetupRemove<T>(this Mock<T> mock, Action<T> removeExpression, IEnumerable<Behavior> behaviors)
+			where T : class
+		{
+			Guard.NotNull(removeExpression, nameof(removeExpression));
+			Guard.NotNull(behaviors, nameof(behaviors));
+
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(removeExpression, mock.ConstructorArguments);
+			Guard.IsEventRemove(expression, nameof(expression));
+
+			return mock.Setup((LambdaExpression)expression, behaviors);
+		}
+
+		/// <todo/>
+		public static IBehaviorSetupResult SetupSet<T, TProperty>(this Mock<T> mock, Action<T> setterExpression, IEnumerable<Behavior> behaviors)
+			where T : class
+		{
+			Guard.NotNull(setterExpression, nameof(setterExpression));
+			Guard.NotNull(behaviors, nameof(behaviors));
+
+			var expression = ExpressionReconstructor.Instance.ReconstructExpression(setterExpression, mock.ConstructorArguments);
+			Guard.IsAssignmentToPropertyOrIndexer(expression, nameof(expression));
+
+			return mock.Setup((LambdaExpression)expression, behaviors);
+		}
+	}
+}

--- a/src/Moq/Behaviors/MockExtensions.cs
+++ b/src/Moq/Behaviors/MockExtensions.cs
@@ -10,11 +10,30 @@ using Moq.Behaviors.Language;
 
 namespace Moq.Behaviors
 {
-	/// <todo/>
+	/// <summary>
+	///   Extension methods for creating <see cref="Behavior"/>-driven setups.
+	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public static class MockExtensions
 	{
-		/// <todo/>
+		/// <summary>
+		///   Creates a <see cref="Behavior"/>-driven setup for the given expression.
+		///   <para>
+		///     This method offers practically no static type safety and shouldn't be casually used in regular test code.
+		///     It is intended as an advanced entry point into Moq's setup machinery for those developing extensions
+		///     beyond the fluent setup API.
+		///   </para>
+		/// </summary>
+		/// <param name="mock">
+		///   The mock on which to create a setup.
+		/// </param>
+		/// <param name="expression">
+		///   The expression describing the invocation(s) for which to create a setup.
+		/// </param>
+		/// <param name="behaviors">
+		///   A set of <see cref="Behavior"/> defining how the setup will react to invocations.
+		/// </param>
+		[EditorBrowsable(EditorBrowsableState.Advanced)]
 		public static IBehaviorSetupResult Setup(this Mock mock, LambdaExpression expression, IEnumerable<Behavior> behaviors)
 		{
 			Guard.NotNull(expression, nameof(expression));
@@ -32,7 +51,18 @@ namespace Moq.Behaviors
 			return new BehaviorSetupPhrase(setup);
 		}
 
-		/// <todo/>
+		/// <summary>
+		///   Creates a <see cref="Behavior"/>-driven setup for invocation(s) of a <see langword="void"/> method.
+		/// </summary>
+		/// <param name="mock">
+		///   The mock on which to create a setup.
+		/// </param>
+		/// <param name="action">
+		///   The expression describing the invocation(s) of a <see langword="void"/> method for which to create a setup.
+		/// </param>
+		/// <param name="behaviors">
+		///   A set of <see cref="Behavior"/> defining how the setup will react to invocations.
+		/// </param>
 		public static IBehaviorSetupResult Setup<T>(this Mock<T> mock, Expression<Action<T>> action, IEnumerable<Behavior> behaviors)
 			where T : class
 		{
@@ -42,7 +72,18 @@ namespace Moq.Behaviors
 			return mock.Setup((LambdaExpression)action, behaviors);
 		}
 
-		/// <todo/>
+		/// <summary>
+		///   Creates a <see cref="Behavior"/>-driven setup for invocation(s) of a non-<see langword="void"/> method or property.
+		/// </summary>
+		/// <param name="mock">
+		///   The mock on which to create a setup.
+		/// </param>
+		/// <param name="expression">
+		///   The expression describing the invocation(s) of a non-<see langword="void"/> method or property for which to create a setup.
+		/// </param>
+		/// <param name="behaviors">
+		///   A set of <see cref="Behavior"/> defining how the setup will react to invocations.
+		/// </param>
 		public static IBehaviorSetupResult Setup<T, TResult>(this Mock<T> mock, Expression<Func<T, TResult>> expression, IEnumerable<Behavior> behaviors)
 			where T : class
 		{
@@ -52,7 +93,18 @@ namespace Moq.Behaviors
 			return mock.Setup((LambdaExpression)expression, behaviors);
 		}
 
-		/// <todo/>
+		/// <summary>
+		///   Creates a <see cref="Behavior"/>-driven setup for invocation(s) of an event <see langword="add"/> accessor (<c>`+=`</c>).
+		/// </summary>
+		/// <param name="mock">
+		///   The mock on which to create a setup.
+		/// </param>
+		/// <param name="addExpression">
+		///   The expression describing the invocation(s) of an event <see langword="add"/> accessor for which to create a setup.
+		/// </param>
+		/// <param name="behaviors">
+		///   A set of <see cref="Behavior"/> defining how the setup will react to invocations.
+		/// </param>
 		public static IBehaviorSetupResult SetupAdd<T>(this Mock<T> mock, Action<T> addExpression, IEnumerable<Behavior> behaviors)
 			where T : class
 		{
@@ -65,7 +117,18 @@ namespace Moq.Behaviors
 			return mock.Setup((LambdaExpression)expression, behaviors);
 		}
 
-		/// <todo/>
+		/// <summary>
+		///   Creates a <see cref="Behavior"/>-driven setup for invocation(s) of a property getter.
+		/// </summary>
+		/// <param name="mock">
+		///   The mock on which to create a setup.
+		/// </param>
+		/// <param name="getterExpression">
+		///   The expression describing the invocation(s) of a property getter for which to create a setup.
+		/// </param>
+		/// <param name="behaviors">
+		///   A set of <see cref="Behavior"/> defining how the setup will react to invocations.
+		/// </param>
 		public static IBehaviorSetupResult SetupGet<T, TProperty>(this Mock<T> mock, Expression<Func<T, TProperty>> getterExpression, IEnumerable<Behavior> behaviors)
 			where T : class
 		{
@@ -76,7 +139,18 @@ namespace Moq.Behaviors
 			return mock.Setup((LambdaExpression)getterExpression, behaviors);
 		}
 
-		/// <todo/>
+		/// <summary>
+		///   Creates a <see cref="Behavior"/>-driven setup for invocation(s) of an event <see langword="remove"/> accessor (<c>`-=`</c>).
+		/// </summary>
+		/// <param name="mock">
+		///   The mock on which to create a setup.
+		/// </param>
+		/// <param name="removeExpression">
+		///   The expression describing the invocation(s) of an event <see langword="remove"/> accessor for which to create a setup.
+		/// </param>
+		/// <param name="behaviors">
+		///   A set of <see cref="Behavior"/> defining how the setup will react to invocations.
+		/// </param>
 		public static IBehaviorSetupResult SetupRemove<T>(this Mock<T> mock, Action<T> removeExpression, IEnumerable<Behavior> behaviors)
 			where T : class
 		{
@@ -89,7 +163,18 @@ namespace Moq.Behaviors
 			return mock.Setup((LambdaExpression)expression, behaviors);
 		}
 
-		/// <todo/>
+		/// <summary>
+		///   Creates a <see cref="Behavior"/>-driven setup for invocation(s) of a property setter.
+		/// </summary>
+		/// <param name="mock">
+		///   The mock on which to create a setup.
+		/// </param>
+		/// <param name="setterExpression">
+		///   The expression describing the invocation(s) of a property setter for which to create a setup.
+		/// </param>
+		/// <param name="behaviors">
+		///   A set of <see cref="Behavior"/> defining how the setup will react to invocations.
+		/// </param>
 		public static IBehaviorSetupResult SetupSet<T, TProperty>(this Mock<T> mock, Action<T> setterExpression, IEnumerable<Behavior> behaviors)
 			where T : class
 		{

--- a/src/Moq/Behaviors/Return.cs
+++ b/src/Moq/Behaviors/Return.cs
@@ -3,7 +3,9 @@
 
 namespace Moq.Behaviors
 {
-	/// <todo/>
+	/// <summary>
+	///   Terminates an invocation as if by a <see langword="return"/> statement.
+	/// </summary>
 	public sealed class Return : Behavior
 	{
 		/// <inheritdoc/>

--- a/src/Moq/Behaviors/Return.cs
+++ b/src/Moq/Behaviors/Return.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+namespace Moq.Behaviors
+{
+	/// <todo/>
+	public sealed class Return : Behavior
+	{
+		/// <inheritdoc/>
+		public override BehaviorExecution Execute(IInvocation invocation, in BehaviorExecutionContext context)
+		{
+			return BehaviorExecution.Return();
+		}
+	}
+}

--- a/src/Moq/Behaviors/ReturnBase.cs
+++ b/src/Moq/Behaviors/ReturnBase.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+namespace Moq.Behaviors
+{
+	/// <todo/>
+	public sealed class ReturnBase : Behavior
+	{
+		/// <inheritdoc/>
+		public override BehaviorExecution Execute(IInvocation invocation, in BehaviorExecutionContext context)
+		{
+			return BehaviorExecution.ReturnBase();
+		}
+	}
+}

--- a/src/Moq/Behaviors/ReturnBase.cs
+++ b/src/Moq/Behaviors/ReturnBase.cs
@@ -3,7 +3,9 @@
 
 namespace Moq.Behaviors
 {
-	/// <todo/>
+	/// <summary>
+	///   Terminates an invocation by delegating to the invoked method's <see langword="base"/> implementation.
+	/// </summary>
 	public sealed class ReturnBase : Behavior
 	{
 		/// <inheritdoc/>

--- a/src/Moq/Behaviors/ReturnBaseOrDefaultValue.cs
+++ b/src/Moq/Behaviors/ReturnBaseOrDefaultValue.cs
@@ -6,7 +6,13 @@ using System.Linq;
 
 namespace Moq.Behaviors
 {
-	/// <todo/>
+	/// <summary>
+	///   Terminates an invocation either by delegating to the invoked method's <see langword="base"/> implementation
+	///   if <see cref="Mock.CallBase"/> is set on the mock; or by returning a value that is in line with
+	///   the default value settings of the mock (see <see cref="Mock.DefaultValue"/>, <see cref="Mock.DefaultValueProvider"/>,
+	///   and <see cref="Mock.SetReturnsDefault{TReturn}(TReturn)"/>; or, for <see langword="void"/> methods,
+	///   by a simple <see langword="return"/> statement.
+	/// </summary>
 	public sealed class ReturnBaseOrDefaultValue : Behavior
 	{
 		internal static readonly ReturnBaseOrDefaultValue Instance = new ReturnBaseOrDefaultValue();

--- a/src/Moq/Behaviors/ReturnBaseOrDefaultValue.cs
+++ b/src/Moq/Behaviors/ReturnBaseOrDefaultValue.cs
@@ -1,0 +1,86 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.Diagnostics;
+using System.Linq;
+
+namespace Moq.Behaviors
+{
+	/// <todo/>
+	public sealed class ReturnBaseOrDefaultValue : Behavior
+	{
+		internal static readonly ReturnBaseOrDefaultValue Instance = new ReturnBaseOrDefaultValue();
+
+		/// <inheritdoc/>
+		public override BehaviorExecution Execute(IInvocation invocation, in BehaviorExecutionContext context)
+		{
+			Debug.Assert(invocation.Method != null);
+			Debug.Assert(invocation.Method.ReturnType != null);
+
+			var method = invocation.Method;
+			var mock = context.Mock;
+
+			if (mock.CallBase)
+			{
+				var declaringType = method.DeclaringType;
+				if (declaringType.IsInterface)
+				{
+					if (mock.MockedType.IsInterface)
+					{
+						// Case 1: Interface method of an interface proxy.
+						// There is no base method to call, so fall through.
+					}
+					else
+					{
+						Debug.Assert(mock.MockedType.IsClass);
+						Debug.Assert(mock.ImplementsInterface(declaringType));
+
+						// Case 2: Explicitly implemented interface method of a class proxy.
+
+						if (mock.InheritedInterfaces.Contains(declaringType))
+						{
+							// Case 2a: Re-implemented interface.
+							// The base class has its own implementation. Only call base method if it isn't an event accessor.
+							if (!method.IsEventAddAccessor() && !method.IsEventRemoveAccessor())
+							{
+								return BehaviorExecution.ReturnBase();
+							}
+						}
+						else
+						{
+							Debug.Assert(mock.AdditionalInterfaces.Contains(declaringType));
+
+							// Case 2b: Additional interface.
+							// There is no base method to call, so fall through.
+						}
+					}
+				}
+				else
+				{
+					Debug.Assert(declaringType.IsClass);
+
+					// Case 3: Non-interface method of a class proxy.
+					// Only call base method if it isn't abstract.
+					if (!method.IsAbstract)
+					{
+						return BehaviorExecution.ReturnBase();
+					}
+				}
+			}
+
+			if (method.ReturnType == typeof(void))
+			{
+				return BehaviorExecution.Return();
+			}
+			else
+			{
+				var returnValue = mock.GetDefaultValue(method, out var innerMock);
+				if (innerMock != null)
+				{
+					mock.AddInnerMockSetup(invocation, returnValue);
+				}
+				return BehaviorExecution.ReturnValue(returnValue);
+			}
+		}
+	}
+}

--- a/src/Moq/Behaviors/ReturnComputedValue.cs
+++ b/src/Moq/Behaviors/ReturnComputedValue.cs
@@ -5,12 +5,20 @@ using System;
 
 namespace Moq.Behaviors
 {
-	/// <todo/>
+	/// <summary>
+	///   Terminates an invocation as if by a <see langword="return"/> statement with a lazily computed return value.
+	/// </summary>
 	public sealed class ReturnComputedValue : Behavior
 	{
 		private readonly Func<object> valueFunction;
 
-		/// <todo/>
+		/// <summary>
+		///   Initializes a new instance of the <see cref="ReturnComputedValue"/> class
+		///   using the specified return value factory function.
+		/// </summary>
+		/// <param name="valueFunction">
+		///   The factory function that computes the return value(s) to be returned when terminating invocations.
+		/// </param>
 		public ReturnComputedValue(Func<object> valueFunction)
 		{
 			if (valueFunction == null)
@@ -21,7 +29,9 @@ namespace Moq.Behaviors
 			this.valueFunction = valueFunction;
 		}
 
-		/// <todo/>
+		/// <summary>
+		///   The factory function that computes the return value(s) to be returned when terminating invocations.
+		/// </summary>
 		public Func<object> ValueFunction => this.valueFunction;
 
 		/// <inheritdoc/>

--- a/src/Moq/Behaviors/ReturnComputedValue.cs
+++ b/src/Moq/Behaviors/ReturnComputedValue.cs
@@ -1,0 +1,33 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+
+namespace Moq.Behaviors
+{
+	/// <todo/>
+	public sealed class ReturnComputedValue : Behavior
+	{
+		private readonly Func<object> valueFunction;
+
+		/// <todo/>
+		public ReturnComputedValue(Func<object> valueFunction)
+		{
+			if (valueFunction == null)
+			{
+				throw new ArgumentNullException(nameof(valueFunction));
+			}
+
+			this.valueFunction = valueFunction;
+		}
+
+		/// <todo/>
+		public Func<object> ValueFunction => this.valueFunction;
+
+		/// <inheritdoc/>
+		public override BehaviorExecution Execute(IInvocation invocation, in BehaviorExecutionContext context)
+		{
+			return BehaviorExecution.ReturnValue(this.valueFunction());
+		}
+	}
+}

--- a/src/Moq/Behaviors/ReturnValue.cs
+++ b/src/Moq/Behaviors/ReturnValue.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+namespace Moq.Behaviors
+{
+	/// <todo/>
+	public sealed class ReturnValue : Behavior
+	{
+		private readonly object value;
+
+		/// <todo/>
+		public ReturnValue(object value)
+		{
+			this.value = value;
+		}
+
+		/// <todo/>
+		public object Value => this.value;
+
+		/// <inheritdoc/>
+		public override BehaviorExecution Execute(IInvocation invocation, in BehaviorExecutionContext context)
+		{
+			return BehaviorExecution.ReturnValue(this.value);
+		}
+	}
+}

--- a/src/Moq/Behaviors/ReturnValue.cs
+++ b/src/Moq/Behaviors/ReturnValue.cs
@@ -3,18 +3,27 @@
 
 namespace Moq.Behaviors
 {
-	/// <todo/>
+	/// <summary>
+	///   Terminates an invocation as if by a <see langword="return"/> statement with a return value.
+	/// </summary>
 	public sealed class ReturnValue : Behavior
 	{
 		private readonly object value;
 
-		/// <todo/>
+		/// <summary>
+		///   Initializes a new instance of the <see cref="ReturnValue"/> class using the specified return value.
+		/// </summary>
+		/// <param name="value">
+		///   The return value to be returned when terminating invocations.
+		/// </param>
 		public ReturnValue(object value)
 		{
 			this.value = value;
 		}
 
-		/// <todo/>
+		/// <summary>
+		///   The return value to be returned when terminating invocations.
+		/// </summary>
 		public object Value => this.value;
 
 		/// <inheritdoc/>

--- a/src/Moq/Behaviors/ThrowComputedException.cs
+++ b/src/Moq/Behaviors/ThrowComputedException.cs
@@ -1,0 +1,33 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+
+namespace Moq.Behaviors
+{
+	/// <todo/>
+	public sealed class ThrowComputedException : Behavior
+	{
+		private readonly Func<Exception> exceptionFunction;
+
+		/// <todo/>
+		public ThrowComputedException(Func<Exception> exceptionFunction)
+		{
+			if (exceptionFunction == null)
+			{
+				throw new ArgumentNullException(nameof(exceptionFunction));
+			}
+
+			this.exceptionFunction = exceptionFunction;
+		}
+
+		/// <todo/>
+		public Func<Exception> ExceptionFunction => this.exceptionFunction;
+
+		/// <inheritdoc/>
+		public override BehaviorExecution Execute(IInvocation invocation, in BehaviorExecutionContext context)
+		{
+			return BehaviorExecution.ThrowException(this.exceptionFunction());
+		}
+	}
+}

--- a/src/Moq/Behaviors/ThrowComputedException.cs
+++ b/src/Moq/Behaviors/ThrowComputedException.cs
@@ -5,12 +5,20 @@ using System;
 
 namespace Moq.Behaviors
 {
-	/// <todo/>
+	/// <summary>
+	///   Terminates an invocation as if by a <see langword="throw"/>-ing a lazily computed exception.
+	/// </summary>
 	public sealed class ThrowComputedException : Behavior
 	{
 		private readonly Func<Exception> exceptionFunction;
 
-		/// <todo/>
+		/// <summary>
+		///   Initializes a new instance of the <see cref="ThrowComputedException"/> class
+		///   using the specified exception factory function.
+		/// </summary>
+		/// <param name="exceptionFunction">
+		///   The factory function that computes the exception(s) to be thrown when terminating invocations.
+		/// </param>
 		public ThrowComputedException(Func<Exception> exceptionFunction)
 		{
 			if (exceptionFunction == null)
@@ -21,7 +29,9 @@ namespace Moq.Behaviors
 			this.exceptionFunction = exceptionFunction;
 		}
 
-		/// <todo/>
+		/// <summary>
+		///   The factory function that computes the exception(s) to be thrown when terminating invocations.
+		/// </summary>
 		public Func<Exception> ExceptionFunction => this.exceptionFunction;
 
 		/// <inheritdoc/>

--- a/src/Moq/Behaviors/ThrowException.cs
+++ b/src/Moq/Behaviors/ThrowException.cs
@@ -1,0 +1,33 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+
+namespace Moq.Behaviors
+{
+	/// <todo/>
+	public sealed class ThrowException : Behavior
+	{
+		private readonly Exception exception;
+
+		/// <todo/>
+		public ThrowException(Exception exception)
+		{
+			if (exception == null)
+			{
+				throw new ArgumentNullException(nameof(exception));
+			}
+
+			this.exception = exception;
+		}
+
+		/// <todo/>
+		public Exception Exception => this.exception;
+
+		/// <inheritdoc/>
+		public override BehaviorExecution Execute(IInvocation invocation, in BehaviorExecutionContext context)
+		{
+			return BehaviorExecution.ThrowException(this.exception);
+		}
+	}
+}

--- a/src/Moq/Behaviors/ThrowException.cs
+++ b/src/Moq/Behaviors/ThrowException.cs
@@ -5,12 +5,19 @@ using System;
 
 namespace Moq.Behaviors
 {
-	/// <todo/>
+	/// <summary>
+	///   Terminates an invocation as if by a <see langword="throw"/>-ing an exception.
+	/// </summary>
 	public sealed class ThrowException : Behavior
 	{
 		private readonly Exception exception;
 
-		/// <todo/>
+		/// <summary>
+		///   Initializes a new instance of the <see cref="ThrowException"/> class using the specified exception.
+		/// </summary>
+		/// <param name="exception">
+		///   The exception to be thrown when terminating invocations.
+		/// </param>
 		public ThrowException(Exception exception)
 		{
 			if (exception == null)
@@ -21,7 +28,9 @@ namespace Moq.Behaviors
 			this.exception = exception;
 		}
 
-		/// <todo/>
+		/// <summary>
+		///   The exception to be thrown when terminating invocations.
+		/// </summary>
 		public Exception Exception => this.exception;
 
 		/// <inheritdoc/>

--- a/src/Moq/Guard.cs
+++ b/src/Moq/Guard.cs
@@ -55,6 +55,15 @@ namespace Moq
 			Guard.CanCreateInstance(type);
 		}
 
+		public static void IsPropertyOrIndexer(LambdaExpression expression, string paramName)
+		{
+			if (!expression.IsPropertyIndexer())  // guard because `.ToPropertyInfo()` doesn't (yet) work for indexers
+			{
+				var property = expression.ToPropertyInfo();
+				Guard.CanRead(property);
+			}
+		}
+
 		public static void IsAssignmentToPropertyOrIndexer(LambdaExpression expression, string paramName)
 		{
 			Debug.Assert(expression != null);

--- a/src/Moq/Invocation.cs
+++ b/src/Moq/Invocation.cs
@@ -7,6 +7,8 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Text;
 
+using Moq.Behaviors;
+
 namespace Moq
 {
 	internal abstract class Invocation : IInvocation

--- a/src/Moq/Invocation.cs
+++ b/src/Moq/Invocation.cs
@@ -75,6 +75,27 @@ namespace Moq
 
 		public bool WasVerified => this.verified;
 
+		public void Apply(in BehaviorExecution result)
+		{
+			switch (result.Kind)
+			{
+				case BehaviorExecutionKind.Return:
+					this.Return();
+					return;
+
+				case BehaviorExecutionKind.ReturnBase:
+					this.ReturnBase();
+					return;
+
+				case BehaviorExecutionKind.ReturnValue:
+					this.Return(result.Argument);
+					return;
+
+				case BehaviorExecutionKind.ThrowException:
+					throw (Exception)result.Argument;
+			}
+		}
+
 		/// <summary>
 		/// Ends the invocation as if a <see langword="return"/> statement occurred.
 		/// </summary>

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -527,12 +527,7 @@ namespace Moq
 		internal static MethodCall SetupGet(Mock mock, LambdaExpression expression, Condition condition)
 		{
 			Guard.NotNull(expression, nameof(expression));
-
-			if (!expression.IsPropertyIndexer())  // guard because `.ToPropertyInfo()` doesn't (yet) work for indexers
-			{
-				var property = expression.ToPropertyInfo();
-				Guard.CanRead(property);
-			}
+			Guard.IsPropertyOrIndexer(expression, nameof(expression));
 
 			return Mock.Setup(mock, expression, condition);
 		}
@@ -573,7 +568,7 @@ namespace Moq
 			});
 		}
 
-		private static TSetup SetupRecursive<TSetup>(Mock mock, LambdaExpression expression, Func<Mock, Expression, InvocationShape, TSetup> setupLast)
+		internal static TSetup SetupRecursive<TSetup>(Mock mock, LambdaExpression expression, Func<Mock, Expression, InvocationShape, TSetup> setupLast)
 			where TSetup : ISetup
 		{
 			Debug.Assert(mock != null);
@@ -780,7 +775,7 @@ namespace Moq
 
 		#region Inner mocks
 
-		internal void AddInnerMockSetup(Invocation invocation, object returnValue)
+		internal void AddInnerMockSetup(IInvocation invocation, object returnValue)
 		{
 			var method = invocation.Method;
 

--- a/src/Moq/MockException.cs
+++ b/src/Moq/MockException.cs
@@ -144,7 +144,7 @@ namespace Moq
 		/// <summary>
 		///   Returns the exception to be thrown when a strict mock has no setup that provides a return value for the specified invocation.
 		/// </summary>
-		internal static MockException ReturnValueRequired(Invocation invocation)
+		internal static MockException ReturnValueRequired(IInvocation invocation)
 		{
 			return new MockException(
 				MockExceptionReasons.ReturnValueRequired,


### PR DESCRIPTION
Adds a new namespace `Moq.Behaviors` providing a new abstract base class `Behavior`, as well as additional `Setup*` extension methods on `Mock<T>` for creating `Behavior`-driven setups.

#### Basic usage:

1. Import the namespace:

   ```csharp
   using Moq.Behaviors;
   ```

2. Define behaviors to be used in setups: (Optional, but the initially provided predefined behaviors won't get you very far.)

   ```csharp
   class LogInvocation : Behavior
   {
       public override BehaviorExecution Execute(IInvocation invocation, in BehaviorExecutionContext context)
       {
           Console.WriteLine(invocation);
           return BehaviorExecution.Continue();
       }
   }
   ```

3. Create setups using custom and/or pre-defined `Behavior` types:

   ```csharp
   mock.Setup(m => m.HandleMessage(It.IsAny<Message>()), new Behavior[]
   {
       new LogInvocation(),
       new ReturnBaseOrDefaultValue(),
   });

4. Invoke methods and see the behaviors at work:

   ```csharp
   mock.Object.HandleMessage(...);
   ```

This is still work in progress.

* [ ] Add unit tests.
* [ ] Complenetess: Should similar `Setup*` methods be made available on `.Protected()` mocks and on top of `.When()`.
* [ ] Or should all new `Setup*` methods except the `LambdaExpression` be removed (as this is supposed to be for extensions, not casual use)?
* [ ] Ideally, make sure the API is good enough to allow conversion of *all* setup types to `Behavior`s later on. (This would allow even deeper setup introspection.)