### PR TITLE
Fix type mismatch during callback validation for task `.Result` setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 * `AmbiguousMatchException` raised when interface has property indexer besides property in VB. (@mujdatdinc, #1129)
 * Interface default methods are ignored (@hahn-kev, #972)
+* Callback validation too strict when setting up a task's `.Result` property (@stakx, #1132)
+
 
 ## 4.16.0 (2021-01-16)
 

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -13,6 +13,8 @@ using System.Text;
 using Moq.Behaviors;
 using Moq.Properties;
 
+using TypeNameFormatter;
+
 namespace Moq
 {
 	internal sealed partial class MethodCall : SetupWithOutParameterSupport
@@ -322,8 +324,8 @@ namespace Moq
 							string.Format(
 								CultureInfo.CurrentCulture,
 								Resources.InvalidCallbackReturnTypeMismatch,
-								expectedReturnType,
-								actualReturnType));
+								expectedReturnType.GetFormattedName(),
+								actualReturnType.GetFormattedName()));
 					}
 				}
 			}

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -310,7 +310,8 @@ namespace Moq
 					throw new ArgumentException(Resources.InvalidReturnsCallbackNotADelegateWithReturnType);
 				}
 
-				var expectedReturnType = this.Method.ReturnType;
+				var expectedReturnType = this.Expectation.HasResultExpression(out var awaitable) ? awaitable.ResultType
+				                                                                                 : this.Method.ReturnType;
 
 				if (!expectedReturnType.IsAssignableFrom(actualReturnType))
 				{

--- a/src/Moq/Properties/Resources.Designer.cs
+++ b/src/Moq/Properties/Resources.Designer.cs
@@ -187,7 +187,7 @@ namespace Moq.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid callback. Setup on method with return type ({0}) cannot invoke callback with return type ({1})..
+        ///   Looks up a localized string similar to Invalid callback. Setup on method with return type &apos;{0}&apos; cannot invoke callback with return type &apos;{1}&apos;..
         /// </summary>
         internal static string InvalidCallbackReturnTypeMismatch {
             get {

--- a/src/Moq/Properties/Resources.resx
+++ b/src/Moq/Properties/Resources.resx
@@ -285,7 +285,7 @@ Remember that there's no generics covariance in the CLR, so your object must be 
     <value>Type {0} does not have matching protected member: {1}</value>
   </data>
   <data name="InvalidCallbackReturnTypeMismatch" xml:space="preserve">
-    <value>Invalid callback. Setup on method with return type ({0}) cannot invoke callback with return type ({1}).</value>
+    <value>Invalid callback. Setup on method with return type '{0}' cannot invoke callback with return type '{1}'.</value>
   </data>
   <data name="InvalidCallbackParameterCountMismatch" xml:space="preserve">
     <value>Invalid callback. Setup on method with {0} parameter(s) cannot invoke callback with different number of parameters ({1}).</value>

--- a/tests/Moq.Tests/SetupTaskResultFixture.cs
+++ b/tests/Moq.Tests/SetupTaskResultFixture.cs
@@ -102,6 +102,15 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public async Task Setup__completed_Task__Returns_callback()
+		{
+			var person = new Mock<IPerson>();
+			person.Setup(p => p.GetFriendTaskAsync().Result).Returns(() => Friend);
+			var friend = await person.Object.GetFriendTaskAsync();
+			Assert.Same(Friend, friend);
+		}
+
+		[Fact]
 		public async Task Setup__completed_Task__Throws()
 		{
 			var person = new Mock<IPerson>();
@@ -115,6 +124,15 @@ namespace Moq.Tests
 		{
 			var person = new Mock<IPerson>();
 			person.Setup(p => p.GetFriendValueTaskAsync().Result).Returns(Friend);
+			var friend = await person.Object.GetFriendValueTaskAsync();
+			Assert.Same(Friend, friend);
+		}
+
+		[Fact]
+		public async Task Setup__completed_ValueTask__Returns_callback()
+		{
+			var person = new Mock<IPerson>();
+			person.Setup(p => p.GetFriendValueTaskAsync().Result).Returns(()=> Friend);
 			var friend = await person.Object.GetFriendValueTaskAsync();
 			Assert.Same(Friend, friend);
 		}


### PR DESCRIPTION
Fixes #1132.