### PR TITLE
Simplify `MethodCall`'s response types

### DIFF
--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -137,11 +137,11 @@ namespace Moq
 			}
 		}
 
-		public static object InvokePreserveStack(this Delegate del, params object[] args)
+		public static object InvokePreserveStack(this Delegate del, IReadOnlyList<object> args = null)
 		{
 			try
 			{
-				return del.DynamicInvoke(args);
+				return del.DynamicInvoke((args as object[]) ?? args?.ToArray());
 			}
 			catch (TargetInvocationException ex)
 			{

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -131,14 +131,14 @@ namespace Moq
 
 			if (callback is Action callbackWithoutArguments)
 			{
-				response = new CallbackResponse(args => callbackWithoutArguments());
+				response = new CallbackResponse(_ => callbackWithoutArguments());
 			}
 			else if (callback.GetType() == typeof(Action<IInvocation>))
 			{
 				// NOTE: Do NOT rewrite the above condition as `callback is Action<IInvocation>`,
 				// because this will also yield true if `callback` is a `Action<object>` and thus
 				// break existing uses of `(object arg) => ...` callbacks!
-				response = new InvocationCallbackResponse((Action<IInvocation>)callback);
+				response = new CallbackResponse((Action<IInvocation>)callback);
 			}
 			else
 			{
@@ -158,7 +158,7 @@ namespace Moq
 					throw new ArgumentException(Resources.InvalidCallbackNotADelegateWithReturnTypeVoid, nameof(callback));
 				}
 
-				response = new CallbackResponse(args => callback.InvokePreserveStack(args));
+				response = new CallbackResponse(invocation => callback.InvokePreserveStack(invocation.Arguments));
 			}
 		}
 
@@ -382,26 +382,9 @@ namespace Moq
 
 		private sealed class CallbackResponse : Response
 		{
-			private readonly Action<object[]> callback;
-
-			public CallbackResponse(Action<object[]> callback)
-			{
-				Debug.Assert(callback != null);
-
-				this.callback = callback;
-			}
-
-			public override void RespondTo(Invocation invocation)
-			{
-				this.callback.Invoke(invocation.Arguments);
-			}
-		}
-
-		private sealed class InvocationCallbackResponse : Response
-		{
 			private readonly Action<IInvocation> callback;
 
-			public InvocationCallbackResponse(Action<IInvocation> callback)
+			public CallbackResponse(Action<IInvocation> callback)
 			{
 				Debug.Assert(callback != null);
 

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -18,10 +18,10 @@ namespace Moq
 	{
 		private Response afterReturnCallbackResponse;
 		private Response callbackResponse;
-		private LimitInvocationCountResponse limitInvocationCountResponse;
+		private LimitInvocationCount limitInvocationCountResponse;
 		private Condition condition;
 		private string failMessage;
-		private RaiseEventResponse raiseEventResponse;
+		private RaiseEvent raiseEventResponse;
 		private Response returnOrThrowResponse;
 
 		private string declarationSite;
@@ -30,7 +30,7 @@ namespace Moq
 			: base(originalExpression, mock, expectation)
 		{
 			this.condition = condition;
-			this.returnOrThrowResponse = DefaultReturnResponse.Instance;
+			this.returnOrThrowResponse = DefaultReturnOrThrow.Instance;
 
 			if ((mock.Switches & Switches.CollectDiagnosticFileInfoForSetups) != 0)
 			{
@@ -97,9 +97,9 @@ namespace Moq
 
 		public override bool TryGetReturnValue(out object returnValue)
 		{
-			if (this.returnOrThrowResponse is ReturnValueResponse rvr)
+			if (this.returnOrThrowResponse is ReturnValue rv)
 			{
-				returnValue = rvr.Value;
+				returnValue = rv.Value;
 				return true;
 			}
 			else
@@ -116,7 +116,7 @@ namespace Moq
 				throw new NotSupportedException(Resources.CallBaseCannotBeUsedWithDelegateMocks);
 			}
 
-			this.returnOrThrowResponse = ReturnBaseResponse.Instance;
+			this.returnOrThrowResponse = ReturnBase.Instance;
 		}
 
 		public void SetCallbackResponse(Delegate callback)
@@ -126,19 +126,19 @@ namespace Moq
 				throw new ArgumentNullException(nameof(callback));
 			}
 
-			ref Response response = ref (this.returnOrThrowResponse is DefaultReturnResponse) ? ref this.callbackResponse
-			                                                                                  : ref this.afterReturnCallbackResponse;
+			ref Response response = ref (this.returnOrThrowResponse is DefaultReturnOrThrow) ? ref this.callbackResponse
+			                                                                          : ref this.afterReturnCallbackResponse;
 
 			if (callback is Action callbackWithoutArguments)
 			{
-				response = new CallbackResponse(_ => callbackWithoutArguments());
+				response = new Callback(_ => callbackWithoutArguments());
 			}
 			else if (callback.GetType() == typeof(Action<IInvocation>))
 			{
 				// NOTE: Do NOT rewrite the above condition as `callback is Action<IInvocation>`,
 				// because this will also yield true if `callback` is a `Action<object>` and thus
 				// break existing uses of `(object arg) => ...` callbacks!
-				response = new CallbackResponse((Action<IInvocation>)callback);
+				response = new Callback((Action<IInvocation>)callback);
 			}
 			else
 			{
@@ -158,7 +158,7 @@ namespace Moq
 					throw new ArgumentException(Resources.InvalidCallbackNotADelegateWithReturnTypeVoid, nameof(callback));
 				}
 
-				response = new CallbackResponse(invocation => callback.InvokePreserveStack(invocation.Arguments));
+				response = new Callback(invocation => callback.InvokePreserveStack(invocation.Arguments));
 			}
 		}
 
@@ -176,7 +176,7 @@ namespace Moq
 
 			// TODO: validate that expression is for event subscription or unsubscription
 
-			this.raiseEventResponse = new RaiseEventResponse(this.Mock, expression, func, null);
+			this.raiseEventResponse = new RaiseEvent(this.Mock, expression, func, null);
 		}
 
 		public void SetRaiseEventResponse<TMock>(Action<TMock> eventExpression, params object[] args)
