### PR TITLE
`.CallBase` for default interface implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 ## Unreleased
 
-#### Fixed
-* Newly introduced: `AmbiguousMatchException` raised when interface has property indexer besides property in VB. (@mujdatdinc, #1129)
+#### Added
 
+* `CallBase` can now be used with interface methods that have a default interface implementation. It will call [the most specific override](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-8.0/default-interface-methods#the-most-specific-override-rule). (@stakx, #1130)
+
+#### Fixed
+
+* `AmbiguousMatchException` raised when interface has property indexer besides property in VB. (@mujdatdinc, #1129)
+* Interface default methods are ignored (@hahn-kev, #972)
 
 ## 4.16.0 (2021-01-16)
 

--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -16,7 +16,11 @@
 		<RootNamespace>Moq</RootNamespace>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<WarningLevel>4</WarningLevel>
-		<LangVersion>8.0</LangVersion>
+		<LangVersion>9.0</LangVersion>
+	</PropertyGroup>
+
+	<PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+		<DefineConstants>$(DefineConstants);FEATURE_DEFAULT_INTERFACE_IMPLEMENTATIONS</DefineConstants>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Moq/Pair.cs
+++ b/src/Moq/Pair.cs
@@ -1,9 +1,11 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using System;
+
 namespace Moq
 {
-	internal readonly struct Pair<T1, T2>
+	internal readonly struct Pair<T1, T2> : IEquatable<Pair<T1, T2>>
 	{
 		public readonly T1 Item1;
 		public readonly T2 Item2;
@@ -18,6 +20,22 @@ namespace Moq
 		{
 			item1 = this.Item1;
 			item2 = this.Item2;
+		}
+
+		public bool Equals(Pair<T1, T2> other)
+		{
+			return object.Equals(this.Item1, other.Item1)
+				&& object.Equals(this.Item2, other.Item2);
+		}
+
+		public override bool Equals(object obj)
+		{
+			return obj is Pair<T1, T2> other && this.Equals(other);
+		}
+
+		public override int GetHashCode()
+		{
+			return unchecked(1001 * this.Item1?.GetHashCode() ?? 101 + this.Item2?.GetHashCode() ?? 11);
 		}
 	}
 }

--- a/src/Moq/ProxyFactories/CastleProxyFactory.cs
+++ b/src/Moq/ProxyFactories/CastleProxyFactory.cs
@@ -2,15 +2,17 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
+using System.Diagnostics;
+using System.Reflection;
+
+#if FEATURE_DEFAULT_INTERFACE_IMPLEMENTATIONS
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
-using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime;
 using System.Text;
+#endif
 
 using Castle.DynamicProxy;
 
@@ -135,12 +137,9 @@ namespace Moq
 				if (method.DeclaringType.IsInterface && !method.IsAbstract)
 				{
 					// As of version 4.4.0, DynamicProxy cannot proceed to default method implementations of interfaces.
-					// In order to support this anyway, we use a dynamic thunk that calls it via a non-virtual `call`.
-					// This is roughly equivalent to how you'd choose the interface default implementation in C#:
-					// you'd cast the object to the desired interface, and call the method on that.
-					var mostSpecificOverride = MostSpecificOverride.Find(method, this.underlying.Proxy);
-					var thunk = DefaultImplementationThunk.Get(mostSpecificOverride);
-					return thunk.Invoke(this.underlying.Proxy, this.Arguments);
+					// we need to find and call those manually.
+					var mostSpecificOverride = FindMostSpecificOverride(method, this.underlying.Proxy.GetType());
+					return DynamicInvokeNonVirtually(mostSpecificOverride, this.underlying.Proxy, this.Arguments);
 				}
 #endif
 
@@ -155,192 +154,203 @@ namespace Moq
 		}
 
 #if FEATURE_DEFAULT_INTERFACE_IMPLEMENTATIONS
-		internal static class MostSpecificOverride
+		// Finding and calling default interface implementations currently involves a lot of reflection,
+		// we are using two caches to speed up these operations for repeated calls.
+		private static ConcurrentDictionary<Pair<MethodInfo, Type>, MethodInfo> mostSpecificOverrides;
+		private static ConcurrentDictionary<MethodInfo, Func<object, object[], object>> nonVirtualInvocationThunks;
+
+		static CastleProxyFactory()
 		{
-			private static ConcurrentDictionary<Pair<MethodInfo, Type>, MethodInfo> cache;
+			mostSpecificOverrides = new ConcurrentDictionary<Pair<MethodInfo, Type>, MethodInfo>();
+			nonVirtualInvocationThunks = new ConcurrentDictionary<MethodInfo, Func<object, object[], object>>();
+		}
 
-			static MostSpecificOverride()
-			{
-				cache = new ConcurrentDictionary<Pair<MethodInfo, Type>, MethodInfo>();
-			}
-
-			/// <summary>
-			///   Attempts to find the most specific override for the given method <paramref name="declaration"/>
-			///   in the type(s) proxied by <paramref name="proxy"/>.
-			/// </summary>
-			public static MethodInfo Find(MethodInfo declaration, object proxy)
+		/// <summary>
+		///   Attempts to find the most specific override for the given method <paramref name="declaration"/>
+		///   in the type chains (base class, interfaces) of the given <paramref name="proxyType"/>.
+		/// </summary>
+		public static MethodInfo FindMostSpecificOverride(MethodInfo declaration, Type proxyType)
+		{
+			return mostSpecificOverrides.GetOrAdd(new Pair<MethodInfo, Type>(declaration, proxyType), static key =>
 			{
 				// This follows the rule specified in:
 				// https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-8.0/default-interface-methods#the-most-specific-override-rule.
-				return cache.GetOrAdd(new Pair<MethodInfo, Type>(declaration, proxy.GetType()), key =>
+
+				var (declaration, proxyType) = key;
+
+				var genericParameterCount = declaration.IsGenericMethod ? declaration.GetGenericArguments().Length : 0;
+				var returnType = declaration.ReturnType;
+				var parameterTypes = declaration.GetParameterTypes().ToArray();
+				var declaringType = declaration.DeclaringType;
+
+				// If the base class has a method implementation, then by rule (2) it will be more specific
+				// than any candidate method from an implemented interface:
+				var baseClass = proxyType.BaseType;
+				if (baseClass != null && declaringType.IsAssignableFrom(baseClass))
 				{
-					var (declaration, proxyType) = key;
+					var map = baseClass.GetInterfaceMap(declaringType);
+					var index = Array.IndexOf(map.InterfaceMethods, declaration);
+					return map.TargetMethods[index];
+				}
 
-					var genericParameterCount = declaration.IsGenericMethod ? declaration.GetGenericArguments().Length : 0;
-					var returnType = declaration.ReturnType;
-					var parameterTypes = declaration.GetParameterTypes().ToArray();
-					var declaringType = declaration.DeclaringType;
+				// Otherwise, we need to look for candidates in all directly or indirectly implemented interfaces:
+				var implementedInterfaces = proxyType.GetInterfaces();
+				var candidateMethods = new HashSet<MethodInfo>();
+				foreach (var implementedInterface in implementedInterfaces.Where(i => declaringType.IsAssignableFrom(i)))
+				{
+					// Search for an implicit override:
+					var candidateMethod = implementedInterface.GetMethod(declaration.Name, genericParameterCount, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, parameterTypes, null);
 
-					// If the base class has a method implementation, then by rule (2) it will be more specific
-					// than any candidate method from an implemented interface:
-					var baseClass = proxyType.BaseType;
-					if (baseClass != null && declaringType.IsAssignableFrom(baseClass))
+					// Search for an explicit override:
+					if (candidateMethod?.GetBaseDefinition() != declaration)
 					{
-						var map = baseClass.GetInterfaceMap(declaringType);
-						var index = Array.IndexOf(map.InterfaceMethods, declaration);
-						return map.TargetMethods[index];
+						// Unfortunately, we cannot use `.GetInterfaceMap` to find out whether an interface method
+						// overrides another base interface method, i.e. whether they share the same vtbl slot.
+						// It appears that the best thing we can do is to look for a non-public method having
+						// the right name and parameter types, and hope for the best:
+						var name = new StringBuilder();
+						name.Append(declaringType.FullName);
+						name.Replace('+', '.');
+						name.Append('.');
+						name.Append(declaration.Name);
+						candidateMethod = implementedInterface.GetMethod(name.ToString(), genericParameterCount, BindingFlags.NonPublic | BindingFlags.Instance, null, parameterTypes, null);
 					}
 
-					// Otherwise, we need to look for candidates in all directly or indirectly implemented interfaces:
-					var implementedInterfaces = proxyType.GetInterfaces();
-					var candidateMethods = new HashSet<MethodInfo>();
-					foreach (var implementedInterface in implementedInterfaces.Where(i => declaringType.IsAssignableFrom(i)))
-					{
-						// Search for an implicit override:
-						var candidateMethod = implementedInterface.GetMethod(declaration.Name, genericParameterCount, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, parameterTypes, null);
+					if (candidateMethod == null) continue;
 
-						// Search for an explicit override:
-						if (candidateMethod?.GetBaseDefinition() != declaration)
-						{
-							// Unfortunately, we cannot use `.GetInterfaceMap` to find out whether an interface method
-							// overrides another base interface method, i.e. whether they share the same vtbl slot.
-							// It appears that the best thing we can do is to look for a non-public method having
-							// the right name and parameter types, and hope for the best:
-							var name = new StringBuilder();
-							name.Append(declaringType.FullName);
-							name.Replace('+', '.');
-							name.Append('.');
-							name.Append(declaration.Name);
-							candidateMethod = implementedInterface.GetMethod(name.ToString(), genericParameterCount, BindingFlags.NonPublic | BindingFlags.Instance, null, parameterTypes, null);
-						}
+					// Now we have a candidate override. We need to check if it is less specific than any others
+					// that we have already found earlier:
+					if (candidateMethods.Any(cm => implementedInterface.IsAssignableFrom(cm.DeclaringType))) continue;
 
-						if (candidateMethod == null) continue;
+					// No, it is the most specific override so far. Add it to the list, but before doing so,
+					// remove all less specific overrides from it:
+					candidateMethods.ExceptWith(candidateMethods.Where(cm => cm.DeclaringType.IsAssignableFrom(implementedInterface)).ToArray());
+					candidateMethods.Add(candidateMethod);
+				}
 
-						// Now we have a candidate override. We need to check if it is less specific than any others
-						// that we have already found earlier:
-						if (candidateMethods.Any(cm => implementedInterface.IsAssignableFrom(cm.DeclaringType))) continue;
-
-						// No, it is the most specific override so far. Add it to the list, but before doing so,
-						// remove all less specific overrides from it:
-						candidateMethods.ExceptWith(candidateMethods.Where(cm => cm.DeclaringType.IsAssignableFrom(implementedInterface)).ToArray());
-						candidateMethods.Add(candidateMethod);
-					}
-
-					var candidateCount = candidateMethods.Count();
-					if (candidateCount > 1)
-					{
-						throw new AmbiguousImplementationException();
-					}
-					else if (candidateCount == 1)
-					{
-						return candidateMethods.First();
-					}
-					else
-					{
-						return declaration;
-					}
-				});
-			}
+				var candidateCount = candidateMethods.Count();
+				if (candidateCount > 1)
+				{
+					throw new AmbiguousImplementationException();
+				}
+				else if (candidateCount == 1)
+				{
+					return candidateMethods.First();
+				}
+				else
+				{
+					return declaration;
+				}
+			});
 		}
 
-		// NOTE: In theory, this helper should work on any platform. It is excluded on `netstandard2.0`
-		// and lower mostly to avoid an additional NuGet dependency required for `DynamicMethod`.
-		private static class DefaultImplementationThunk
+		/// <summary>
+		///   Performs a non-virtual (non-polymorphic) call to the given <paramref name="method"/>
+		///   using the specified object <paramref name="instance"/> and <paramref name="arguments"/>.
+		/// </summary>
+		public static object DynamicInvokeNonVirtually(MethodInfo method, object instance, object[] arguments)
 		{
-			// We store previously generated dynamic thunks for reuse.
-			private static ConcurrentDictionary<MethodInfo, Func<object, object[], object>> thunks;
+			// There are a couple of probable alternatives to the following implementation that
+			// unfortunately don't work in practice:
+			//
+			//  * We could try `method.Invoke(instance, InvokeMethod | DeclaredOnly, arguments)`,
+			//    unfortunately that doesn't work. `DeclaredOnly` does not have the desired effect.
+			//
+			//  * We could get a function pointer via `method.MethodHandle.GetFunctionPointer()`,
+			//    then construct a delegate for it (see ECMA-335 §II.14.4). This does not work
+			//    because the delegate signature would have to have a matching parameter list,
+			//    not just an untyped `object[]`. It also doesn't work because we don't always have
+			//    a suitable delegate type ready (e.g. when a method has by-ref parameters).
+			//
+			// So we end up having to create a dynamic method that transforms the `object[]`array
+			// to a properly typed argument list and then invokes the method using the IL `call`
+			// instruction.
 
-			static DefaultImplementationThunk()
+			var thunk = nonVirtualInvocationThunks.GetOrAdd(method, static method =>
 			{
-				thunks = new ConcurrentDictionary<MethodInfo, Func<object, object[], object>>();
-			}
+				var originalParameterTypes = method.GetParameterTypes();
+				var n = originalParameterTypes.Count;
 
-			public static Func<object, object[], object> Get(MethodInfo method)
-			{
-				return thunks.GetOrAdd(method, static method =>
+				var dynamicMethod = new DynamicMethod(string.Empty, returnType: typeof(object), parameterTypes: new[] { typeof(object), typeof(object[]) });
+				dynamicMethod.InitLocals = true;
+				var il = dynamicMethod.GetILGenerator();
+
+				var arguments = new LocalBuilder[n];
+				var returnValue = il.DeclareLocal(typeof(object));
+
+				// Erase by-ref-ness of parameter types to get at the actual type of value.
+				// We need this because we are handed `invocation.Arguments` as an `object[]` array.
+				var parameterTypes = originalParameterTypes.ToArray();
+				for (var i = 0; i < n; ++i)
 				{
-					var originalParameterTypes = method.GetParameterTypes();
-					var n = originalParameterTypes.Count;
-
-					var dynamicMethod = new DynamicMethod(string.Empty, returnType: typeof(object), parameterTypes: new[] { typeof(object), typeof(object[]) });
-					dynamicMethod.InitLocals = true;
-					var il = dynamicMethod.GetILGenerator();
-
-					var arguments = new LocalBuilder[n];
-					var returnValue = il.DeclareLocal(typeof(object));
-
-					// Erase by-ref-ness of parameter types to get at the actual type of value.
-					// We need this because we are handed `invocation.Arguments` as an `object[]` array.
-					var parameterTypes = originalParameterTypes.ToArray();
-					for (var i = 0; i < n; ++i)
+					if (parameterTypes[i].IsByRef)
 					{
-						if (parameterTypes[i].IsByRef)
-						{
-							parameterTypes[i] = parameterTypes[i].GetElementType();
-						}
+						parameterTypes[i] = parameterTypes[i].GetElementType();
 					}
+				}
 
-					// Transfer `invocation.Arguments` into appropriately typed local variables.
-					// This involves unboxing value-typed arguments, and possibly down-casting others from `object`.
-					// The `unbox.any` instruction will do the right thing in both cases.
-					for (var i = 0; i < n; ++i)
-					{
-						arguments[i] = il.DeclareLocal(parameterTypes[i]);
+				// Transfer `invocation.Arguments` into appropriately typed local variables.
+				// This involves unboxing value-typed arguments, and possibly down-casting others from `object`.
+				// The `unbox.any` instruction will do the right thing in both cases.
+				for (var i = 0; i < n; ++i)
+				{
+					arguments[i] = il.DeclareLocal(parameterTypes[i]);
 
-						il.Emit(OpCodes.Ldarg_1);
-						il.Emit(OpCodes.Ldc_I4, i);
-						il.Emit(OpCodes.Ldelem_Ref);
-						il.Emit(OpCodes.Unbox_Any, parameterTypes[i]);
-						il.Emit(OpCodes.Stloc, arguments[i]);
-					}
+					il.Emit(OpCodes.Ldarg_1);
+					il.Emit(OpCodes.Ldc_I4, i);
+					il.Emit(OpCodes.Ldelem_Ref);
+					il.Emit(OpCodes.Unbox_Any, parameterTypes[i]);
+					il.Emit(OpCodes.Stloc, arguments[i]);
+				}
 
-					// Now we're going to call the actual default implementation.
+				// Now we're going to call the actual default implementation.
 
-					// We do this inside a `try` block because we need to write back possibly modified
-					// arguments to `invocation.Arguments` even if the called method throws.
-					var returnLabel = il.DefineLabel();
-					il.BeginExceptionBlock();
+				// We do this inside a `try` block because we need to write back possibly modified
+				// arguments to `invocation.Arguments` even if the called method throws.
+				var returnLabel = il.DefineLabel();
+				il.BeginExceptionBlock();
 
-					// Perform the actual call.
-					il.Emit(OpCodes.Ldarg_0);
-					il.Emit(OpCodes.Castclass, method.DeclaringType);
-					for (var i = 0; i < n; ++i)
-					{
-						il.Emit(originalParameterTypes[i].IsByRef ? OpCodes.Ldloca : OpCodes.Ldloc, arguments[i]);
-					}
-					il.Emit(OpCodes.Call, method);
+				// Perform the actual call.
+				il.Emit(OpCodes.Ldarg_0);
+				il.Emit(OpCodes.Castclass, method.DeclaringType);
+				for (var i = 0; i < n; ++i)
+				{
+					il.Emit(originalParameterTypes[i].IsByRef ? OpCodes.Ldloca : OpCodes.Ldloc, arguments[i]);
+				}
+				il.Emit(OpCodes.Call, method);
 
-					// Put the return value in a local variable for later retrieval.
-					if (method.ReturnType != typeof(void))
-					{
-						il.Emit(OpCodes.Box, method.ReturnType);
-						il.Emit(OpCodes.Castclass, typeof(object));
-						il.Emit(OpCodes.Stloc, returnValue);
-					}
-					il.Emit(OpCodes.Leave, returnLabel);
+				// Put the return value in a local variable for later retrieval.
+				if (method.ReturnType != typeof(void))
+				{
+					il.Emit(OpCodes.Box, method.ReturnType);
+					il.Emit(OpCodes.Castclass, typeof(object));
+					il.Emit(OpCodes.Stloc, returnValue);
+				}
+				il.Emit(OpCodes.Leave, returnLabel);
 
-					il.BeginFinallyBlock();
+				il.BeginFinallyBlock();
 
-					// Write back possibly modified arguments to `invocation.Arguments`.
-					for (var i = 0; i < n; ++i)
-					{
-						il.Emit(OpCodes.Ldarg_1);
-						il.Emit(OpCodes.Ldc_I4, i);
-						il.Emit(OpCodes.Ldloc, arguments[i]);
-						il.Emit(OpCodes.Box, arguments[i].LocalType);
-						il.Emit(OpCodes.Stelem_Ref);
-					}
-					il.Emit(OpCodes.Endfinally);
+				// Write back possibly modified arguments to `invocation.Arguments`.
+				for (var i = 0; i < n; ++i)
+				{
+					il.Emit(OpCodes.Ldarg_1);
+					il.Emit(OpCodes.Ldc_I4, i);
+					il.Emit(OpCodes.Ldloc, arguments[i]);
+					il.Emit(OpCodes.Box, arguments[i].LocalType);
+					il.Emit(OpCodes.Stelem_Ref);
+				}
+				il.Emit(OpCodes.Endfinally);
 
-					il.EndExceptionBlock();
-					il.MarkLabel(returnLabel);
+				il.EndExceptionBlock();
+				il.MarkLabel(returnLabel);
 
-					il.Emit(OpCodes.Ldloc, returnValue);
-					il.Emit(OpCodes.Ret);
+				il.Emit(OpCodes.Ldloc, returnValue);
+				il.Emit(OpCodes.Ret);
 
-					return (Func<object, object[], object>)dynamicMethod.CreateDelegate(typeof(Func<object, object[], object>));
-				});
-			}
+				return (Func<object, object[], object>)dynamicMethod.CreateDelegate(typeof(Func<object, object[], object>));
+			});
+
+			return thunk.Invoke(instance, arguments);
 		}
 #endif
 

