### PR TITLE
No longer need to use `AttributesToAvoidReplicating`

### DIFF
--- a/src/Moq/ProxyFactories/CastleProxyFactory.cs
+++ b/src/Moq/ProxyFactories/CastleProxyFactory.cs
@@ -13,15 +13,6 @@ using Castle.DynamicProxy;
 using Moq.Internals;
 using Moq.Properties;
 
-#if FEATURE_CAS
-using System.Security.Permissions;
-using Castle.DynamicProxy.Generators;
-#endif
-
-#if FEATURE_COM
-using System.Runtime.InteropServices;
-#endif
-
 namespace Moq
 {
 	/// <summary>
@@ -31,23 +22,6 @@ namespace Moq
 	{
 		private ProxyGenerationOptions generationOptions;
 		private ProxyGenerator generator;
-
-		#if FEATURE_CAS || FEATURE_COM
-		static CastleProxyFactory()
-		{
-			#if FEATURE_CAS
-			AttributesToAvoidReplicating.Add<SecurityPermissionAttribute>();
-			AttributesToAvoidReplicating.Add<ReflectionPermissionAttribute>();
-			AttributesToAvoidReplicating.Add<PermissionSetAttribute>();
-			AttributesToAvoidReplicating.Add<UIPermissionAttribute>();
-			#endif
-
-			#if FEATURE_COM
-			AttributesToAvoidReplicating.Add<MarshalAsAttribute>();
-			AttributesToAvoidReplicating.Add<TypeIdentifierAttribute>();
-			#endif
-		}
-		#endif
 
 		public CastleProxyFactory()
 		{


### PR DESCRIPTION
The [attributes that we're adding to `AttributesToAvoidReplicating`](https://github.com/moq/moq4/blob/baa2a9ef4b8dd7def55f200d51bb4fe979d77a10/src/Moq/ProxyFactories/CastleProxyFactory.cs#L38-L48) are [already registered by DynamicProxy itself](https://github.com/castleproject/Core/blob/f0626e2cb2a8df9da113bed8abcbfc7d50631d63/src/Castle.Core/DynamicProxy/Generators/AttributesToAvoidReplicating.cs#L32-L39). (Security attributes don't need to be registered separately; registering the common base type `SecurityAttribute` is sufficient.)

Closes #1026.