### PR TITLE
Added GetInvocationsOf extension method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+#### Added
+
+* Added extension method `GetInvocationsOf` which returns only the invocations on the specified method (same lamda specification like in Setup/Verify).
+
 
 ## 4.15.2 (2020-11-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 #### Added
 
-* Added extension method `GetInvocationsOf` which returns only the invocations on the specified method (same lamda specification like in Setup/Verify).
+* Added extension method `GetInvocationsOf` which returns only the invocations on the specified method (same lamda specification like in Setup/Verify). (@Mrxx99, #1115)
 
 
 ## 4.15.2 (2020-11-26)

--- a/src/Moq/MockExtensions.cs
+++ b/src/Moq/MockExtensions.cs
@@ -1,7 +1,11 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
+using System.Linq.Expressions;
 
 namespace Moq
 {
@@ -21,6 +25,35 @@ namespace Moq
 			mock.MutableSetups.Clear();
 			mock.EventHandlers.Clear();
 			mock.Invocations.Clear();
+		}
+
+		/// <summary>
+		/// Gets the invocations on this mock of the specified method. The arguments of the specified method will be ignored.
+		/// </summary>
+		/// <typeparam name="T">The mocked type.</typeparam>
+		/// <param name="mock">The mock which should be queried for invocations.</param>
+		/// <param name="methodCall">Lambda expression that specifies the method invocation for which to return the invocations.</param>
+		/// <returns>A list of all invocations of the specified method on this mock.</returns>
+		/// <example>
+		///   <code>
+		///     var mock = new Mock&lt;IProcessor&gt;();
+		///     
+		///     ... // exercise mock
+		///     
+		///     var invocationsOnExecute = mock.GetInvocationsOf(x => x.Execute(default(string)));
+		///   </code>
+		/// </example>
+		public static IEnumerable<IInvocation> GetInvocationsOf<T>(this Mock<T> mock, Expression<Action<T>> methodCall) where T : class
+		{
+			var methodCallExpression = (MethodCallExpression)methodCall.Body;
+			var calledMethod = methodCallExpression.Method;
+
+			var invocationsOfMethod = from invocation in mock.Invocations
+									   let method = invocation.Method
+									   where method == calledMethod
+									   select invocation;
+
+			return invocationsOfMethod;
 		}
 	}
 }


### PR DESCRIPTION
This adds one extension method to `Mock<T>` called `GetInvocationsOf` which allows to get the invocations on one specific method instead of all methods like with `Mock.Invocations`.

This acts like the `GetArgumentsForCallsMadeOn` method from Rhino.Mocks.
It can be used like this:
```csharp
	var mock = new Mock<IProcessor>();
		
	... // exercise mock
		
	var invocationsOnExecute = mock.GetInvocationsOf(x => x.Execute(default(string)));
```

Like the Rhino.Mocks verison it ignores the values of the arguments on the specified method.
This is very useful when you need to inspect the arguments of a method call manually.