### PR TITLE
Add `Await` operator for use in async setup expressions

### DIFF
--- a/src/Moq/AwaitOperatorObserver.cs
+++ b/src/Moq/AwaitOperatorObserver.cs
@@ -1,0 +1,94 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Moq
+{
+	internal sealed class AwaitOperatorObserver : IDisposable
+	{
+		[ThreadStatic]
+		private static Stack<AwaitOperatorObserver> activations;
+
+		public static AwaitOperatorObserver Activate()
+		{
+			var activation = new AwaitOperatorObserver();
+
+			var activations = AwaitOperatorObserver.activations;
+			if (activations == null)
+			{
+				AwaitOperatorObserver.activations = activations = new Stack<AwaitOperatorObserver>();
+			}
+			activations.Push(activation);
+
+			return activation;
+		}
+
+		public static bool IsActive(out AwaitOperatorObserver observer)
+		{
+			var activations = AwaitOperatorObserver.activations;
+
+			if (activations != null && activations.Count > 0)
+			{
+				observer = activations.Peek();
+				return true;
+			}
+			else
+			{
+				observer = null;
+				return false;
+			}
+		}
+
+		private int timestamp;
+		private List<int> observations;
+
+		private AwaitOperatorObserver()
+		{
+		}
+
+		public void Dispose()
+		{
+			var activations = AwaitOperatorObserver.activations;
+			Debug.Assert(activations != null && activations.Count > 0);
+			activations.Pop();
+		}
+
+		/// <summary>
+		///   Returns the current timestamp. The next call will return a timestamp greater than this one,
+		///   allowing you to order invocations and matcher observations.
+		/// </summary>
+		public int GetNextTimestamp()
+		{
+			return ++this.timestamp;
+		}
+
+		/// <summary>
+		///   Adds the specified <see cref="Match"/> as an observation.
+		/// </summary>
+		public void OnAwaitOperator()
+		{
+			if (this.observations == null)
+			{
+				this.observations = new List<int>();
+			}
+
+			this.observations.Add(this.GetNextTimestamp());
+		}
+
+		public bool HasAwaitOperatorBetween(int fromTimestampInclusive, int toTimestampExclusive)
+		{
+			if (this.observations != null)
+			{
+				return this.observations.Any(o => fromTimestampInclusive <= o && o < toTimestampExclusive);
+			}
+			else
+			{
+				return false;
+			}
+		}
+	}
+}

--- a/src/Moq/ExpressionExtensions.cs
+++ b/src/Moq/ExpressionExtensions.cs
@@ -229,6 +229,11 @@ namespace Moq
 										method,
 										arguments);
 						}
+						else if (methodCallExpression.Method.DeclaringType == typeof(Moq.Linq.Expressions.AwaitOperator))
+						{
+							Split(methodCallExpression.Arguments.Single(), out r, out p);
+							p.Await = true;
+						}
 						else
 						{
 							Debug.Assert(methodCallExpression.Method.IsExtensionMethod());

--- a/src/Moq/InvocationShape.cs
+++ b/src/Moq/InvocationShape.cs
@@ -59,6 +59,8 @@ namespace Moq
 			this.exactGenericTypeArguments = exactGenericTypeArguments;
 		}
 
+		internal bool Await { get; set; }
+
 		public void Deconstruct(out LambdaExpression expression, out MethodInfo method, out IReadOnlyList<Expression> arguments)
 		{
 			expression = this.Expression;

--- a/src/Moq/Linq/Expressions/AwaitOperator.cs
+++ b/src/Moq/Linq/Expressions/AwaitOperator.cs
@@ -11,25 +11,35 @@ namespace Moq.Linq.Expressions
 		/// <todo/>
 		public static TResult Await<TResult>(Task<TResult> task)
 		{
-			return task.Result;
+			return Impl(task.Result);
 		}
 
 		/// <todo/>
 		public static TResult Await<TResult>(ValueTask<TResult> task)
 		{
-			return task.Result;
+			return Impl(task.Result);
 		}
 
 		/// <todo/>
 		public static TResult Result<TResult>(this Task<TResult> task)
 		{
-			return task.Result;
+			return Impl(task.Result);
 		}
 
 		/// <todo/>
 		public static TResult Result<TResult>(this ValueTask<TResult> task)
 		{
-			return task.Result;
+			return Impl(task.Result);
+		}
+
+		private static TResult Impl<TResult>(TResult result)
+		{
+			if (AwaitOperatorObserver.IsActive(out var o))
+			{
+				o.OnAwaitOperator();
+			}
+
+			return result;
 		}
 	}
 }

