### PR TITLE
Implement It.Is, It.IsIn, It.IsNotIn with a comparer overload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+#### Added
+
+* New method overloads for `It.Is`, `It.IsIn`, and `It.IsNotIn` that compare values using a custom `IEqualityComparer<T>` (@weitzhandler, #1064)
+Implement It.Is, It.IsIn, It.IsNotIn with a comparer overload (#1059)
+
 
 ## 4.14.6 (2020-09-30)
 

--- a/src/Moq/It.cs
+++ b/src/Moq/It.cs
@@ -176,6 +176,23 @@ namespace Moq
 		}
 
 		/// <summary>
+		///   Matches any value that equals the <paramref name="value"/> using the <paramref name="comparer"/>.
+		///   To use the default comparer for the specified object, specify the value inline,
+		///   i.e. <code>mock.Verify(service => service.DoWork(value))</code>.
+		///   <para>
+		///     Use this overload when you specify a value and a comparer.
+		///   </para>
+		/// </summary>
+		/// <param name="value">The value to match with.</param>
+		/// <param name="comparer">An <see cref="IEqualityComparer{T}"/> with which the values should be compared.</param>
+		/// <typeparam name="TValue">Type of the argument to check.</typeparam>
+		[EditorBrowsable(EditorBrowsableState.Advanced)]
+		public static TValue Is<TValue>(TValue value, IEqualityComparer<TValue> comparer)
+		{
+			return Match.Create<TValue>(actual => comparer.Equals(actual, value), () => It.Is<TValue>(value, comparer));
+		}
+
+		/// <summary>
 		///   Matches any value that is in the range specified.
 		/// </summary>
 		/// <param name="from">The lower bound of the range.</param>
@@ -238,6 +255,17 @@ namespace Moq
 		///   Matches any value that is present in the sequence specified.
 		/// </summary>
 		/// <param name="items">The sequence of possible values.</param>
+		/// <param name="comparer">An <see cref="IEqualityComparer{T}"/> with which the values should be compared.</param>
+		/// <typeparam name="TValue">Type of the argument to check.</typeparam>
+		public static TValue IsIn<TValue>(IEnumerable<TValue> items, IEqualityComparer<TValue> comparer)
+		{
+			return Match<TValue>.Create(value => items.Contains(value, comparer), () => It.IsIn(items, comparer));
+		}
+
+		/// <summary>
+		///   Matches any value that is present in the sequence specified.
+		/// </summary>
+		/// <param name="items">The sequence of possible values.</param>
 		/// <typeparam name="TValue">Type of the argument to check.</typeparam>
 		/// <example>
 		///   The following example shows how to expect a method call with an integer argument
@@ -274,6 +302,17 @@ namespace Moq
 		public static TValue IsNotIn<TValue>(IEnumerable<TValue> items)
 		{
 			return Match<TValue>.Create(value => !items.Contains(value), () => It.IsNotIn(items));
+		}
+
+		/// <summary>
+		///   Matches any value that is not found in the sequence specified.
+		/// </summary>
+		/// <param name="items">The sequence of disallowed values.</param>
+		/// <param name="comparer">An <see cref="IEqualityComparer{T}"/> with which the values should be compared.</param>
+		/// <typeparam name="TValue">Type of the argument to check.</typeparam>
+		public static TValue IsNotIn<TValue>(IEnumerable<TValue> items, IEqualityComparer<TValue> comparer)
+		{
+			return Match<TValue>.Create(value => !items.Contains(value, comparer), () => It.IsNotIn(items, comparer));
 		}
 
 		/// <summary>

--- a/tests/Moq.Tests/CustomTypeMatchersFixture.cs
+++ b/tests/Moq.Tests/CustomTypeMatchersFixture.cs
@@ -2,6 +2,8 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 using Xunit;
@@ -160,6 +162,46 @@ namespace Moq.Tests
 			Assert.Equal(2, invocationCount);
 		}
 
