### PR TITLE
Make `DefaultValue.Mock` inherit property stubbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,14 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * Implement It.Is, It.IsIn, It.IsNotIn with a comparer overload (#1059)
 * New property `IInvocation.ReturnValue` to query recorded invocations return values (@MaStr11, #921)
 
+#### Changed
+
+* Mocks created by `DefaultValue.Mock` now inherit `SetupAllProperties` from their "parent" mock (like it says in the XML documentation) (@stakx, #1074)
+
 #### Fixed
 
 * Setup not triggered due to VB.NET transparently inserting superfluous type conversions into a setup expression (@InteXX, #1067)
+* Nested mocks created by `Mock.Of<T>()` no longer have their properties stubbed since version 4.14.0 (@vruss, @1071)
 
 
 ## 4.14.6 (2020-09-30)

--- a/src/Moq/MockDefaultValueProvider.cs
+++ b/src/Moq/MockDefaultValueProvider.cs
@@ -36,6 +36,7 @@ namespace Moq
 				var mockType = typeof(Mock<>).MakeGenericType(type);
 				Mock newMock = (Mock)Activator.CreateInstance(mockType, mock.Behavior);
 				newMock.DefaultValueProvider = mock.DefaultValueProvider;
+				newMock.AutoSetupPropertiesDefaultValueProvider = mock.AutoSetupPropertiesDefaultValueProvider;
 				if(!type.IsDelegateType())
 				{
 					newMock.CallBase = mock.CallBase;

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -3451,6 +3451,43 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 1071
+
+		public class Issue1071
+		{
+			public interface IFoo
+			{
+				int Property { get; set; }
+			}
+
+			public interface IBar
+			{
+				IFoo Foo { get; set; }
+			}
+
+			[Fact]
+			public void Property_set_up_with_Mock_Of__is_automatically_stubbed__automatic_inner_mock()
+			{
+				var bar = Mock.Of<IBar>(x => x.Foo.Property == 123);
+				Assert.Equal(123, bar.Foo.Property);
+
+				bar.Foo.Property = 321;
+				Assert.Equal(321, bar.Foo.Property);
+			}
+
+			[Fact]
+			public void Property_set_up_with_Mock_Of_is_automatically_stubbed__manual_inner_mock()
+			{
+				var bar = Mock.Of<IBar>(x => x.Foo == Mock.Of<IFoo>(y => y.Property == 123));
+				Assert.Equal(123, bar.Foo.Property);
+
+				bar.Foo.Property = 321;
+				Assert.Equal(321, bar.Foo.Property);
+			}
+		}
+
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47


### PR DESCRIPTION
This should fix #1071.

**Note:** While this introduces a small breaking change (at least in theory), it is one that fulfills a promise made by the pre-existing XML documentation for `SetupAllProperties`:

https://github.com/moq/moq4/blob/947c6a0aa1bbf265b5555ad0a84beb5bfc53b4e2/src/Moq/Mock.Generic.cs#L671-L674