### PR TITLE
Fix setting of nested non-overridable properties via `Mock.Of`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
+## Unreleased
+
+#### Fixed
+
+* Regression since 4.14.0: setting nested non-overridable properties via `Mock.Of` (@mariotee, #1039)
+
+
 ## 4.14.5 (2020-07-01)
 
 #### Fixed

--- a/src/Moq/ExpressionExtensions.cs
+++ b/src/Moq/ExpressionExtensions.cs
@@ -136,7 +136,7 @@ namespace Moq
 		/// <exception cref="ArgumentException">
 		///   It was not possible to completely split up the expression.
 		/// </exception>
-		internal static Stack<InvocationShape> Split(this LambdaExpression expression)
+		internal static Stack<InvocationShape> Split(this LambdaExpression expression, bool allowNonOverridableLastProperty = false)
 		{
 			Debug.Assert(expression != null);
 
@@ -145,7 +145,7 @@ namespace Moq
 			Expression remainder = expression.Body;
 			while (CanSplit(remainder))
 			{
-				Split(remainder, out remainder, out var part);
+				Split(remainder, out remainder, out var part, allowNonOverridableLastProperty: allowNonOverridableLastProperty);
 				parts.Push(part);
 			}
 
@@ -162,7 +162,7 @@ namespace Moq
 						remainder.ToStringFixed()));
 			}
 
-			void Split(Expression e, out Expression r /* remainder */, out InvocationShape p /* part */, bool assignment = false)
+			void Split(Expression e, out Expression r /* remainder */, out InvocationShape p /* part */, bool assignment = false, bool allowNonOverridableLastProperty = false)
 			{
 				const string ParameterName = "...";
 
@@ -253,7 +253,8 @@ namespace Moq
 										parameter),
 									method,
 									arguments,
-									skipMatcherInitialization: assignment);
+									skipMatcherInitialization: assignment,
+									allowNonOverridable: allowNonOverridableLastProperty);
 						return;
 					}
 
@@ -288,7 +289,8 @@ namespace Moq
 										Expression.MakeMemberAccess(parameter, property),
 										parameter),
 									method,
-									skipMatcherInitialization: assignment);
+									skipMatcherInitialization: assignment,
+									allowNonOverridable: allowNonOverridableLastProperty);
 						return;
 					}
 

--- a/src/Moq/ExpressionExtensions.cs
+++ b/src/Moq/ExpressionExtensions.cs
@@ -145,7 +145,7 @@ namespace Moq
 			Expression remainder = expression.Body;
 			while (CanSplit(remainder))
 			{
-				Split(remainder, out remainder, out var part, allowNonOverridableLastProperty: allowNonOverridableLastProperty);
+				Split(remainder, out remainder, out var part, allowNonOverridableLastProperty: allowNonOverridableLastProperty && parts.Count == 0);
 				parts.Push(part);
 			}
 

--- a/src/Moq/InvocationShape.cs
+++ b/src/Moq/InvocationShape.cs
@@ -72,13 +72,16 @@ namespace Moq
 #endif
 		private readonly bool exactGenericTypeArguments;
 
-		public InvocationShape(LambdaExpression expression, MethodInfo method, IReadOnlyList<Expression> arguments = null, bool exactGenericTypeArguments = false, bool skipMatcherInitialization = false)
+		public InvocationShape(LambdaExpression expression, MethodInfo method, IReadOnlyList<Expression> arguments = null, bool exactGenericTypeArguments = false, bool skipMatcherInitialization = false, bool allowNonOverridable = false)
 		{
 			Debug.Assert(expression != null);
 			Debug.Assert(method != null);
 
-			Guard.IsOverridable(method, expression);
-			Guard.IsVisibleToProxyFactory(method);
+			if (!allowNonOverridable)  // the sole currently known legitimate case where this evaluates to `false` is when setting non-overridable properties via LINQ to Mocks
+			{
+				Guard.IsOverridable(method, expression);
+				Guard.IsVisibleToProxyFactory(method);
+			}
 
 			this.Expression = expression;
 			this.Method = method;

--- a/src/Moq/Linq/Mocks.cs
+++ b/src/Moq/Linq/Mocks.cs
@@ -128,78 +128,23 @@ namespace Moq
 			while (true);
 		}
 
