### PR TITLE
Add Discord channel link to improve the experience over Gitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The most popular and friendly mocking library for .NET
 
 [![Version](https://img.shields.io/nuget/vpre/Moq.svg)](https://www.nuget.org/packages/Moq)
 [![Downloads](https://img.shields.io/nuget/dt/Moq.svg)](https://www.nuget.org/packages/Moq)
+[![Discord Chat](https://img.shields.io/badge/chat-on%20discord-7289DA.svg)](https://discord.gg/8PtpGdu)
 [![Join the chat at https://gitter.im/moq/moq](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/moq/moq?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 


### PR DESCRIPTION
Discord has several benefits over gitter and is now the de-facto place for other Microsoft large-scale projects (i.e. https://cs.dotnet.gg/)

I'm there now most of the time, so selfishly, I'd like to move this over too :)