### PR TITLE
Add ability to set up the `.Result` of (value) tasks

### DIFF
--- a/src/Moq/Async/AwaitExpression.cs
+++ b/src/Moq/Async/AwaitExpression.cs
@@ -1,0 +1,40 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.Diagnostics;
+using System.Linq.Expressions;
+
+namespace Moq.Async
+{
+	internal sealed class AwaitExpression : Expression
+	{
+		private readonly IAwaitableFactory awaitableFactory;
+		private readonly Expression operand;
+
+		public AwaitExpression(Expression operand, IAwaitableFactory awaitableFactory)
+		{
+			Debug.Assert(awaitableFactory != null);
+			Debug.Assert(operand != null);
+
+			this.awaitableFactory = awaitableFactory;
+			this.operand = operand;
+		}
+
+		public override bool CanReduce => false;
+
+		public override ExpressionType NodeType => ExpressionType.Extension;
+
+		public Expression Operand => this.operand;
+
+		public override Type Type => this.awaitableFactory.ResultType;
+
+		public override string ToString()
+		{
+			return this.awaitableFactory.ResultType == typeof(void) ? $"await {this.operand}"
+			                                                        : $"(await {this.operand})";
+		}
+
+		protected override Expression VisitChildren(ExpressionVisitor visitor) => this;
+	}
+}

--- a/src/Moq/Async/AwaitableFactory`1.cs
+++ b/src/Moq/Async/AwaitableFactory`1.cs
@@ -2,7 +2,9 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 namespace Moq.Async
 {
@@ -21,6 +23,25 @@ namespace Moq.Async
 			Debug.Assert(result == null);
 
 			return this.CreateCompleted();
+		}
+
+		public abstract TAwaitable CreateFaulted(Exception exception);
+
+		object IAwaitableFactory.CreateFaulted(Exception exception)
+		{
+			Debug.Assert(exception != null);
+
+			return this.CreateFaulted(exception);
+		}
+
+		public abstract TAwaitable CreateFaulted(IEnumerable<Exception> exceptions);
+
+		object IAwaitableFactory.CreateFaulted(IEnumerable<Exception> exceptions)
+		{
+			Debug.Assert(exceptions != null);
+			Debug.Assert(exceptions.Any());
+
+			return this.CreateFaulted(exceptions);
 		}
 
 		bool IAwaitableFactory.TryGetResult(object awaitable, out object result)

--- a/src/Moq/Async/AwaitableFactory`1.cs
+++ b/src/Moq/Async/AwaitableFactory`1.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Linq.Expressions;
 
 namespace Moq.Async
 {
@@ -42,6 +43,11 @@ namespace Moq.Async
 			Debug.Assert(exceptions.Any());
 
 			return this.CreateFaulted(exceptions);
+		}
+
+		Expression IAwaitableFactory.CreateResultExpression(Expression awaitableExpression)
+		{
+			return new AwaitExpression(awaitableExpression, this);
 		}
 
 		bool IAwaitableFactory.TryGetResult(object awaitable, out object result)

--- a/src/Moq/Async/AwaitableFactory`2.cs
+++ b/src/Moq/Async/AwaitableFactory`2.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Linq.Expressions;
 
 namespace Moq.Async
 {
@@ -45,6 +46,8 @@ namespace Moq.Async
 		}
 
 		public abstract bool TryGetResult(TAwaitable awaitable, out TResult result);