--- a/tests/Moq.Tests/CallBaseDefaultInterfaceImplementationsFixture.cs
+++ b/tests/Moq.Tests/CallBaseDefaultInterfaceImplementationsFixture.cs
@@ -1,0 +1,145 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+#if FEATURE_DEFAULT_INTERFACE_IMPLEMENTATIONS
+
+using System;
+
+using Xunit;
+
+namespace Moq.Tests
+{
+	public class CallBaseDefaultInterfaceImplementationsFixture
+	{
+		[Fact]
+		public void CallBase__configured_on_mock__succeeds()
+		{
+			var mock = new Mock<IX>() { CallBase = true };
+			mock.Object.Inert();
+		}
+
+		[Fact]
+		public void CallBase__configured_on_setup__succeeds()
+		{
+			var mock = new Mock<IX>();
+			mock.Setup(m => m.Inert()).CallBase();
+			mock.Object.Inert();
+		}
+
+		[Fact]
+		public void Reference_typed_return_value__is_returned()
+		{
+			var mock = new Mock<IX>() { CallBase = true };
+			var returnValue = mock.Object.ReturnsHello();
+			Assert.Equal("Hello", returnValue);
+		}
+
+		[Fact]
+		public void Value_typed_return_value__is_returned()
+		{
+			var mock = new Mock<IX>() { CallBase = true };
+			var returnValue = mock.Object.ReturnsFortyTwo();
+			Assert.Equal(42, returnValue);
+		}
+
+		[Fact]
+		public void Can_deal_with__value_typed_argument()
+		{
+			var mock = new Mock<IX>() { CallBase = true };
+			var returnValue = mock.Object.ReturnsIntArg(42);
+			Assert.Equal(42, returnValue);
+		}
+
+		[Fact]
+		public void Can_deal_with__reference_typed_argument()
+		{
+			var mock = new Mock<IX>() { CallBase = true };
+			var returnValue = mock.Object.ReturnsStringArg("Echo");
+			Assert.Equal("Echo", returnValue);
+		}
+
+		[Fact]
+		public void Can_deal_with__generic_argument()
+		{
+			var mock = new Mock<IX>() { CallBase = true };
+			var returnValue = mock.Object.ReturnsArg<bool>(true);
+			Assert.True(returnValue);
+		}
+
+		[Fact]
+		public void Can_deal_with__value_typed_by_ref_argument()
+		{
+			var mock = new Mock<IX>() { CallBase = true };
+			var arg = 42;
+			var returnValue = mock.Object.Increment(ref arg);
+			Assert.Equal(42, returnValue);
+			Assert.Equal(43, arg);
+		}
+
+		[Fact]
+		public void Can_deal_with__reference_typed_by_ref_argument()
+		{
+			var mock = new Mock<IX>() { CallBase = true };
+			var arg = "C+";
+			var returnValue = mock.Object.AppendPlus(ref arg);
+			Assert.Equal("C+", returnValue);
+			Assert.Equal("C++", arg);
+		}
+
+		[Fact]
+		public void Does_not_lose_modified_arguments__when_exception_thrown()
+		{
+			var mock = new Mock<IX>() { CallBase = true };
+			var arg = "C+";
+			Assert.Throws<ArithmeticException>(() => mock.Object.AppendPlusThenThrow(ref arg));
+			Assert.Equal("C++", arg);
+		}
+
+		[Fact]
+		public void Should_call__most_specific__most_derived__implementation()
+		{
+			var mock = new Mock<IZ>() { CallBase = true };
+			Assert.Equal(nameof(IZ), mock.Object.WhoAmI());
+		}
+
+		public interface IX
+		{
+			void Inert()
+			{
+			}
+
+			int ReturnsFortyTwo() => 42;
+			string ReturnsHello() => "Hello";
+
+			int ReturnsIntArg(int arg) => arg;
+			string ReturnsStringArg(string arg) => arg;
+			T ReturnsArg<T>(T arg) => arg;
+
+			int Increment(ref int arg) => arg++;
+			string AppendPlus(ref string arg)
+			{
+				var argBefore = arg;
+				arg += "+";
+				return argBefore;
+			}
+
+			string AppendPlusThenThrow(ref string arg)
+			{
+				arg += "+";
+				throw new ArithmeticException();
+			}
+		}
+
+		public interface IY
+		{
+			string WhoAmI() => nameof(IY);
+		}
+
+		public interface IZ : IY
+		{
+			string IY.WhoAmI() => nameof(IZ);
+		}
+	}
+}
+
+#endif

