### PR TITLE
Enable parameterized `Mock.Of<>` in query comprehension `from` clause 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 * `SetupProperty` fails if property getter and setter are not both defined in mocked type (@stakx, #1017)
 * Expression tree argument not matched when it contains a captured variable &ndash; evaluate all captures to their current values when comparing two expression trees (@QTom01, #1054)
+* Failure when parameterized `Mock.Of<>` is used in query comprehension `from` clause (@stakx, #982)
 
 
 ## 4.14.7 (2020-10-14)

--- a/src/Moq/Linq/MockSetupsBuilder.cs
+++ b/src/Moq/Linq/MockSetupsBuilder.cs
@@ -18,6 +18,7 @@ namespace Moq.Linq
 		private static readonly string[] unsupportedMethods = new[] { "All", "Any", "Last", "LastOrDefault", "Single", "SingleOrDefault" };
 
 		private int stackIndex;
+		private int quoteDepth;
 
 		public MockSetupsBuilder()
 		{
@@ -89,6 +90,14 @@ namespace Moq.Linq
 			if (this.stackIndex > 0 && node.NodeType == ExpressionType.Not)
 			{
 				return ConvertToSetup(node.Operand, Expression.Constant(false)) ?? base.VisitUnary(node);
+			}
+
+			if (node.NodeType == ExpressionType.Quote)
+			{
+				this.quoteDepth++;
+				var result = this.quoteDepth > 1 ? node : base.VisitUnary(node);
+				this.quoteDepth--;
+				return result;
 			}
 
 			return base.VisitUnary(node);

--- a/tests/Moq.Tests/Linq/QueryableMocksFixture.cs
+++ b/tests/Moq.Tests/Linq/QueryableMocksFixture.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 
 using Xunit;
 
-namespace Moq.Tests
+namespace Moq.Tests.Linq
 {
 	public class QueryableMocksFixture
 	{

--- a/tests/Moq.Tests/Linq/QueryableMocksFixture.cs
+++ b/tests/Moq.Tests/Linq/QueryableMocksFixture.cs
@@ -212,6 +212,27 @@ namespace Moq.Tests
 			Assert.Throws<MockException>(() => _ = foo.Name);
 		}
 
+		[Fact]
+		public void Multiple_mocks_with_query_comprehension_syntax__predicates_in_where_clause()
+		{
+			var x = (from x1 in Mocks.Of<IFoo>()
+			         from __ in Mocks.Of<IFoo>()
+			         where x1.Name == "1" && __.Name == "2"
+			         select x1)
+			        .First();
+			Assert.Equal("1", x.Name);
+		}
+
+		[Fact]
+		public void Multiple_mocks_with_query_comprehension_syntax__predicates_in_from_clause()
+		{
+			var x = (from x1 in Mocks.Of<IFoo>(_ => _.Name == "1")
+			         from __ in Mocks.Of<IFoo>(_ => _.Name == "2")
+			         select x1)
+			        .First();
+			Assert.Equal("1", x.Name);
+		}
+
 		public class Dto
 		{
 			public string Value { get; set; }


### PR DESCRIPTION
Fixes #982.