### PR TITLE
Avoid `AmbiguousMatchException` when interface has indexer besides property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+#### Fixed
+* Newly introduced: `AmbiguousMatchException` raised when interface has property indexer besides property in VB. (@mujdatdinc, #1129)
+
 
 ## 4.16.0 (2021-01-16)
 

--- a/src/Moq/Interception/InterceptionAspects.cs
+++ b/src/Moq/Interception/InterceptionAspects.cs
@@ -200,7 +200,7 @@ namespace Moq
 			if (invocationMethod.IsPropertyAccessor())
 			{
 				string propertyNameToSearch = invocationMethod.Name.Substring(AccessorPrefixLength);
-				PropertyInfo property = invocationMethod.DeclaringType.GetProperty(propertyNameToSearch);
+				PropertyInfo property = invocationMethod.DeclaringType.GetProperty(propertyNameToSearch, Type.EmptyTypes);
 
 				if (property == null)
 				{
@@ -258,7 +258,7 @@ namespace Moq
 
 		private static object CreateInitialPropertyValue(Mock mock, MethodInfo getter)
 		{
-			object initialValue = mock.GetDefaultValue(getter, out Mock innerMock, 
+			object initialValue = mock.GetDefaultValue(getter, out Mock innerMock,
 				useAlternateProvider: mock.AutoSetupPropertiesDefaultValueProvider);
 
 			if (innerMock != null)

--- a/tests/Moq.Tests.VisualBasic/IssueReports.vb
+++ b/tests/Moq.Tests.VisualBasic/IssueReports.vb
@@ -75,4 +75,22 @@ Public Class IssueReports
 
 	End Class
 
+	Public Class Issue1129
+
+		<Fact>
+		Public Sub Test()
+			Dim classMock = New Mock(Of IndexerInterface)()
+
+			classMock.SetupAllProperties()
+
+			Assert.False(classMock.Object.Value)
+		End Sub
+		Public Interface IndexerInterface
+			ReadOnly Property SystemDefault() As Boolean
+			Property Value() As Boolean
+			Property Value(ByVal OverrideLevel As Integer) As Boolean
+			Property Value(ByVal OverrideLevel As Integer, ByVal OverrideID As String) As Boolean
+		End Interface
+	End Class
+
 End Class


### PR DESCRIPTION
fix(vb): Indexer properties raise AmbiguousMatchException.

Fixes #1129.