--- a/tests/Moq.Tests/Moq.Tests.csproj
+++ b/tests/Moq.Tests/Moq.Tests.csproj
@@ -18,7 +18,7 @@
 		<DefineConstants>$(DefineConstants);FEATURE_DYNAMICPROXY_SERIALIZABLE_PROXIES;FEATURE_EF;FEATURE_SYSTEM_WEB;FEATURE_SYSTEM_WINDOWS_FORMS</DefineConstants>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-		<DefineConstants>$(DefineConstants)</DefineConstants>
+		<DefineConstants>$(DefineConstants);FEATURE_DEFAULT_INTERFACE_IMPLEMENTATIONS</DefineConstants>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/tests/Moq.Tests/ProxyFactories/MostSpecificOverrideFixture.cs
+++ b/tests/Moq.Tests/ProxyFactories/MostSpecificOverrideFixture.cs
@@ -1,0 +1,73 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+#if FEATURE_DEFAULT_INTERFACE_IMPLEMENTATIONS
+
+using System;
+using System.Reflection;
+
+using Xunit;
+
+using static Moq.CastleProxyFactory;
+
+namespace Moq.Tests.ProxyFactories
+{
+	public class MostSpecificOverrideFixture
+	{
+		[Theory]
+		[InlineData(typeof(IA), "Method", typeof(IA), typeof(IA), "Method")]
+		[InlineData(typeof(IA), "Method", typeof(CA), typeof(IA), "Method")]
+		[InlineData(typeof(IA), "Method", typeof(CAimpl), typeof(CAimpl), "Method")]
+		[InlineData(typeof(IA), "Method", typeof(IBoverride), typeof(IBoverride), "Moq.Tests.ProxyFactories.MostSpecificOverrideFixture.IA.Method")]
+		[InlineData(typeof(IA), "Method", typeof(IBnew), typeof(IA), "Method")]
+		[InlineData(typeof(IA), "Method", typeof(ICfromBoverride), typeof(ICfromBoverride), "Moq.Tests.ProxyFactories.MostSpecificOverrideFixture.IA.Method")]
+		[InlineData(typeof(IA), "Method", typeof(ICfromBnew), typeof(ICfromBnew), "Moq.Tests.ProxyFactories.MostSpecificOverrideFixture.IA.Method")]
+		[InlineData(typeof(IBnew), "Method", typeof(ICfromBnew), typeof(ICfromBnew), "Moq.Tests.ProxyFactories.MostSpecificOverrideFixture.IBnew.Method")]
+		public void Finds_correct_most_specific_override(Type declarationType, string declarationName, Type proxyType, Type overrideType, string overrideName)
+		{
+			var expected = overrideType.GetMethod(overrideName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+			var proxy = typeof(Mock).GetMethod("Of", BindingFlags.Public | BindingFlags.Static, null, Type.EmptyTypes, null).MakeGenericMethod(proxyType).Invoke(null, null);
+			var actual = MostSpecificOverride.Find(
+				declaration: declarationType.GetMethod(declarationName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly),
+				proxy);
+			Assert.Same(expected, actual);
+		}
+
+		public interface IA
+		{
+			string Method() => "Method in IA";
+		}
+
+		public class CA : IA
+		{
+		}
+
+		public class CAimpl : IA
+		{
+			public string Method() => "Method in CAimpl";
+		}
+
+		public interface IBoverride : IA
+		{
+			string IA.Method() => "IA.Method in IBoverride";
+		}
+
+		public interface IBnew : IA
+		{
+			new string Method() => "Method in IBnew";
+		}
+
+		public interface ICfromBoverride : IBoverride
+		{
+			string IA.Method() => "IA.Method in ICfromBoverride";
+		}
+
+		public interface ICfromBnew : IBnew
+		{
+			string IBnew.Method() => "IBnewMethod in ICfromBnew";
+			string IA.Method() => "IA.Method in ICfromBnew";
+		}
+	}
+}
+
+#endif

--- a/tests/Moq.Tests/ProxyFactories/MostSpecificOverrideFixture.cs
+++ b/tests/Moq.Tests/ProxyFactories/MostSpecificOverrideFixture.cs
@@ -23,13 +23,14 @@ namespace Moq.Tests.ProxyFactories
 		[InlineData(typeof(IA), "Method", typeof(ICfromBoverride), typeof(ICfromBoverride), "Moq.Tests.ProxyFactories.MostSpecificOverrideFixture.IA.Method")]
 		[InlineData(typeof(IA), "Method", typeof(ICfromBnew), typeof(ICfromBnew), "Moq.Tests.ProxyFactories.MostSpecificOverrideFixture.IA.Method")]
 		[InlineData(typeof(IBnew), "Method", typeof(ICfromBnew), typeof(ICfromBnew), "Moq.Tests.ProxyFactories.MostSpecificOverrideFixture.IBnew.Method")]
-		public void Finds_correct_most_specific_override(Type declarationType, string declarationName, Type proxyType, Type overrideType, string overrideName)
+		public void Finds_correct_most_specific_override(Type declarationType, string declarationName, Type proxiedType, Type overrideType, string overrideName)
 		{
 			var expected = overrideType.GetMethod(overrideName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
-			var proxy = typeof(Mock).GetMethod("Of", BindingFlags.Public | BindingFlags.Static, null, Type.EmptyTypes, null).MakeGenericMethod(proxyType).Invoke(null, null);
-			var actual = MostSpecificOverride.Find(
+			var proxy = typeof(Mock).GetMethod("Of", BindingFlags.Public | BindingFlags.Static, null, Type.EmptyTypes, null).MakeGenericMethod(proxiedType).Invoke(null, null);
+			var proxyType = proxy.GetType();
+			var actual = CastleProxyFactory.FindMostSpecificOverride(
 				declaration: declarationType.GetMethod(declarationName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly),
-				proxy);
+				proxyType);
 			Assert.Same(expected, actual);
 		}
 


### PR DESCRIPTION
As of version 4.4.0, DynamicProxy is not able to reliably `.Proceed()` to a base method implementation if it is provided by an interface. From a user perspective, one would likely try to invoke a default interface implementation using `.CallBase()`.

This is an attempt to work around this current DynamicProxy limitation by performing the non-virtual call to the interface method manually. This involves some System.Reflection.Emit code inspired by @thomaslevesque's approach mentioned in https://github.com/castleproject/Core/issues/447#issuecomment-536274305.

~~This works mostly, except for one important detail: Moq will always call the least specific default implementation, instead of the most specific one. (This matters when one overrides a default implementation in a derived interface, then mocks that derived interface or a type inheriting/implementing it.)~~ (Update: Most specific override identification is now implemented, too.)

The code being added here is rather horrible, and it would be very good to get rid of it as soon as DynamicProxy properly supports proceeding to default interface implementations.

Resolves #972.