### PR TITLE
Clean up setup execution method

### DIFF
--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -89,12 +89,12 @@ namespace Moq
 
 			this.callbackResponse?.RespondTo(invocation);
 
+			this.raiseEventResponse?.RespondTo(invocation);
+
 			if ((this.flags & Flags.CallBase) != 0)
 			{
 				invocation.ReturnBase();
 			}
-
-			this.raiseEventResponse?.RespondTo(invocation);
 
 			this.returnOrThrowResponse?.RespondTo(invocation);
 

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -110,8 +110,6 @@ namespace Moq
 						Return.Handle(invocation, this.Mock);
 					}
 				}
-
-				this.afterReturnCallbackResponse?.RespondTo(invocation);
 			}
 			else
 			{
@@ -120,6 +118,8 @@ namespace Moq
 					invocation.Return();
 				}
 			}
+
+			this.afterReturnCallbackResponse?.RespondTo(invocation);
 		}
 
 		public override bool TryGetReturnValue(out object returnValue)

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -118,6 +118,13 @@ namespace Moq
 
 				this.afterReturnCallbackResponse?.RespondTo(invocation);
 			}
+			else
+			{
+				if (this.returnOrThrowResponse == null && (this.flags & Flags.CallBase) == 0)
+				{
+					invocation.Return();
+				}
+			}
 		}
 
 		public override bool TryGetReturnValue(out object returnValue)

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -21,7 +21,6 @@ namespace Moq
 		private LimitInvocationCountResponse limitInvocationCountResponse;
 		private Condition condition;
 		private string failMessage;
-		private Flags flags;
 		private RaiseEventResponse raiseEventResponse;
 		private Response returnOrThrowResponse;
 
@@ -31,7 +30,6 @@ namespace Moq
 			: base(originalExpression, mock, expectation)
 		{
 			this.condition = condition;
-			this.flags = expectation.Method.ReturnType != typeof(void) ? Flags.MethodIsNonVoid : 0;
 			this.returnOrThrowResponse = DefaultReturnResponse.Instance;
 
 			if ((mock.Switches & Switches.CollectDiagnosticFileInfoForSetups) != 0)
@@ -195,7 +193,7 @@ namespace Moq
 
 		public void SetEagerReturnsResponse(object value)
 		{
-			Debug.Assert((this.flags & Flags.MethodIsNonVoid) != 0);
+			Debug.Assert(this.Method.ReturnType != typeof(void));
 			Debug.Assert(this.returnOrThrowResponse is DefaultReturnResponse);
 
 			this.returnOrThrowResponse = new ReturnEagerValueResponse(value);
@@ -203,7 +201,7 @@ namespace Moq
 
 		public void SetReturnsResponse(Delegate valueFactory)
 		{
-			Debug.Assert((this.flags & Flags.MethodIsNonVoid) != 0);
+			Debug.Assert(this.Method.ReturnType != typeof(void));
 			Debug.Assert(this.returnOrThrowResponse is DefaultReturnResponse);
 
 			if (valueFactory == null)
@@ -335,12 +333,6 @@ namespace Moq
 			}
 
 			return message.ToString().Trim();
-		}
-
-		[Flags]
-		private enum Flags : byte
-		{
-			MethodIsNonVoid = 2,
 		}
 
 		private sealed class LimitInvocationCountResponse

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -91,11 +91,6 @@ namespace Moq
 
 			this.raiseEventResponse?.RespondTo(invocation);
 
-			if ((this.flags & Flags.CallBase) != 0)
-			{
-				invocation.ReturnBase();
-			}
-
 			this.returnOrThrowResponse?.RespondTo(invocation);
 
 			if ((this.flags & Flags.MethodIsNonVoid) != 0)
@@ -120,7 +115,7 @@ namespace Moq
 			}
 			else
 			{
-				if (this.returnOrThrowResponse == null && (this.flags & Flags.CallBase) == 0)
+				if (this.returnOrThrowResponse == null)
 				{
 					invocation.Return();
 				}
@@ -148,14 +143,7 @@ namespace Moq
 				throw new NotSupportedException(Resources.CallBaseCannotBeUsedWithDelegateMocks);
 			}
 
-			if ((this.flags & Flags.MethodIsNonVoid) != 0)
-			{
-				this.returnOrThrowResponse = ReturnBaseResponse.Instance;
-			}
-			else
-			{
-				this.flags |= Flags.CallBase;
-			}
+			this.returnOrThrowResponse = ReturnBaseResponse.Instance;
 		}
 
 		public void SetCallbackResponse(Delegate callback)
@@ -377,7 +365,6 @@ namespace Moq
 		[Flags]
 		private enum Flags : byte
 		{
-			CallBase = 1,
 			MethodIsNonVoid = 2,
 		}
 

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -93,9 +93,9 @@ namespace Moq
 
 			this.returnOrThrowResponse?.RespondTo(invocation);
 
-			if ((this.flags & Flags.MethodIsNonVoid) != 0)
+			if (this.returnOrThrowResponse == null)
 			{
-				if (this.returnOrThrowResponse == null)
+				if ((this.flags & Flags.MethodIsNonVoid) != 0)
 				{
 					if (this.Mock.Behavior == MockBehavior.Strict)
 					{
@@ -110,10 +110,7 @@ namespace Moq
 						Return.Handle(invocation, this.Mock);
 					}
 				}
-			}
-			else
-			{
-				if (this.returnOrThrowResponse == null)
+				else
 				{
 					invocation.Return();
 				}


### PR DESCRIPTION
(This was triggered by the addition of a missing call to `invocation.Return()` in order to terminate a `void` method `Invocation`.)