+
+		public abstract Expression CreateResultExpression(Expression awaitableExpression);
 
 		bool IAwaitableFactory.TryGetResult(object awaitable, out object result)
 		{

--- a/src/Moq/Async/AwaitableFactory`2.cs
+++ b/src/Moq/Async/AwaitableFactory`2.cs
@@ -2,7 +2,9 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 namespace Moq.Async
 {
@@ -21,6 +23,25 @@ namespace Moq.Async
 			Debug.Assert(result is TResult || result == null);
 
 			return this.CreateCompleted((TResult)result);
+		}
+
+		public abstract TAwaitable CreateFaulted(Exception exception);
+
+		object IAwaitableFactory.CreateFaulted(Exception exception)
+		{
+			Debug.Assert(exception != null);
+
+			return this.CreateFaulted(exception);
+		}
+
+		public abstract TAwaitable CreateFaulted(IEnumerable<Exception> exceptions);
+
+		object IAwaitableFactory.CreateFaulted(IEnumerable<Exception> exceptions)
+		{
+			Debug.Assert(exceptions != null);
+			Debug.Assert(exceptions.Any());
+
+			return this.CreateFaulted(exceptions);
 		}
 
 		public abstract bool TryGetResult(TAwaitable awaitable, out TResult result);

--- a/src/Moq/Async/IAwaitableFactory.cs
+++ b/src/Moq/Async/IAwaitableFactory.cs
@@ -2,6 +2,7 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
+using System.Collections.Generic;
 
 namespace Moq.Async
 {
@@ -10,6 +11,10 @@ namespace Moq.Async
 		Type ResultType { get; }
 
 		object CreateCompleted(object result = null);
+
+		object CreateFaulted(Exception exception);
+
+		object CreateFaulted(IEnumerable<Exception> exceptions);
 
 		bool TryGetResult(object awaitable, out object result);
 	}

--- a/src/Moq/Async/IAwaitableFactory.cs
+++ b/src/Moq/Async/IAwaitableFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 
 namespace Moq.Async
 {
@@ -15,6 +16,8 @@ namespace Moq.Async
 		object CreateFaulted(Exception exception);
 
 		object CreateFaulted(IEnumerable<Exception> exceptions);
+
+		Expression CreateResultExpression(Expression awaitableExpression);
 
 		bool TryGetResult(object awaitable, out object result);
 	}

--- a/src/Moq/Async/TaskFactory.cs
+++ b/src/Moq/Async/TaskFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
 

--- a/src/Moq/Async/TaskFactory.cs
+++ b/src/Moq/Async/TaskFactory.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using System;
+using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace Moq.Async
@@ -16,6 +19,20 @@ namespace Moq.Async
 		public override Task CreateCompleted()
 		{
 			return Task.FromResult<object>(default);
+		}
+
+		public override Task CreateFaulted(Exception exception)
+		{
+			var tcs = new TaskCompletionSource<object>();
+			tcs.SetException(exception);
+			return tcs.Task;
+		}
+
+		public override Task CreateFaulted(IEnumerable<Exception> exceptions)
+		{
+			var tcs = new TaskCompletionSource<object>();
+			tcs.SetException(exceptions);
+			return tcs.Task;
 		}
 	}
 }

--- a/src/Moq/Async/TaskFactory`1.cs
+++ b/src/Moq/Async/TaskFactory`1.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Moq.Async
@@ -10,6 +12,20 @@ namespace Moq.Async
 		public override Task<TResult> CreateCompleted(TResult result)
 		{
 			return Task.FromResult(result);
+		}
+
+		public override Task<TResult> CreateFaulted(Exception exception)
+		{
+			var tcs = new TaskCompletionSource<TResult>();
+			tcs.SetException(exception);
+			return tcs.Task;
+		}
+
+		public override Task<TResult> CreateFaulted(IEnumerable<Exception> exceptions)
+		{
+			var tcs = new TaskCompletionSource<TResult>();
+			tcs.SetException(exceptions);
+			return tcs.Task;
 		}
 
 		public override bool TryGetResult(Task<TResult> task, out TResult result)

--- a/src/Moq/Async/TaskFactory`1.cs
+++ b/src/Moq/Async/TaskFactory`1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 
 namespace Moq.Async
@@ -26,6 +27,13 @@ namespace Moq.Async
 			var tcs = new TaskCompletionSource<TResult>();
 			tcs.SetException(exceptions);
 			return tcs.Task;
+		}
+
+		public override Expression CreateResultExpression(Expression awaitableExpression)
+		{
+			return Expression.MakeMemberAccess(
+				awaitableExpression,
+				typeof(Task<TResult>).GetProperty(nameof(Task<TResult>.Result)));
 		}
 
 		public override bool TryGetResult(Task<TResult> task, out TResult result)

