### PR TITLE
Stop searching for setup when first match found

### DIFF
--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -128,8 +128,6 @@ namespace Moq
 				return null;
 			}
 
-			Setup matchingSetup = null;
-
 			lock (this.setups)
 			{
 				// Iterating in reverse order because newer setups are more relevant than (i.e. override) older ones
@@ -138,25 +136,14 @@ namespace Moq
 					var setup = this.setups[i];
 					if (setup.IsOverridden) continue;
 
-					// the following conditions are repetitive, but were written that way to avoid
-					// unnecessary expensive calls to `setup.Matches`; cheap tests are run first.
-					if (matchingSetup == null && setup.Matches(invocation))
+					if (setup.Matches(invocation))
 					{
-						matchingSetup = setup;
-						if (setup.Method == invocation.Method)
-						{
-							break;
-						}
-					}
-					else if (setup.Method == invocation.Method && setup.Matches(invocation))
-					{
-						matchingSetup = setup;
-						break;
+						return setup;
 					}
 				}
 			}
 
-			return matchingSetup;
+			return null;
 		}
 
 		public IEnumerable<Setup> GetInnerMockSetups()

--- a/tests/Moq.Tests/ItIsAnyTypeFixture.cs
+++ b/tests/Moq.Tests/ItIsAnyTypeFixture.cs
@@ -14,9 +14,9 @@ namespace Moq.Tests
 		public void Setup_without_It_IsAnyType()
 		{
 			var mock = new Mock<IX>();
+			mock.Setup(x => x.Method<object>());
 			mock.Setup(x => x.Method<bool>());
 			mock.Setup(x => x.Method<int>());
-			mock.Setup(x => x.Method<object>());
 			mock.Setup(x => x.Method<string>());
 
 			mock.Object.Method<bool>();


### PR DESCRIPTION
This would have caused a regression before version 4.13, but appears to work now&mdash;and should result in improved performance due to the reduced amount of matching performed.