### PR TITLE
Fix for slow down with many setups on single mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
+## Unreleased
+
+#### Fixed
+
+* Added Hashset of active invocations to SetupCollection to only call MarkOverridden when a duplicated expectation is added (@CeesKaas, #1110)
+
 ## 4.15.2 (2020-11-26)
 
 #### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 #### Fixed
 
-* Added Hashset of active invocations to SetupCollection to only call MarkOverridden when a duplicated expectation is added (@CeesKaas, #1110)
+* Performance regression: Adding setups to a mock becomes slower with each setup (@CeesKaas, #1110)
 
 ## 4.15.2 (2020-11-26)
 

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -11,10 +11,12 @@ namespace Moq
 	internal sealed class SetupCollection : ISetupList
 	{
 		private List<Setup> setups;
+		private HashSet<InvocationShape> activeInvocationShapes;
 
 		public SetupCollection()
 		{
 			this.setups = new List<Setup>();
+			this.activeInvocationShapes = new HashSet<InvocationShape>();
 		}
 
 		public int Count
@@ -44,8 +46,10 @@ namespace Moq
 			lock (this.setups)
 			{
 				this.setups.Add(setup);
-
-				this.MarkOverriddenSetups();
+				if (!this.activeInvocationShapes.Add(setup.Expectation))
+				{
+					this.MarkOverriddenSetups();
+				}
 			}
 		}
 
@@ -101,6 +105,7 @@ namespace Moq
 			lock (this.setups)
 			{
 				this.setups.Clear();
+				this.activeInvocationShapes.Clear();
 			}
 		}
 

--- a/tests/Moq.Tests/MockFixture.cs
+++ b/tests/Moq.Tests/MockFixture.cs
@@ -1312,37 +1312,5 @@ namespace Moq.Tests
 			Assert.ThrowsAny<Exception>(() => mock.Object.BadSerializable);
 		}
 #endif
-
-		public interface ITestInterface
-		{
-			void Get(Guid id);
-		}
-
-		[Fact]
-		public void Thousand_different_setups_can_be_done_in_under_a_second()
-		{
-			var sw = System.Diagnostics.Stopwatch.StartNew();
-			var mock = new Mock<ITestInterface>();
-			for (int i = 0; i < 1000; i++)
-			{
-				mock.Setup(m => m.Get(Guid.NewGuid()));
-			}
-			sw.Stop();
-			Assert.True(sw.Elapsed < TimeSpan.FromSeconds(1), $"Setups were expected to take less than a second but it took {sw.Elapsed}");
-		}
-
-		[Fact]
-		public void Thousand_same_setups_can_be_done_in_under_a_second()
-		{
-			var sw = System.Diagnostics.Stopwatch.StartNew();
-			var mock = new Mock<ITestInterface>();
-			var id = Guid.NewGuid();
-			for (int i = 0; i < 1000; i++)
-			{
-				mock.Setup(m => m.Get(id));
-			}
-			sw.Stop();
-			Assert.True(sw.Elapsed < TimeSpan.FromSeconds(1), $"Setups were expected to take less than a second but it took {sw.Elapsed}");
-		}
 	}
 }

--- a/tests/Moq.Tests/MockFixture.cs
+++ b/tests/Moq.Tests/MockFixture.cs
@@ -1312,5 +1312,37 @@ namespace Moq.Tests
 			Assert.ThrowsAny<Exception>(() => mock.Object.BadSerializable);
 		}
 #endif
+
+		public interface ITestInterface
+		{
+			void Get(Guid id);
+		}
+
+		[Fact]
+		public void Thousand_different_setups_can_be_done_in_under_a_second()
+		{
+			var sw = System.Diagnostics.Stopwatch.StartNew();
+			var mock = new Mock<ITestInterface>();
+			for (int i = 0; i < 1000; i++)
+			{
+				mock.Setup(m => m.Get(Guid.NewGuid()));
+			}
+			sw.Stop();
+			Assert.True(sw.Elapsed < TimeSpan.FromSeconds(1), $"Setups were expected to take less than a second but it took {sw.Elapsed}");
+		}
+
+		[Fact]
+		public void Thousand_same_setups_can_be_done_in_under_a_second()
+		{
+			var sw = System.Diagnostics.Stopwatch.StartNew();
+			var mock = new Mock<ITestInterface>();
+			var id = Guid.NewGuid();
+			for (int i = 0; i < 1000; i++)
+			{
+				mock.Setup(m => m.Get(id));
+			}
+			sw.Stop();
+			Assert.True(sw.Elapsed < TimeSpan.FromSeconds(1), $"Setups were expected to take less than a second but it took {sw.Elapsed}");
+		}
 	}
 }


### PR DESCRIPTION
I've played with the code a bit this morning and this change fixes the unittests I've added (at the cost of a bit of extra memory consumption and an extra operation always to save n operations in most cases)

fixes #1110 