+		[Fact]
+		public void It_Is_works_with_custom_comparer()
+		{
+			var acceptableArg = "FOO";
+
+			var invocationCount = 0;
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Method(It.Is<string>(acceptableArg, StringComparer.OrdinalIgnoreCase)))
+				.Callback((object arg) => invocationCount++);
+
+			mock.Object.Method("foo");
+			mock.Object.Method("bar");
+			Assert.Equal(1, invocationCount);
+
+			mock.Object.Method("FOO");
+			mock.Object.Method("foo");
+			mock.Object.Method((string)null);
+			Assert.Equal(3, invocationCount);
+		}
+
+		[Fact]
+		public void It_Is_object_works_with_custom_comparer()
+		{
+			var acceptableArg = "FOO";
+
+			var invocationCount = 0;
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Method(It.Is<object>(acceptableArg, new ObjectStringOrdinalIgnoreCaseComparer())))
+				.Callback((object arg) => invocationCount++);
+
+			mock.Object.Method("foo");
+			mock.Object.Method("bar");
+			Assert.Equal(1, invocationCount);
+
+			mock.Object.Method("FOO");
+			mock.Object.Method("foo");
+			mock.Object.Method((string)null);
+			Assert.Equal(3, invocationCount);
+		}
+
 		public interface IX
 		{
 			void Method<T>();
@@ -228,6 +270,25 @@ namespace Moq.Tests
 		public struct AnyStruct : ITypeMatcher
 		{
 			public bool Matches(Type typeArgument) => typeArgument.IsValueType;
+		}
+
+		public class ObjectStringOrdinalIgnoreCaseComparer : IEqualityComparer<object>
+		{
+			private static IEqualityComparer<string> InternalComparer => StringComparer.OrdinalIgnoreCase;
+
+			public new bool Equals(object x, object y)
+			{
+				Debug.Assert(x is string && y is string);
+
+				return InternalComparer.Equals((string)x, (string)y);
+			}
+
+			public int GetHashCode(object obj)
+			{
+				Debug.Assert(obj is string);
+
+				return InternalComparer.GetHashCode((string)obj);
+			}
 		}
 	}
 }

--- a/tests/Moq.Tests/MatchersFixture.cs
+++ b/tests/Moq.Tests/MatchersFixture.cs
@@ -81,6 +81,25 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public void MatchesIsInEnumerableWithCustomComparer()
+		{
+			var acceptableArgs = Enumerable.Repeat("foo", 1);
+			var unacceptableArgs = Enumerable.Repeat("bar", 1);
+
+			var mock = new Mock<IFoo>();
+
+			mock.Setup(x => x.Execute(It.IsIn(acceptableArgs, StringComparer.OrdinalIgnoreCase))).Returns("foo");
+			mock.Setup(x => x.Execute(It.IsIn(unacceptableArgs, StringComparer.OrdinalIgnoreCase))).Returns("bar");
+
+			Assert.Equal("foo", mock.Object.Execute("foo"));
+			Assert.Equal("foo", mock.Object.Execute("FOO"));
+			Assert.Equal("foo", mock.Object.Execute("FoO"));
+
+			Assert.Equal("bar", mock.Object.Execute("bar"));
+			Assert.Equal("bar", mock.Object.Execute("BAR"));
+		}
+
+		[Fact]
 		public void MatchesIsInVariadicParameters()
 		{
 			var mock = new Mock<IFoo>();
@@ -110,6 +129,26 @@ namespace Moq.Tests
 
 			Assert.Equal(1, mock.Object.Echo(7));
 			Assert.Equal(1, mock.Object.Echo(9));
+		}
+
+		[Fact]
+		public void MatchesIsNotInEnumerableWithCustomComparer()
+		{
+			var acceptableArgs = new[] { "foo", "bar" };
+
+			var mock = new Mock<IFoo>();
+
+			mock.Setup(x => x.Execute(It.IsNotIn(acceptableArgs, StringComparer.OrdinalIgnoreCase))).Returns("foo");
+
+			Assert.Equal("foo", mock.Object.Execute("baz"));
+			Assert.Equal("foo", mock.Object.Execute("alpha"));
+
+			Assert.Equal(default, mock.Object.Execute("foo"));
+			Assert.Equal(default, mock.Object.Execute("FOO"));
+			Assert.Equal(default, mock.Object.Execute("FoO"));
+			Assert.Equal(default, mock.Object.Execute("Bar"));
+			Assert.Equal(default, mock.Object.Execute("BAR"));
+			Assert.Equal(default, mock.Object.Execute("bar"));
 		}
 
 		[Fact]


### PR DESCRIPTION
Fixes #1059.