### PR TITLE
Ensure `Returns(InvocationFunc)` doesn't throw `TargetInvocationException`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * `AmbiguousMatchException` raised when interface has property indexer besides property in VB. (@mujdatdinc, #1129)
 * Interface default methods are ignored (@hahn-kev, #972)
 * Callback validation too strict when setting up a task's `.Result` property (@stakx, #1132)
+* `setup.Returns(InvocationFunc)` wraps thrown exceptions in `TargetInvocationException` (@stakx, #1141)
 
 
 ## 4.16.0 (2021-01-16)

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -247,7 +247,7 @@ namespace Moq
 			}
 			else if (IsInvocationFunc(valueFactory))
 			{
-				this.returnOrThrow = new ReturnComputedValue(invocation => valueFactory.DynamicInvoke(invocation));
+				this.returnOrThrow = new ReturnComputedValue(invocation => valueFactory.InvokePreserveStack(new object[] { invocation }));
 			}
 			else
 			{

--- a/tests/Moq.Tests/CallbacksFixture.cs
+++ b/tests/Moq.Tests/CallbacksFixture.cs
@@ -516,6 +516,19 @@ namespace Moq.Tests
 			Assert.Equal(2, result);
 		}
 
+		[Fact]
+		public void Type_of_exception_thrown_from_InvocationFunc_callback_should_be_preserved()
+		{
+			var mock = new Mock<IFoo>();
+			mock.Setup(m => m.Submit("good", "bad")).Returns(new InvocationFunc(invocation =>
+			{
+				throw new Exception("very bad");  // this used to be erroneously wrapped as a `TargetInvocationException`
+			}));
+
+			var ex = Assert.Throws<Exception>(() => mock.Object.Submit("good", "bad"));
+			Assert.Equal("very bad", ex.Message);
+		}
+
 		public interface IInterface
 		{
 			void Method(Derived b);


### PR DESCRIPTION
Fixes a problem mentioned in https://github.com/moq/moq4/issues/1139#issuecomment-771563898.