@@ -188,21 +188,21 @@ namespace Moq
 
 			// TODO: validate that expression is for event subscription or unsubscription
 
-			this.raiseEventResponse = new RaiseEventResponse(this.Mock, expression, null, args);
+			this.raiseEventResponse = new RaiseEvent(this.Mock, expression, null, args);
 		}
 
 		public void SetEagerReturnsResponse(object value)
 		{
 			Debug.Assert(this.Method.ReturnType != typeof(void));
-			Debug.Assert(this.returnOrThrowResponse is DefaultReturnResponse);
+			Debug.Assert(this.returnOrThrowResponse is DefaultReturnOrThrow);
 
-			this.returnOrThrowResponse = new ReturnValueResponse(value);
+			this.returnOrThrowResponse = new ReturnValue(value);
 		}
 
 		public void SetReturnsResponse(Delegate valueFactory)
 		{
 			Debug.Assert(this.Method.ReturnType != typeof(void));
-			Debug.Assert(this.returnOrThrowResponse is DefaultReturnResponse);
+			Debug.Assert(this.returnOrThrowResponse is DefaultReturnOrThrow);
 
 			if (valueFactory == null)
 			{
@@ -212,7 +212,7 @@ namespace Moq
 				// and instead of in `Returns(TResult)`, we ended up in `Returns(Delegate)` or `Returns(Func)`,
 				// which likely isn't what the user intended.
 				// So here we do what we would've done in `Returns(TResult)`:
-				this.returnOrThrowResponse = new ReturnValueResponse(this.Method.ReturnType.GetDefaultValue());
+				this.returnOrThrowResponse = new ReturnValue(this.Method.ReturnType.GetDefaultValue());
 			}
 			else if (this.Method.ReturnType == typeof(Delegate))
 			{
@@ -220,11 +220,11 @@ namespace Moq
 				// that returns a `Delegate`, then we have arrived here because C# picked the wrong overload:
 				// We don't want to invoke the passed delegate to get a return value; the passed delegate
 				// already is the return value.
-				this.returnOrThrowResponse = new ReturnValueResponse(valueFactory);
+				this.returnOrThrowResponse = new ReturnValue(valueFactory);
 			}
 			else if (IsInvocationFunc(valueFactory))
 			{
-				this.returnOrThrowResponse = new ReturnComputedValueResponse(invocation => valueFactory.DynamicInvoke(invocation));
+				this.returnOrThrowResponse = new ReturnComputedValue(invocation => valueFactory.DynamicInvoke(invocation));
 			}
 			else
 			{
@@ -233,11 +233,11 @@ namespace Moq
 				if (valueFactory.CompareParameterTypesTo(Type.EmptyTypes))
 				{
 					// we need this for the user to be able to use parameterless methods
-					this.returnOrThrowResponse = new ReturnComputedValueResponse(invocation => valueFactory.InvokePreserveStack());
+					this.returnOrThrowResponse = new ReturnComputedValue(invocation => valueFactory.InvokePreserveStack());
 				}
 				else
 				{
-					this.returnOrThrowResponse = new ReturnComputedValueResponse(invocation => valueFactory.InvokePreserveStack(invocation.Arguments));
+					this.returnOrThrowResponse = new ReturnComputedValue(invocation => valueFactory.InvokePreserveStack(invocation.Arguments));
 				}
 			}
 
@@ -312,7 +312,7 @@ namespace Moq
 
 		public void SetThrowExceptionResponse(Exception exception)
 		{
-			this.returnOrThrowResponse = new ThrowExceptionResponse(exception);
+			this.returnOrThrowResponse = new ThrowException(exception);
 		}
 
 		protected override void ResetCore()
@@ -322,7 +322,7 @@ namespace Moq
 
 		public void AtMost(int count)
 		{
-			this.limitInvocationCountResponse = new LimitInvocationCountResponse(this, count);
+			this.limitInvocationCountResponse = new LimitInvocationCount(this, count);
 		}
 
 		public override string ToString()
@@ -344,13 +344,13 @@ namespace Moq
 			return message.ToString().Trim();
 		}
 