--- a/src/Moq/Linq/Expressions/AwaitOperator.cs
+++ b/src/Moq/Linq/Expressions/AwaitOperator.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.Threading.Tasks;
+
+namespace Moq.Linq.Expressions
+{
+	/// <todo/>
+	public static class AwaitOperator
+	{
+		/// <todo/>
+		public static TResult Await<TResult>(Task<TResult> task)
+		{
+			return task.Result;
+		}
+
+		/// <todo/>
+		public static TResult Await<TResult>(ValueTask<TResult> task)
+		{
+			return task.Result;
+		}
+
+		/// <todo/>
+		public static TResult Result<TResult>(this Task<TResult> task)
+		{
+			return task.Result;
+		}
+
+		/// <todo/>
+		public static TResult Result<TResult>(this ValueTask<TResult> task)
+		{
+			return task.Result;
+		}
+	}
+}

--- a/src/Moq/LookupOrFallbackDefaultValueProvider.cs
+++ b/src/Moq/LookupOrFallbackDefaultValueProvider.cs
@@ -151,22 +151,14 @@ namespace Moq
 		{
 			var resultType = type.GetGenericArguments()[0];
 			var result = this.GetDefaultValue(resultType, mock);
-
-			var tcsType = typeof(TaskCompletionSource<>).MakeGenericType(resultType);
-			var tcs = Activator.CreateInstance(tcsType);
-			tcsType.GetMethod("SetResult").Invoke(tcs, new[] { result });
-			return tcsType.GetProperty("Task").GetValue(tcs, null);
+			return Wrap.AsTask(type, result);
 		}
 
 		private object CreateValueTaskOf(Type type, Mock mock)
 		{
 			var resultType = type.GetGenericArguments()[0];
 			var result = this.GetDefaultValue(resultType, mock);
-
-			// `Activator.CreateInstance` could throw an `AmbiguousMatchException` in this use case,
-			// so we're explicitly selecting and calling the constructor we want to use:
-			var valueTaskCtor = type.GetConstructor(new[] { resultType });
-			return valueTaskCtor.Invoke(new object[] { result });
+			return Wrap.AsValueTask(type, result);
 		}
 
 		private object CreateValueTupleOf(Type type, Mock mock)

--- a/src/Moq/Wrap.cs
+++ b/src/Moq/Wrap.cs
@@ -1,0 +1,51 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.Threading.Tasks;
+
+namespace Moq
+{
+	internal static class Wrap
+	{
+		public static object AsFaultedTask(Type type, Exception exception)
+		{
+			var resultType = type.GetGenericArguments()[0];
+
+			var tcsType = typeof(TaskCompletionSource<>).MakeGenericType(resultType);
+			var tcs = Activator.CreateInstance(tcsType);
+			tcsType.GetMethod("SetException", new Type[] { typeof(Exception) }).Invoke(tcs, new[] { exception });
+			return tcsType.GetProperty("Task").GetValue(tcs, null);
+		}
+
+		public static object AsTask(Type type, object result)
+		{
+			var resultType = type.GetGenericArguments()[0];
+
+			var tcsType = typeof(TaskCompletionSource<>).MakeGenericType(resultType);
+			var tcs = Activator.CreateInstance(tcsType);
+			tcsType.GetMethod("SetResult").Invoke(tcs, new[] { result });
+			return tcsType.GetProperty("Task").GetValue(tcs, null);
+		}
+
+		public static object AsFaultedValueTask(Type type, Exception exception)
+		{
+			var resultType = type.GetGenericArguments()[0];
+
+			// `Activator.CreateInstance` could throw an `AmbiguousMatchException` in this use case,
+			// so we're explicitly selecting and calling the constructor we want to use:
+			var valueTaskCtor = type.GetConstructor(new[] { typeof(Task<>).MakeGenericType(resultType) });
+			return valueTaskCtor.Invoke(new object[] { Wrap.AsFaultedTask(type, exception) });
+		}
+
+		public static object AsValueTask(Type type, object result)
+		{
+			var resultType = type.GetGenericArguments()[0];
+
+			// `Activator.CreateInstance` could throw an `AmbiguousMatchException` in this use case,
+			// so we're explicitly selecting and calling the constructor we want to use:
+			var valueTaskCtor = type.GetConstructor(new[] { resultType });
+			return valueTaskCtor.Invoke(new object[] { result });
+		}
+	}
+}


### PR DESCRIPTION
This is a proof of concept demonstrating the general feasibility of an `Await` operator for use in async setup expressions as described in #1007. This would still need to be...

* [ ] properly tested (including `Verify`!?)
* [ ] cleaned up

Closes #1007.