### PR TITLE
Remove superfluous `Convert` nodes added by VB.NET in cases involving constrained generic type parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * New method overloads for `It.Is`, `It.IsIn`, and `It.IsNotIn` that compare values using a custom `IEqualityComparer<T>` (@weitzhandler, #1064)
 Implement It.Is, It.IsIn, It.IsNotIn with a comparer overload (#1059)
 
+#### Fixed
+
+* Setup not triggered due to VB.NET transparently inserting superfluous type conversions into a setup expression (@InteXX, #1067)
+
 
 ## 4.14.6 (2020-09-30)
 

--- a/src/Moq/MatcherFactory.cs
+++ b/src/Moq/MatcherFactory.cs
@@ -120,8 +120,13 @@ namespace Moq
 			// the values are ints, but if the method to call 
 			// expects, say, a double, a Convert node will be on 
 			// the expression.
+			//
+			// Another case is VB.NET explicitly upcasting generic type parameters to the type they're constrained to,
+			// in places where the constrained-to type is expected. Say you have a parameter with static type `TBase`,
+			// and you're passing `It.IsAny<T>()` where `T : TBase`. VB.NET will then transform this call to
+			// `(TBase)(object)It.IsAny<T>()`.
 			var originalExpression = expression;
-			if (expression.NodeType == ExpressionType.Convert)
+			while (expression.NodeType == ExpressionType.Convert)
 			{
 				expression = ((UnaryExpression)expression).Operand;
 			}
@@ -173,7 +178,7 @@ namespace Moq
 			}
 
 			throw new NotSupportedException(
-				string.Format(CultureInfo.CurrentCulture, Resources.UnsupportedExpression, expression));
+				string.Format(CultureInfo.CurrentCulture, Resources.UnsupportedExpression, originalExpression));
 		}
 	}
 }

--- a/tests/Moq.Tests.VisualBasic/IssueReports.vb
+++ b/tests/Moq.Tests.VisualBasic/IssueReports.vb
@@ -1,10 +1,9 @@
 ' Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
 ' All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
-Imports Moq
+Imports System.Linq.Expressions
+
 Imports Xunit
-
-
 
 Public Class IssueReports
 
@@ -27,6 +26,53 @@ Public Class IssueReports
 			ReadOnly Property PropertyWithMultipleArgs(setting As Integer, setting2 As Integer) As Integer
 
 		End Interface
+	End Class
+
+	Public Class Issue1067
+
+		<Fact>
+		Public Sub Test_NonGeneric()
+			Dim userManagerMock = New Mock(Of IUserManager)()
+			Setup_NonGeneric(userManagerMock, 42)
+
+			Dim user As New User()
+			userManagerMock.Object.Create(user)
+
+			Assert.Equal(42, user.Id)
+		End Sub
+
+		<Fact>
+		Public Sub Test_Generic()
+			Dim userManagerMock = New Mock(Of IUserManager)()
+			Setup_Generic(Of User)(userManagerMock, 42)
+
+			Dim user As New User()
+			userManagerMock.Object.Create(user)
+
+			Assert.Equal(42, user.Id)
+		End Sub
+
+		Public Class User
+			Property Id As Integer
+		End Class
+
+		Public Interface IUserManager
+			Sub Create(User As User)
+		End Interface
+
+		Protected Sub Setup_NonGeneric(userManagerMock As Mock(Of IUserManager), expectedId As Integer)
+			userManagerMock.Setup(Sub(manager) manager.Create(It.IsAny(Of User))).Callback(Sub(user) user.Id = expectedId)
+		End Sub
+
+		Protected Sub Setup_Generic(Of TUser As User)(userManagerMock As Mock(Of IUserManager), expectedId As Integer)
+			userManagerMock.Setup(Sub(manager) manager.Create(It.IsAny(Of TUser))).Callback(Sub(user) user.Id = expectedId)
+			'                                                             ^
+			' The use of generics will cause the VB.NET compiler to wrap the `It.IsAny<>` call with two `Convert` nodes.
+			' The inner conversion will convert to `Object`, and the outer conversion will convert to `User` (i.e. the type that
+			' `TUser` is constrained to). `MatcherFactory` needs to be able to recognize the `It.IsAny<>` matcher even if it
+			' is doubly wrapped!
+		End Sub
+
 	End Class
 
 End Class


### PR DESCRIPTION
This should fix #1067.

I'll probably have to run a few more checks on whether it's really safe to blindly remove all type conversion nodes in `MatcherFactory` before merging this.