### PR TITLE
Expression execution during override detection must not stop setup from being added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
+## Unreleased
+
+#### Fixed
+
+* Regression: `NullReferenceException` on subsequent setup if expression contains null reference (@IanYates83, #1031)
+
+
 ## 4.14.3 (2020-06-18)
 
 #### Fixed

--- a/src/Moq/Evaluator.cs
+++ b/src/Moq/Evaluator.cs
@@ -109,7 +109,17 @@ namespace Moq
 					base.Visit(expression);
 					if (!this.cannotBeEvaluated)
 					{
-						if (this.fnCanBeEvaluated(expression))
+						bool canBeEvaluated;
+						try
+						{
+							canBeEvaluated = this.fnCanBeEvaluated(expression);
+						}
+						catch
+						{
+							canBeEvaluated = false;
+						}
+
+						if (canBeEvaluated)
 						{
 							this.candidates.Add(expression);
 						}

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -3355,6 +3355,56 @@ namespace Moq.Tests.Regressions
 		}
 		#endregion
 
+		#region 1031
+
+		public class Issue1031
+		{
+			[Fact]
+			public void MultiSetupNRE_Abbreviated()
+			{
+				StubDataStore obj = null;
+				var exampleMock = new Mock<IDataStore>(MockBehavior.Strict);
+				exampleMock.Setup(m => m.IsStored(It.Is<string>(s => obj.Value == s))); // Binds correctly
+				exampleMock.Setup(m => m.IsStored(It.Is<string>(s => obj.Value != s))); // Null Reference Exception
+			}
+
+			[Fact]
+			public void MultiSetupNRE()
+			{
+				// Arrange
+				var exampleMock = new Mock<IDataStore>(MockBehavior.Strict);
+
+				StubDataStore obj = null;
+				exampleMock.Setup(m => m.IsStored(It.Is<string>(s => obj.Value == s))) // Binds correctly
+					.Returns(true).Verifiable();
+				exampleMock.Setup(m => m.IsStored(It.Is<string>(s => obj.Value != s))) // Null Reference Exception
+					.Returns(false).Verifiable();
+
+				// Act
+				obj = new StubDataStore { Value = "a" };
+				var resHit = exampleMock.Object.IsStored("a");
+				var resMiss = exampleMock.Object.IsStored("b");
+
+				// Assert
+				exampleMock.Verify();
+				Assert.True(resHit);
+				Assert.False(resMiss);
+			}
+
+			public class StubDataStore
+			{
+				public string Value { get; set; }
+			}
+
+			public interface IDataStore
+			{
+				bool IsStored(string arg);
+			}
+		}
+
+
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47


### PR DESCRIPTION
This might fix #1031.

This is not the best possible solution. It would be preferable to require matchers to carry an easily discoverable `[Matcher]` attribute, such that expressions don't have to be compiled and executed anymore just to discover whether a matcher ran. (Requiring that attribute would be a breaking change, which perhaps we can avoid for a little while longer.)