### PR TITLE
Abandon 'Try' pattern in verification methods

### DIFF
--- a/src/Moq/AutoImplementedPropertyGetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertyGetterSetup.cs
@@ -35,10 +35,8 @@ namespace Moq
 			return true;
 		}
 
-		protected override bool TryVerifySelf(out MockException error)
+		protected override void VerifySelf()
 		{
-			error = null;
-			return true;
 		}
 	}
 }

--- a/src/Moq/AutoImplementedPropertySetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertySetterSetup.cs
@@ -28,10 +28,8 @@ namespace Moq
 			this.setter.Invoke(invocation.Arguments[0]);
 		}
 
-		protected override bool TryVerifySelf(out MockException error)
+		protected override void VerifySelf()
 		{
-			error = null;
-			return true;
 		}
 	}
 }

--- a/src/Moq/InnerMockSetup.cs
+++ b/src/Moq/InnerMockSetup.cs
@@ -36,10 +36,8 @@ namespace Moq
 			this.InnerMock.MutableSetups.Reset();
 		}
 
-		protected override bool TryVerifySelf(out MockException error)
+		protected override void VerifySelf()
 		{
-			error = null;
-			return true;
 		}
 	}
 }


### PR DESCRIPTION
This makes code both shorter and more consistent with the existing code pattern used in `MockRepository`.