--- a/src/Moq/Async/ValueTaskFactory.cs
+++ b/src/Moq/Async/ValueTaskFactory.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Moq.Async
@@ -16,6 +18,20 @@ namespace Moq.Async
 		public override ValueTask CreateCompleted()
 		{
 			return default;
+		}
+
+		public override ValueTask CreateFaulted(Exception exception)
+		{
+			var tcs = new TaskCompletionSource<object>();
+			tcs.SetException(exception);
+			return new ValueTask(tcs.Task);
+		}
+
+		public override ValueTask CreateFaulted(IEnumerable<Exception> exceptions)
+		{
+			var tcs = new TaskCompletionSource<object>();
+			tcs.SetException(exceptions);
+			return new ValueTask(tcs.Task);
 		}
 	}
 }

--- a/src/Moq/Async/ValueTaskFactory`1.cs
+++ b/src/Moq/Async/ValueTaskFactory`1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 
 namespace Moq.Async
@@ -26,6 +27,13 @@ namespace Moq.Async
 			var tcs = new TaskCompletionSource<TResult>();
 			tcs.SetException(exceptions);
 			return new ValueTask<TResult>(tcs.Task);
+		}
+
+		public override Expression CreateResultExpression(Expression awaitableExpression)
+		{
+			return Expression.MakeMemberAccess(
+				awaitableExpression,
+				typeof(ValueTask<TResult>).GetProperty(nameof(ValueTask<TResult>.Result)));
 		}
 
 		public override bool TryGetResult(ValueTask<TResult> valueTask, out TResult result)

--- a/src/Moq/Async/ValueTaskFactory`1.cs
+++ b/src/Moq/Async/ValueTaskFactory`1.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Moq.Async
@@ -10,6 +12,20 @@ namespace Moq.Async
 		public override ValueTask<TResult> CreateCompleted(TResult result)
 		{
 			return new ValueTask<TResult>(result);
+		}
+
+		public override ValueTask<TResult> CreateFaulted(Exception exception)
+		{
+			var tcs = new TaskCompletionSource<TResult>();
+			tcs.SetException(exception);
+			return new ValueTask<TResult>(tcs.Task);
+		}
+
+		public override ValueTask<TResult> CreateFaulted(IEnumerable<Exception> exceptions)
+		{
+			var tcs = new TaskCompletionSource<TResult>();
+			tcs.SetException(exceptions);
+			return new ValueTask<TResult>(tcs.Task);
 		}
 
 		public override bool TryGetResult(ValueTask<TResult> valueTask, out TResult result)

--- a/src/Moq/Invocation.cs
+++ b/src/Moq/Invocation.cs
@@ -7,6 +7,8 @@ using System.Diagnostics;
 using System.Reflection;
 using System.Text;
 
+using Moq.Async;
+
 namespace Moq
 {
 	internal abstract class Invocation : IInvocation
@@ -86,6 +88,18 @@ namespace Moq
 			{
 				Debug.Assert(this.result == null);
 				this.result = new ExceptionResult(value);
+			}
+		}
+
+		public void ConvertResultToAwaitable(IAwaitableFactory awaitableFactory)
+		{
+			if (this.result is ExceptionResult r)
+			{
+				this.result = awaitableFactory.CreateFaulted(r.Exception);
+			}
+			else if (this.result != null && !this.method.ReturnType.IsAssignableFrom(this.result.GetType()))
+			{
+				this.result = awaitableFactory.CreateCompleted(this.result);
 			}
 		}
 

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -65,7 +65,25 @@ namespace Moq
 			this.Condition?.SetupEvaluatedSuccessfully();
 			this.expectation.SetupEvaluatedSuccessfully(invocation);
 
-			this.ExecuteCore(invocation);
+			if (this.expectation.HasResultExpression(out var awaitableFactory))
+			{
+				try
+				{
+					this.ExecuteCore(invocation);
+				}
+				catch (Exception exception)
+				{
+					invocation.Exception = exception;
+				}
+				finally
+				{
+					invocation.ConvertResultToAwaitable(awaitableFactory);
+				}
+			}
+			else
+			{
+				this.ExecuteCore(invocation);
+			}
 		}
 
 		protected abstract void ExecuteCore(Invocation invocation);

