### PR TITLE
Allow InSequence to be used with protected mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
    This should work in all principal setup methods (`Mock.Of`, `mock.Setup…`, `mock.Verify…`). Support in `mock.Protected()` and for custom awaitable types may be added in the future. (@stakx, #1126)
 
+* `InSequence` can now be used with protected mocks (@FTWinston, #1127)
+
 #### Changed
 
 * Attempts to mark conditionals setup as verifiable are once again allowed; it turns out that forbidding it (as was done in #997 for version 4.14.0) is in fact a regression. (@stakx, #1121)

--- a/src/Moq/MockSequence.cs
+++ b/src/Moq/MockSequence.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 
 using Moq.Language;
 using Moq.Language.Flow;
+using Moq.Protected;
 
 namespace Moq
 {
@@ -65,6 +66,33 @@ namespace Moq
 			Guard.NotNull(sequence, nameof(sequence));
 
 			return sequence.For(mock);
+		}
+
+		/// <summary>
+		/// Perform an expectation in the trace.
+		/// </summary>
+		public static ISetupConditionResult<TMock> InSequence<TMock>(
+			this IProtectedMock<TMock> mock,
+			MockSequence sequence)
+			where TMock : class
+		{
+			Guard.NotNull(sequence, nameof(sequence));
+
+			return sequence.For(mock.UnderlyingMock);
+		}
+
+		/// <summary>
+		/// Perform an expectation in the trace.
+		/// </summary>
+		public static ISetupConditionResult<TMock> InSequence<TMock, TAnalog>(
+			this IProtectedAsMock<TMock, TAnalog> mock,
+			MockSequence sequence)
+			where TMock : class
+			where TAnalog : class
+		{
+			Guard.NotNull(sequence, nameof(sequence));
+
+			return sequence.For(mock.UnderlyingMock);
 		}
 	}
 }

--- a/src/Moq/Protected/IProtectedAsMock.cs
+++ b/src/Moq/Protected/IProtectedAsMock.cs
@@ -25,6 +25,11 @@ namespace Moq.Protected
 		where TAnalog : class
 	{
 		/// <summary>
+		/// Accesses the underlying Mock<typeparamref name="T"/>.
+		/// </summary>
+		Mock<T> UnderlyingMock { get; }
+
+		/// <summary>
 		/// Specifies a setup on the mocked type for a call to a <see langword="void"/> method.
 		/// </summary>
 		/// <param name="expression">Lambda expression that specifies the expected method invocation.</param>

--- a/src/Moq/Protected/IProtectedMock.cs
+++ b/src/Moq/Protected/IProtectedMock.cs
@@ -28,6 +28,11 @@ namespace Moq.Protected
 		IProtectedAsMock<TMock, TAnalog> As<TAnalog>()
 			where TAnalog : class;
 
+		/// <summary>
+		/// Accesses the underlying Mock<typeparamref name="TMock"/>.
+		/// </summary>
+		Mock<TMock> UnderlyingMock { get; }
+			
 		#region Setup
 
 		/// <summary>

--- a/src/Moq/Protected/ProtectedAsMock.cs
+++ b/src/Moq/Protected/ProtectedAsMock.cs
@@ -28,6 +28,8 @@ namespace Moq.Protected
 			this.mock = mock;
 		}
 
+		public Mock<T> UnderlyingMock => mock;
+
 		public ISetup<T> Setup(Expression<Action<TAnalog>> expression)
 		{
 			Guard.NotNull(expression, nameof(expression));

--- a/src/Moq/Protected/ProtectedMock.cs
+++ b/src/Moq/Protected/ProtectedMock.cs
@@ -31,6 +31,8 @@ namespace Moq.Protected
 			return new ProtectedAsMock<T, TAnalog>(mock);
 		}
 
+		public Mock<T> UnderlyingMock => mock;
+				
 		#region Setup
 
 		public ISetup<T> Setup(string methodName, params object[] args)

--- a/tests/Moq.Tests/MockSequenceFixture.cs
+++ b/tests/Moq.Tests/MockSequenceFixture.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using Moq.Protected;
 using Xunit;
 
 namespace Moq.Tests
@@ -115,7 +116,74 @@ namespace Moq.Tests
 			Assert.Throws<MockException>(() => a.Object.Do(200));
 		}
 
+		[Fact]
+		public void ProtectedMockRightSequenceSuccess()
+		{
+			var a = new Mock<IFoo>(MockBehavior.Strict);
+
+			var protectedA = a.Protected();
+
+			var sequence = new MockSequence();
+			protectedA.InSequence(sequence).Setup(x => x.Do(100)).Returns(101);
+			protectedA.InSequence(sequence).Setup(x => x.Do(200)).Returns(201);
+
+			Assert.Equal(101, a.Object.Do(100));
+			Assert.Equal(201, a.Object.Do(200));
+			Assert.Throws<MockException>(() => a.Object.Do(100));
+			Assert.Throws<MockException>(() => a.Object.Do(200));
+		}
+
+		[Fact]
+		public void ProtectedMockInvalidSequenceFail()
+		{
+			var a = new Mock<IFoo>(MockBehavior.Strict);
+
+			var protectedA = a.Protected();
+
+			var sequence = new MockSequence();
+			protectedA.InSequence(sequence).Setup(x => x.Do(100)).Returns(101);
+			protectedA.InSequence(sequence).Setup(x => x.Do(200)).Returns(201);
+
+			Assert.Throws<MockException>(() => a.Object.Do(200));
+		}
+
+		[Fact]
+		public void ProtectedAsMockRightSequenceSuccess()
+		{
+			var a = new Mock<IFoo>(MockBehavior.Strict);
+
+			var protectedA = a.Protected().As<IBar>();
+
+			var sequence = new MockSequence();
+			protectedA.InSequence(sequence).Setup(x => x.Do(100)).Returns(101);
+			protectedA.InSequence(sequence).Setup(x => x.Do(200)).Returns(201);
+
+			Assert.Equal(101, a.Object.Do(100));
+			Assert.Equal(201, a.Object.Do(200));
+			Assert.Throws<MockException>(() => a.Object.Do(100));
+			Assert.Throws<MockException>(() => a.Object.Do(200));
+		}
+
+		[Fact]
+		public void ProtectedAsMockInvalidSequenceFail()
+		{
+			var a = new Mock<IFoo>(MockBehavior.Strict);
+
+			var protectedA = a.Protected().As<IBar>();
+
+			var sequence = new MockSequence();
+			protectedA.InSequence(sequence).Setup(x => x.Do(100)).Returns(101);
+			protectedA.InSequence(sequence).Setup(x => x.Do(200)).Returns(201);
+
+			Assert.Throws<MockException>(() => a.Object.Do(200));
+		}
+
 		public interface IFoo
+		{
+			int Do(int arg);
+		}
+
+		public interface IBar
 		{
 			int Do(int arg);
 		}


### PR DESCRIPTION
Added a couple of overloads of InSequence to work with IProtectedMock and IProtectedAsMock, in addition to working with Mock directly.

Exposed the underlying mock on (I)ProtectedMock and (I)ProtectedAsMock to support this.

If I've missed something obvious and there's an existing way of testing the sequence of calls to protected methods without getting into callback hell, then by all means close this off. But otherwise, this is (IMO) a quick and convienient minor addition to support that specific case.