-		/// <summary>
-		/// Extension method used to support Linq-like setup properties that are not virtual but do have 
-		/// a getter and a setter, thereby allowing the use of Linq to Mocks to quickly initialize DTOs too :)
-		/// </summary>
-		private static bool SetProperty(Mock target, PropertyInfo property, object value)
-		{
-			// For strict mocks, we haven't called `SetupAllProperties` on the mock being set up.
-			// Therefore, whenever a property is being initialized, we quickly need to enable auto-stubbing.
-			//
-			// (One would think that it would be simpler to perform `SetupAllProperties` at the beginning
-			// and leave it enabled until the initialized mock is returned to the user. However, transforming
-			// the LINQ query such that a final disable of auto-stubbing happens is much more difficult!)
-
-			var temporaryAutoSetupProperties = target.AutoSetupPropertiesDefaultValueProvider == null;
-
-			if (temporaryAutoSetupProperties)
-			{
-				target.AutoSetupPropertiesDefaultValueProvider = target.DefaultValueProvider;
-			}
-			try
-			{
-				property.SetValue(target.Object, value, null);
-			}
-			finally
-			{
-				if (temporaryAutoSetupProperties)
-				{
-					target.AutoSetupPropertiesDefaultValueProvider = null;
-				}
-			}
-
-			return true;
-		}
-
 		internal static readonly MethodInfo SetupReturnsMethod =
 			typeof(Mocks).GetMethod(nameof(SetupReturns), BindingFlags.NonPublic | BindingFlags.Static);
 
 		internal static bool SetupReturns(Mock mock, LambdaExpression expression, object value)
 		{
-			PropertyInfo propertyToSet = null;
-
 			if (expression.Body is MemberExpression me
 				&& me.Member is PropertyInfo pi
 				&& !(pi.CanRead(out var getter) && getter.CanOverride() && ProxyFactory.Instance.IsMethodVisible(getter, out _))
 				&& pi.CanWrite(out _))
 			{
 				// LINQ to Mocks allows setting non-interceptable properties, which is handy e.g. when initializing DTOs.
-				// Generally, we prefer having a setup for a property's return value, but if that isn't possible (e.g.
-				// with a non-virtual or sealed property), we will have to fall back to simply setting that property
-				// through reflection.
-				//
-				// The above condition detects exactly those cases.
-				propertyToSet = pi;
-
-				// The property access (which is one that cannot be setup) must be subtracted from the setup expression:
-				expression = Expression.Lambda(me.Expression, expression.Parameters);
-				if (!expression.CanSplit())
-				{
-					Mocks.SetProperty(mock, propertyToSet, value);
-					return true;
-				}
-			}
-
-			var setup = Mock.Setup(mock, expression, condition: null);
-
-			if (propertyToSet == null)
-			{
-				setup.SetReturnValueBehavior(value);
+				Mock.SetupSet(mock, expression, propertyToSet: pi, value);
 			}
 			else
 			{
-				Mocks.SetProperty(setup.Mock, propertyToSet, value);
+				var setup = Mock.Setup(mock, expression, condition: null);
+				setup.SetReturnValueBehavior(value);
 			}
 
 			return true;

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -3427,6 +3427,30 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 1039
+
+		public class Issue1039
+		{
+			[Fact]
+			public void Test()
+			{
+				Mock.Of<IOptions<DatabaseOptions>>(
+					o => o.Value.ConnectionString == "connection");
+			}
+
+			public interface IOptions<out TOptions>
+			{
+				TOptions Value { get; }
+			}
+
+			public class DatabaseOptions
+			{
+				public string ConnectionString { get; set; }
+			}
+		}
+
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47


### PR DESCRIPTION
Fixes #1039.