-		private sealed class LimitInvocationCountResponse
+		private sealed class LimitInvocationCount
 		{
 			private readonly MethodCall setup;
 			private readonly int maxCount;
 			private int count;
 
-			public LimitInvocationCountResponse(MethodCall setup, int maxCount)
+			public LimitInvocationCount(MethodCall setup, int maxCount)
 			{
 				this.setup = setup;
 				this.maxCount = maxCount;
@@ -389,11 +389,11 @@ namespace Moq
 			public abstract void RespondTo(Invocation invocation);
 		}
 
-		private sealed class CallbackResponse : Response
+		private sealed class Callback : Response
 		{
 			private readonly Action<IInvocation> callback;
 
-			public CallbackResponse(Action<IInvocation> callback)
+			public Callback(Action<IInvocation> callback)
 			{
 				Debug.Assert(callback != null);
 
@@ -406,11 +406,11 @@ namespace Moq
 			}
 		}
 
-		private sealed class DefaultReturnResponse : Response
+		private sealed class DefaultReturnOrThrow : Response
 		{
-			public static readonly DefaultReturnResponse Instance = new DefaultReturnResponse();
+			public static readonly DefaultReturnOrThrow Instance = new DefaultReturnOrThrow();
 
-			private DefaultReturnResponse()
+			private DefaultReturnOrThrow()
 			{
 			}
 
@@ -441,11 +441,11 @@ namespace Moq
 			}
 		}
 
-		private sealed class ReturnBaseResponse : Response
+		private sealed class ReturnBase : Response
 		{
-			public static readonly ReturnBaseResponse Instance = new ReturnBaseResponse();
+			public static readonly ReturnBase Instance = new ReturnBase();
 
-			private ReturnBaseResponse()
+			private ReturnBase()
 			{
 			}
 
@@ -455,11 +455,11 @@ namespace Moq
 			}
 		}
 
-		private sealed class ReturnValueResponse : Response
+		private sealed class ReturnValue : Response
 		{
 			public readonly object Value;
 
-			public ReturnValueResponse(object value)
+			public ReturnValue(object value)
 			{
 				this.Value = value;
 			}
@@ -470,11 +470,11 @@ namespace Moq
 			}
 		}
 
-		private sealed class ReturnComputedValueResponse : Response
+		private sealed class ReturnComputedValue : Response
 		{
 			private readonly Func<IInvocation, object> valueFactory;
 
-			public ReturnComputedValueResponse(Func<IInvocation, object> valueFactory)
+			public ReturnComputedValue(Func<IInvocation, object> valueFactory)
 			{
 				this.valueFactory = valueFactory;
 			}
@@ -486,11 +486,11 @@ namespace Moq
 			}
 		}
 
-		private sealed class ThrowExceptionResponse : Response
+		private sealed class ThrowException : Response
 		{
 			private readonly Exception exception;
 
-			public ThrowExceptionResponse(Exception exception)
+			public ThrowException(Exception exception)
 			{
 				this.exception = exception;
 			}
@@ -501,14 +501,14 @@ namespace Moq
 			}
 		}
 
-		private sealed class RaiseEventResponse
+		private sealed class RaiseEvent
 		{
 			private Mock mock;
 			private LambdaExpression expression;
 			private Delegate eventArgsFunc;
 			private object[] eventArgsParams;
 
-			public RaiseEventResponse(Mock mock, LambdaExpression expression, Delegate eventArgsFunc, object[] eventArgsParams)
+			public RaiseEvent(Mock mock, LambdaExpression expression, Delegate eventArgsFunc, object[] eventArgsParams)
 			{
 				Debug.Assert(mock != null);
 				Debug.Assert(expression != null);


### PR DESCRIPTION
This is a preparatory step that will facilitate the introduction to behavior-driven setups.