### PR TITLE
Multitarget .NET Standard 2.1

### DIFF
--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -6,7 +6,7 @@
 	<Import Project="$(BuildDirectory)SourceLink.props" />
 
 	<PropertyGroup>
-		<TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net45;netstandard2.0;netstandard2.1</TargetFrameworks>
 		<AssemblyName>Moq</AssemblyName>
 		<DebugSymbols>True</DebugSymbols>
 		<DebugType>portable</DebugType>

--- a/tests/Moq.Tests/MatchExpressionFixture.cs
+++ b/tests/Moq.Tests/MatchExpressionFixture.cs
@@ -18,7 +18,7 @@ namespace Moq.Tests
 		{
 			var ex = Assert.Throws<ArgumentException>(() =>
 				GetExpression().CompileUsingExpressionCompiler());
-			Assert.Contains("reducible", ex.Message);
+			Assert.Contains("ReduceAndCheck", ex.StackTrace);
 		}
 
 		[Fact]


### PR DESCRIPTION
Since v5 is not released as an official nuget package yet I'm pushing this minor update to the v4 repo instead.

Contains:
* Added netstandard2.1 to TargetFrameworks

Additional:
* Make unit test language invariant

In order to test my changes I ran the unit tests and noticed a language depending unit test. Instead it is now based on the stack trace which makes this language invariant.

Fixes #1041 

I'm not too sure if this minor fix actually requires an entry to the changelog. If you want me to add one, please say so.