--- a/tests/Moq.Tests/SetupTaskResultFixture.cs
+++ b/tests/Moq.Tests/SetupTaskResultFixture.cs
@@ -1,0 +1,303 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace Moq.Tests
+{
+	public class SetupTaskResultFixture
+	{
+		private readonly Exception Exception = new Exception("bad");
+		private readonly Exception SecondException = new Exception("very bad");
+
+		private readonly IPerson Friend = Mock.Of<IPerson>(p => p.Name == "Alice");
+		private readonly string NameOfFriend = "Alice";
+		private readonly string SecondNameOfFriend = "Alicia";
+
+		private readonly IPerson SecondFriend = Mock.Of<IPerson>(p => p.Name == "Betty");
+
+		public interface IPerson
+		{
+			string Name { get; set; }
+			Task<string> GetNameTaskAsync();
+			ValueTask<string> GetNameValueTaskAsync();
+
+			IPerson Friend { get; set; }
+			Task<IPerson> GetFriendTaskAsync();
+			ValueTask<IPerson> GetFriendValueTaskAsync();
+		}
+
+		[Fact]
+		public async Task Setup__task_Result__creates_a_single_setup()
+		{
+			var person = new Mock<IPerson>() { DefaultValue = DefaultValue.Mock };
+			person.Setup(p => p.GetFriendTaskAsync().Result);
+			var friend = Mock.Get(await person.Object.GetFriendTaskAsync());
+			Assert.Single(person.Setups);
+			Assert.Empty(friend.Setups);
+		}
+
+		[Fact]
+		public async Task Mock_Of__completed_Task()
+		{
+			var person = Mock.Of<IPerson>(p => p.GetFriendTaskAsync().Result == Friend);
+			var friend = await person.GetFriendTaskAsync();
+			Assert.Same(Friend, friend);
+		}
+
+		[Fact]
+		public async Task Mock_Of__completed_ValueTask()
+		{
+			var person = Mock.Of<IPerson>(p => p.GetFriendValueTaskAsync().Result == Friend);
+			var friend = await person.GetFriendValueTaskAsync();
+			Assert.Same(Friend, friend);
+		}
+
+		[Fact]
+		public async Task Mock_Of__property_of__completed_Task()
+		{
+			var person = Mock.Of<IPerson>(p => p.GetFriendTaskAsync().Result.Name == NameOfFriend);
+			var friend = await person.GetFriendTaskAsync();
+			Assert.Equal(NameOfFriend, friend.Name);
+		}
+
+		[Fact]
+		public async Task Mock_Of__property_of__completed_ValueTask()
+		{
+			var person = Mock.Of<IPerson>(p => p.GetFriendValueTaskAsync().Result.Name == NameOfFriend);
+			var friend = await person.GetFriendValueTaskAsync();
+			Assert.Equal(NameOfFriend, friend.Name);
+		}
+
+		[Fact]
+		public async Task Mock_Of__properties_of__completed_Task()
+		{
+			var person = Mock.Of<IPerson>(p => p.GetFriendTaskAsync().Result.Name == NameOfFriend
+			                                && p.GetFriendTaskAsync().Result.Friend == SecondFriend);
+			var friend = await person.GetFriendTaskAsync();
+			Assert.Equal(NameOfFriend, friend.Name);
+			Assert.Same(SecondFriend, friend.Friend);
+		}
+
+		[Fact]
+		public async Task Mock_Of__properties_of__completed_ValueTask()
+		{
+			var person = Mock.Of<IPerson>(p => p.GetFriendValueTaskAsync().Result.Name == NameOfFriend
+			                                && p.GetFriendValueTaskAsync().Result.Friend == SecondFriend);
+			var friend = await person.GetFriendValueTaskAsync();
+			Assert.Equal(NameOfFriend, friend.Name);
+			Assert.Same(SecondFriend, friend.Friend);
+		}
+
+		[Fact]
+		public async Task Setup__completed_Task__Returns()
+		{
+			var person = new Mock<IPerson>();
+			person.Setup(p => p.GetFriendTaskAsync().Result).Returns(Friend);
+			var friend = await person.Object.GetFriendTaskAsync();
+			Assert.Same(Friend, friend);
+		}
+
+		[Fact]
+		public async Task Setup__completed_Task__Throws()
+		{
+			var person = new Mock<IPerson>();
+			person.Setup(p => p.GetFriendTaskAsync().Result).Throws(Exception);
+			var exception = await Assert.ThrowsAsync<Exception>(async () => await person.Object.GetFriendTaskAsync());
+			Assert.Same(Exception, exception);
+		}
+
+		[Fact]
+		public async Task Setup__completed_ValueTask__Returns()
+		{
+			var person = new Mock<IPerson>();
+			person.Setup(p => p.GetFriendValueTaskAsync().Result).Returns(Friend);
+			var friend = await person.Object.GetFriendValueTaskAsync();
+			Assert.Same(Friend, friend);
+		}
+
+		[Fact]
+		public async Task Setup__completed_ValueTask__Throws()
+		{
+			var person = new Mock<IPerson>();
+			person.Setup(p => p.GetFriendValueTaskAsync().Result).Throws(Exception);
+			var exception = await Assert.ThrowsAsync<Exception>(async () => await person.Object.GetFriendValueTaskAsync());
+			Assert.Same(Exception, exception);
+		}
+
+		[Fact]
+		public async Task SetupGet__property_of__completed_Task__Returns()
+		{
+			var person = new Mock<IPerson>();
+			person.SetupGet(p => p.GetFriendTaskAsync().Result.Name).Returns(NameOfFriend);
+			var friend = await person.Object.GetFriendTaskAsync();
+			Assert.Equal(NameOfFriend, friend.Name);
+		}
+
+		[Fact]
+		public async Task SetupGet__property_of__completed_Task__Throws()
+		{
+			var person = new Mock<IPerson>();
+			person.SetupGet(p => p.GetFriendTaskAsync().Result.Name).Throws(Exception);
+			var friend = await person.Object.GetFriendTaskAsync();
+			var exception = Assert.Throws<Exception>(() => friend.Name);
+			Assert.Same(Exception, exception);
+		}
+
+		[Fact]
+		public async Task SetupGet__property_of__completed_ValueTask__Returns()
+		{
+			var person = new Mock<IPerson>();
+			person.Setup(m => m.GetFriendValueTaskAsync().Result.Name).Returns(NameOfFriend);
+			var friend = await person.Object.GetFriendValueTaskAsync();
+			Assert.Equal(NameOfFriend, friend.Name);
+		}
+
+		[Fact]
+		public async Task SetupGet__property_of__completed_ValueTask__Throws()
+		{
+			var person = new Mock<IPerson>();
+			person.SetupGet(p => p.GetFriendValueTaskAsync().Result.Name).Throws(Exception);
+			var friend = await person.Object.GetFriendValueTaskAsync();
+			var exception = Assert.Throws<Exception>(() => friend.Name);
+			Assert.Same(Exception, exception);
+		}
+
+		[Fact]
+		public async Task SetupSequence__completed_Task__Returns()
+		{
+			var person = new Mock<IPerson>();
+			person.SetupSequence(p => p.GetFriendTaskAsync().Result).Returns(Friend).Returns(SecondFriend);
+			var friend = await person.Object.GetFriendTaskAsync();
+			var secondFriend = await person.Object.GetFriendTaskAsync();
+			Assert.Same(Friend, friend);
+			Assert.Same(SecondFriend, secondFriend);
+		}
+
+		[Fact]
+		public async Task SetupSequence__completed_Task__Throws()
+		{
+			var person = new Mock<IPerson>();
+			person.SetupSequence(p => p.GetFriendTaskAsync().Result).Throws(Exception).Throws(SecondException);
+			var exception = await Assert.ThrowsAsync<Exception>(async () => await person.Object.GetFriendTaskAsync());
+			var secondException = await Assert.ThrowsAsync<Exception>(async () => await person.Object.GetFriendTaskAsync());
+			Assert.Same(Exception, exception);
+			Assert.Same(SecondException, secondException);
+		}
+
+		[Fact]
+		public async Task SetupSequence__completed_ValueTask__Returns()
+		{
+			var person = new Mock<IPerson>();
+			person.SetupSequence(p => p.GetFriendValueTaskAsync().Result).Returns(Friend).Returns(SecondFriend);
+			var friend = await person.Object.GetFriendValueTaskAsync();
+			var secondFriend = await person.Object.GetFriendValueTaskAsync();
+			Assert.Same(Friend, friend);
+			Assert.Same(SecondFriend, secondFriend);
+		}
+
+		[Fact]
+		public async Task SetupSequence__completed_ValueTask__Throws()
+		{
+			var person = new Mock<IPerson>();
+			person.SetupSequence(p => p.GetFriendValueTaskAsync().Result).Throws(Exception).Throws(SecondException);
+			var exception = await Assert.ThrowsAsync<Exception>(async () => await person.Object.GetFriendValueTaskAsync());
+			var secondException = await Assert.ThrowsAsync<Exception>(async () => await person.Object.GetFriendValueTaskAsync());
+			Assert.Same(Exception, exception);
+			Assert.Same(SecondException, secondException);
+		}
+
+		[Fact]
+		public async Task SetupSequence__property_of__completed_Task__Returns()
+		{
+			var person = new Mock<IPerson>();
+			person.SetupSequence(p => p.GetFriendTaskAsync().Result.Name).Returns(NameOfFriend).Returns(SecondNameOfFriend);
+			var friend = await person.Object.GetFriendTaskAsync();
+			Assert.Equal(NameOfFriend, friend.Name);
+			Assert.Equal(SecondNameOfFriend, friend.Name);
+		}
+
+		[Fact]
+		public async Task SetupSequence__property_of__completed_Task__Throws()
+		{
+			var person = new Mock<IPerson>();
+			person.SetupSequence(p => p.GetFriendTaskAsync().Result.Name).Throws(Exception).Throws(SecondException);
+			var friend = await person.Object.GetFriendTaskAsync();
+			var exception = Assert.Throws<Exception>(() => friend.Name);
+			var secondException = Assert.Throws<Exception>(() => friend.Name);
+			Assert.Same(Exception, exception);
+			Assert.Same(SecondException, secondException);
+		}
+
+		[Fact]
+		public async Task SetupSequence__property_of__completed_ValueTask__Returns()
+		{
+			var person = new Mock<IPerson>();
+			person.SetupSequence(p => p.GetFriendValueTaskAsync().Result.Name).Returns(NameOfFriend).Returns(SecondNameOfFriend);
+			var friend = await person.Object.GetFriendValueTaskAsync();
+			Assert.Equal(NameOfFriend, friend.Name);
+			Assert.Equal(SecondNameOfFriend, friend.Name);
+		}
+
+		[Fact]
+		public async Task SetupSequence__property_of__completed_ValueTask__Throws()
+		{
+			var person = new Mock<IPerson>();
+			person.SetupSequence(p => p.GetFriendValueTaskAsync().Result.Name).Throws(Exception).Throws(SecondException);
+			var friend = await person.Object.GetFriendValueTaskAsync();
+			var exception = Assert.Throws<Exception>(() => friend.Name);
+			var secondException = Assert.Throws<Exception>(() => friend.Name);
+			Assert.Same(Exception, exception);
+			Assert.Same(SecondException, secondException);
+		}
+
+		[Fact]
+		public async Task SetupSet__property_of__completed_Task__Callback()
+		{
+			string setToValue = null;
+			var person = new Mock<IPerson>();
+			person.SetupSet(p => p.GetFriendTaskAsync().Result.Name = It.IsAny<string>()).Callback((string value) => setToValue = value);
+			var friend = await person.Object.GetFriendTaskAsync();
+			Assert.Null(setToValue);
+			friend.Name = NameOfFriend;
+			Assert.Equal(NameOfFriend, setToValue);
+		}
+
+		[Fact]
+		public async Task SetupSet__property_of__completed_ValueTask__Callback()
+		{
+			string setToValue = null;
+			var person = new Mock<IPerson>();
+			person.SetupSet(p => p.GetFriendValueTaskAsync().Result.Name = It.IsAny<string>()).Callback((string value) => setToValue = value);
+			var friend = await person.Object.GetFriendValueTaskAsync();
+			Assert.Null(setToValue);
+			friend.Name = NameOfFriend;
+			Assert.Equal(NameOfFriend, setToValue);
+		}
+
+		[Fact]
+		public async Task SetupSet__property_of__completed_Task__Throws()
+		{
+			string setToValue = null;
+			var person = new Mock<IPerson>();
+			person.SetupSet(p => p.GetFriendTaskAsync().Result.Name = It.IsAny<string>()).Throws(Exception);
+			var friend = await person.Object.GetFriendTaskAsync();
+			var exception = Assert.Throws<Exception>(() => friend.Name = NameOfFriend);
+			Assert.Same(Exception, exception);
+		}
+
+		[Fact]
+		public async Task SetupSet__property_of__completed_ValueTask__Throws()
+		{
+			string setToValue = null;
+			var person = new Mock<IPerson>();
+			person.SetupSet(p => p.GetFriendValueTaskAsync().Result.Name = It.IsAny<string>()).Throws(Exception);
+			var friend = await person.Object.GetFriendValueTaskAsync();
+			var exception = Assert.Throws<Exception>(() => friend.Name = NameOfFriend);
+			Assert.Same(Exception, exception);
+		}
+	}
+}


