### PR TITLE
Add .NET Framework reference assembly packages

### DIFF
--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -41,6 +41,7 @@
 	<ItemGroup>
 		<PackageReference Include="Castle.Core" Version="4.4.0" />
 		<PackageReference Include="IFluentInterface" Version="2.1.0" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
 		<PackageReference Include="TypeNameFormatter.Sources" Version="1.0.0" PrivateAssets="All" />
 	</ItemGroup>

--- a/tests/Moq.Tests.FSharpTypes/Moq.Tests.FSharpTypes.fsproj
+++ b/tests/Moq.Tests.FSharpTypes/Moq.Tests.FSharpTypes.fsproj
@@ -12,6 +12,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="FSharp.Core" Version="4.5.4" />
+		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 	</ItemGroup>
 

--- a/tests/Moq.Tests.VisualBasic/Moq.Tests.VisualBasic.vbproj
+++ b/tests/Moq.Tests.VisualBasic/Moq.Tests.VisualBasic.vbproj
@@ -12,6 +12,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
 		<ProjectReference Include="..\..\src\Moq\Moq.csproj" />
 	</ItemGroup>
 

--- a/tests/Moq.Tests/Moq.Tests.csproj
+++ b/tests/Moq.Tests/Moq.Tests.csproj
@@ -23,6 +23,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Castle.Core" Version="4.4.0" />
+		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 		<ProjectReference Include="..\..\src\Moq\Moq.csproj" />
 		<ProjectReference Include="..\Moq.Tests.FSharpTypes\Moq.Tests.FSharpTypes.fsproj" />


### PR DESCRIPTION
This should make it possible to build Moq on machines using `dotnet` even when Visual Studio is not installed.

(Reference assemblies for the .NET Framework used to be only available on your machine if you installed Visual Studio, but now they have been made available through a NuGet package.)

**Things left to do:**

* [x] Check whether builds still work _with_ Visual Studio.

* [x] I remember build warnings in another project saying that you don't need to explicitly add the reference assembly package to your project because the toolchain adds it implicitly. However not all toolchains do this, so figure out how to get rid of that warning without completely undoing the work in this PR.