### PR TITLE
`DefaultValue.Mock` should not add redundant setups for already-matched invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
+## Unreleased
+
+#### Fixed
+
+* Regression: `Verify` behavior change using `DefaultValue.Mock` (@DesrosiersC, #1024)
+
+
 ## 4.14.1 (2020-04-28)
 
 #### Added

--- a/src/Moq/Interception/InterceptionAspects.cs
+++ b/src/Moq/Interception/InterceptionAspects.cs
@@ -262,7 +262,7 @@ namespace Moq
 			else
 			{
 				var returnValue = mock.GetDefaultValue(method, out var innerMock);
-				if (innerMock != null)
+				if (innerMock != null && invocation.MatchingSetup == null)
 				{
 					mock.AddInnerMockSetup(invocation, returnValue);
 				}

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -3313,6 +3313,28 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 1024
+
+		public class Issue1024
+		{
+			[Fact]
+			public void Verify_passes_when_DefaultValue_Mock_and_setup_without_any_Returns()
+			{
+				var totoMock = new Mock<IToto>() { DefaultValue = DefaultValue.Mock };
+				totoMock.Setup(o => o.Do()).Verifiable();
+
+				totoMock.Object.Do();
+
+				totoMock.Verify();
+			}
+
+			public interface IToto
+			{
+				IList<string> Do();
+			}
+		}
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47


### PR DESCRIPTION
This regression is due to a refactoring of `MethodCall.ExecuteCore`, most likely #1013.

Fixes #1024.