### PR DESCRIPTION
This much more focused version of #1123 only covers setting up the `.Result` of (value) task-based async methods.

## Benefits

* The dedicated async setup methods `.ReturnsAsync`, `.ThrowsAsync` etc. are now largely superfluous:

   ```diff
   -mock.Setup(x => x.GetFooAsync()).ReturnsAsync(foo)
   +mock.Setup(x => x.GetFooAsync().Result).Returns(foo)
   ```

   From a user perspective, setups become more uniform in shape. From a maintainer's perspective, we have less work. More specifically, we no longer need to ensure that those async setup verbs are at feature parity with their non-async counterparts.

* It adds async support where such async verbs aren't currently available:

   ```diff
   -Mock.Of<X>(x => x.GetFooAsync() == Task.FromResult(foo))
   +Mock.Of<X>(x => x.GetFooAsync().Result == foo)
   ```

   but also in other places like in `Verify…(callExpression, …)`.

* It enables recursive setups across async calls in a single setup expression. For example, using just `Mock.Of`:

   ```diff
   -Mock.Of<X>(x => x.GetFooAsync() == Task.FromResult(Mock.Of<IFoo>(f => f.Bar == bar)))
   +Mock.Of<X>(x => x.GetFooAsync().Result.Bar == bar)
   ```

## Should `.ReturnsAsync`, `.ThrowsAsync` etc. be marked as `[Obsolete]`?

I am not marking those methods as `[Obsolete]` just yet, mainly for two reasons:

 * There are a few specialized overloads (e.g. for delayed task completion) that would need to be rewritable using just the regular setup verbs. I'd like to look at those separately.

 * `.PassAsync` for sequence setups doesn't have an easy replacement, because non-generic tasks do not have a `.Result` property that one could set up instead. Replacing `.PassAsync` would require an `await`-like operator substitute (as proposed in #1007 and implemented in #1123), which would likely be added together with support for custom awaitable types. Until that happens, it doesn't make sense to deprecate only some (but not all) async setup verbs.

## What is still missing?

As noted in the new changelog entry, support in `mock.Protected()` is still missing, or at least spotty. Also, unlike #1123, there is no support for custom awaitable types just yet; however, most of the necessary machinery is now in place, so this should be relatively easy to add in the future.

Resolves #384, closes #1007, closes #1123.