### PR TITLE
Make `Mock.Of<>` work with COM interop types that are annotated with `[CompilerGenerated]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * Setup not triggered due to VB.NET transparently inserting superfluous type conversions into a setup expression (@InteXX, #1067)
 * Nested mocks created by `Mock.Of<T>()` no longer have their properties stubbed since version 4.14.0 (@vruss, @1071)
 * `Verify` fails for recursive setups not explicitly marked as `Verifiable` (@killergege, #1073)
+* `Mock.Of<>` fails for COM interop types that are annotated with a `[CompilerGenerated]` custom attribute (@killergege, #1072)
 
 
 ## 4.14.6 (2020-09-30)

--- a/src/Moq/Linq/MockSetupsBuilder.cs
+++ b/src/Moq/Linq/MockSetupsBuilder.cs
@@ -151,7 +151,7 @@ namespace Moq.Linq
 
 			protected override Expression VisitMember(MemberExpression node)
 			{
-				if (node.Expression is ParameterExpression pe && pe.Type.IsDefined(typeof(CompilerGeneratedAttribute)))
+				if (node.Expression is ParameterExpression pe && pe.Type.IsDefined(typeof(CompilerGeneratedAttribute)) && pe.Type.Name.Contains("f__AnonymousType"))
 				{
 					// In LINQ query expressions with more than one `from` clause such as:
 					//

--- a/tests/Moq.Tests/ComCompatibilityFixture.cs
+++ b/tests/Moq.Tests/ComCompatibilityFixture.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
 using Moq.Tests.ComTypes;
 
 using Xunit;
@@ -99,6 +102,51 @@ namespace Moq.Tests
 			var indexer = typeof(IHasIndexer).GetProperty("Item");
 			var setter = indexer.GetSetMethod(true);
 			Assert.True(setter.IsSetAccessor() && setter.IsIndexerAccessor());
+		}
+
+		[Fact]
+		public void Can_create_mock_of_Excel_Workbook_using_Mock_Of_1()
+		{
+			_ = Mock.Of<GoodWorkbook>(workbook => workbook.FullName == "");
+		}
+
+		[Fact]
+		public void Can_create_mock_of_Excel_Workbook_using_Mock_Of_2()
+		{
+			_ = Mock.Of<BadWorkbook>(workbook => workbook.FullName == "");
+		}
+
+		// The following two interfaces are simplified versions of the `_Workbook` interface from
+		// two different versions of the `Microsoft.Office.Excel.Interop` interop assemblies.
+		// Note how they differ only in one `[CompilerGenerated]` attribute.
+
+		[ComImport]
+		[Guid("000208DA-0000-0000-C000-000000000046")]
+		public interface GoodWorkbook
+		{
+			[DispId(289)]
+			string FullName
+			{
+				[DispId(289)]
+				[LCIDConversion(0)]
+				[return: MarshalAs(UnmanagedType.BStr)]
+				get;
+			}
+		}
+
+		[ComImport]
+		[CompilerGenerated]
+		[Guid("000208DA-0000-0000-C000-000000000046")]
+		public interface BadWorkbook
+		{
+			[DispId(289)]
+			string FullName
+			{
+				[DispId(289)]
+				[LCIDConversion(0)]
+				[return: MarshalAs(UnmanagedType.BStr)]
+				get;
+			}
 		}
 	}
 }


### PR DESCRIPTION
This should fix #1072.