### PR TITLE
 Evaluate all captured variables when comparing LINQ expressions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 #### Fixed
 
 * `SetupProperty` fails if property getter and setter are not both defined in mocked type (@stakx, #1017)
+* Expression tree argument not matched when it contains a captured variable &ndash; evaluate all captures to their current values when comparing two expression trees (@QTom01, #1054)
 
 
 ## 4.14.7 (2020-10-14)

--- a/src/Moq/ExpressionComparer.cs
+++ b/src/Moq/ExpressionComparer.cs
@@ -31,6 +31,19 @@ namespace Moq
 				return false;
 			}
 
+			// Before actually comparing two nodes, make sure that captures variables have been
+			// evaluated to their current values (as we don't want to compare their identities):
+
+			if (x is MemberExpression)
+			{
+				x = x.Apply(EvaluateCaptures.Rewriter);
+			}
+
+			if (y is MemberExpression)
+			{
+				y = y.Apply(EvaluateCaptures.Rewriter);
+			}
+
 			if (x.NodeType == y.NodeType)
 			{
 				switch (x.NodeType)
@@ -200,21 +213,7 @@ namespace Moq
 
 		private bool EqualsMember(MemberExpression x, MemberExpression y)
 		{
-			// If any of the two nodes represents an access to a captured variable,
-			// we want to compare its value, not its identity. (`EvaluateCaptures` is
-			// a no-op in all other cases, so it is safe to apply "just in case".)
-			var rx = x.Apply(EvaluateCaptures.Rewriter);
-			var ry = y.Apply(EvaluateCaptures.Rewriter);
-
-			if (rx == x && ry == y)
-			{
-				return x.Member == y.Member && this.Equals(x.Expression, y.Expression);
-			}
-			else
-			{
-				// Rewriting occurred, we might no longer have two `MemberExpression`s:
-				return this.Equals(rx, ry);
-			}
+			return x.Member == y.Member && this.Equals(x.Expression, y.Expression);
 		}
 
 		private bool EqualsMemberInit(MemberInitExpression x, MemberInitExpression y)

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -3451,6 +3451,52 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 1054
+
+		public class Issue1054
+		{
+			// These tests assert that Moq compares the values of captured variables
+			// (as opposed to their identities).
+
+			[Fact]
+			public void String_constant()
+			{
+				var s1 = "example";
+				const string s2 = "example";
+
+				var mock = new Mock<IMockObject>();
+				mock.Setup(x => x.Method(y => y.Id == s1)).Returns("mockResult");
+				var result = mock.Object.Method(x => x.Id == s2);
+
+				Assert.Equal("mockResult", result);
+			}
+
+			[Fact]
+			public void String_variable()
+			{
+				var s1 = "example";
+				var s2 = "example";
+
+				var mock = new Mock<IMockObject>();
+				mock.Setup(x => x.Method(y => y.Id == s1)).Returns("mockResult");
+				var result = mock.Object.Method(x => x.Id == s2);
+
+				Assert.Equal("mockResult", result);
+			}
+
+			public class MyObject
+			{
+				public string Id { get; set; }
+			}
+
+			public interface IMockObject
+			{
+				public string Method(Expression<Func<MyObject, bool>> expression);
+			}
+		}
+
+		#endregion
+
 		#region 1071
 
 		public class Issue1071


### PR DESCRIPTION
Fixed #1054.