### PR TITLE
Don't require inner mock setups to be matched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 * Setup not triggered due to VB.NET transparently inserting superfluous type conversions into a setup expression (@InteXX, #1067)
 * Nested mocks created by `Mock.Of<T>()` no longer have their properties stubbed since version 4.14.0 (@vruss, @1071)
+* `Verify` fails for recursive setups not explicitly marked as `Verifiable` (@killergege, #1073)
 
 
 ## 4.14.6 (2020-09-30)

--- a/src/Moq/InnerMockSetup.cs
+++ b/src/Moq/InnerMockSetup.cs
@@ -35,5 +35,11 @@ namespace Moq
 		{
 			this.InnerMock.MutableSetups.Reset();
 		}
+
+		protected override bool TryVerifySelf(out MockException error)
+		{
+			error = null;
+			return true;
+		}
 	}
 }

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -3488,6 +3488,30 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 1073
+
+		public class Issue1073
+		{
+			[Fact]
+			public void Test()
+			{
+				var mock = new Mock<IClassA>();
+				mock.Setup(x => x.Items.Count).Returns(1);  // not verifiable, but won't be invoked
+				mock.Setup(x => x.Method()).Verifiable();   // verifiable, and will be invoked
+
+				mock.Object.Method();
+
+				mock.Verify();
+			}
+			public interface IClassA
+			{
+				public IList<string> Items { get; set; }
+				public void Method();
+			}
+		}
+
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47


### PR DESCRIPTION
This fixes #1073.

(Moq's recursive verification is a pain to get right, so I am half expecting this to break something else. Hopefully, we'll soon be able to replace recursive verification with a better ownership rule&mdash;"mocks own setups, not other mocks"&mdash;see https://github.com/moq/moq4/issues/1018#issuecomment-652265316.)