### PR TITLE
Create symbol packages (.snupkg) and publish from AppVeyor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+ # Unreleased
+ 
+#### Added
+
+* Create symbol packages (.snupkg) and publish from AppVeyor (@304NotModified, #1150)
+
 ## 4.16.1 (2021-02-23)
 
 #### Added

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
   MSBUILD_LOGGER: C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll
 
 build_script:
-  - msbuild Moq.sln /r /t:Build;Test;Pack /logger:"%MSBUILD_LOGGER%"
+  - msbuild Moq.sln /r /t:Build;Test;Pack /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg /logger:"%MSBUILD_LOGGER%"
 
 test: off
 
@@ -23,3 +23,4 @@ nuget:
 
 artifacts:
   - path: 'out\*.nupkg'
+  - path: 'out\*.snupkg'


### PR DESCRIPTION
I saw the symbol packages aren't on nuget.org yet.

See https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg