### PR TITLE
InSequence for protected mocks

### DIFF
--- a/src/Moq/Language/Flow/MockProtectedSequencePhrase.cs
+++ b/src/Moq/Language/Flow/MockProtectedSequencePhrase.cs
@@ -11,25 +11,17 @@ using Moq.Protected;
 
 namespace Moq.Language.Flow
 {
-	internal sealed class WhenPhraseProtected<T,TAnalog> : ISetupConditionResultProtected<T,TAnalog>
+	internal sealed class MockProtectedSequencePhrase
+		<T, TAnalog> : MockSequencePhraseBase<T, TAnalog>
 		where T : class
 		where TAnalog : class
 	{
 		private static DuckReplacer DuckReplacerInstance = new DuckReplacer(typeof(TAnalog), typeof(T));
 
-		private Mock<T> mock;
-		private Condition condition;
+		public MockProtectedSequencePhrase(IProtectedAsMock<T, TAnalog> protectedAsMock, IMockSequence mockSequence) : base(protectedAsMock.Mocked, mockSequence) { }
 
-		public WhenPhraseProtected(IProtectedAsMock<T, TAnalog> protectedAsMock, Condition condition)
+		protected override LambdaExpression GetSetupExpression(Expression<Action<TAnalog>> expression)
 		{
-			mock = protectedAsMock.Mocked;
-			this.condition = condition;
-		}
-
-		public ISetup<T> Setup(Expression<Action<TAnalog>> expression)
-		{
-			Guard.NotNull(expression, nameof(expression));
-
 			Expression<Action<T>> rewrittenExpression;
 			try
 			{
@@ -39,15 +31,11 @@ namespace Moq.Language.Flow
 			{
 				throw new ArgumentException(ex.Message, nameof(expression));
 			}
-
-			var setup = Mock.Setup(this.mock, rewrittenExpression, condition);
-			return new VoidSetupPhrase<T>(setup);
+			return rewrittenExpression;
 		}
 
-		public ISetup<T, TResult> Setup<TResult>(Expression<Func<TAnalog, TResult>> expression)
+		protected override LambdaExpression GetSetupExpression<TResult>(Expression<Func<TAnalog, TResult>> expression)
 		{
-			Guard.NotNull(expression, nameof(expression));
-
 			Expression<Func<T, TResult>> rewrittenExpression;
 			try
 			{
@@ -57,15 +45,11 @@ namespace Moq.Language.Flow
 			{
 				throw new ArgumentException(ex.Message, nameof(expression));
 			}
-
-			var setup = Mock.Setup(this.mock, rewrittenExpression, condition);
-			return new NonVoidSetupPhrase<T, TResult>(setup);
+			return rewrittenExpression;
 		}
 
-		public ISetupGetter<T, TProperty> SetupGet<TProperty>(Expression<Func<TAnalog, TProperty>> expression)
+		protected override LambdaExpression GetSetupGetExpression<TProperty>(Expression<Func<TAnalog, TProperty>> expression)
 		{
-			Guard.NotNull(expression, nameof(expression));
-
 			Expression<Func<T, TProperty>> rewrittenExpression;
 			try
 			{
@@ -76,16 +60,10 @@ namespace Moq.Language.Flow
 				throw new ArgumentException(ex.Message, nameof(expression));
 			}
 
-			var setup = Mock.SetupGet(this.mock, rewrittenExpression, condition);
-			return new NonVoidSetupPhrase<T, TProperty>(setup);
+			return rewrittenExpression;
 		}
 
-		public ISetupSetter<T, TProperty> SetupSet<TProperty>(Action<TAnalog> setterExpression)
-		{
-			throw new NotImplementedException();
-		}
-
-		public ISetup<T> SetupSet(Action<TAnalog> setterExpression)
+		protected override LambdaExpression GetSetupSetExpression(Action<TAnalog> setterExpression)
 		{
 			throw new NotImplementedException();
 		}
@@ -267,4 +245,5 @@ namespace Moq.Language.Flow
 		}
 
 	}
+
 }

--- a/src/Moq/Language/Flow/MockSequencePhrase.cs
+++ b/src/Moq/Language/Flow/MockSequencePhrase.cs
@@ -18,7 +18,7 @@ namespace Moq.Language.Flow
 		{
 			var index = mockSequence.SetupIndex;
 			var sequenceSetup = setup(new Condition(() => mockSequence.Condition(index), () => mockSequence.SequenceSetupExecuted(index)));
-			mockSequence.AddSetup(sequenceSetup, index, mock);// todo mock vs protected mock
+			mockSequence.AddSetup(sequenceSetup, index, mock);
 			mockSequence.SetupIndex++;
 			return sequenceSetup;
 		}

--- a/src/Moq/Language/Flow/MockSequencePhrase.cs
+++ b/src/Moq/Language/Flow/MockSequencePhrase.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Linq.Expressions;
+
+namespace Moq.Language.Flow
+{
+	internal abstract class MockSequencePhraseBase<T, TAnalog> : ISequenceSetupConditionResult<T, TAnalog> where T : class where TAnalog : class
+	{
+		protected Mock<T> mock;
+		private IMockSequence mockSequence;
+
+		public MockSequencePhraseBase(Mock<T> mock, IMockSequence mockSequence)
+		{
+			this.mock = mock;
+			this.mockSequence = mockSequence;
+		}
+
+		private MethodCall DoSetup(Func<Condition, MethodCall> setup)
+		{
+			var index = mockSequence.SetupIndex;
+			var sequenceSetup = setup(new Condition(() => mockSequence.Condition(index), () => mockSequence.SequenceSetupExecuted(index)));
+			mockSequence.AddSetup(sequenceSetup, index, mock);// todo mock vs protected mock
+			mockSequence.SetupIndex++;
+			return sequenceSetup;
+		}
+		public ISetup<T> Setup(Expression<Action<TAnalog>> expression)
+		{
+			var setup = DoSetup(condition => Mock.Setup(mock, GetSetupExpression(expression), condition));
+			return new VoidSetupPhrase<T>(setup);
+		}
+
+		protected virtual LambdaExpression GetSetupExpression(Expression<Action<TAnalog>> expression)
+		{
+			return expression;
+		}
+
+		public ISetup<T, TResult> Setup<TResult>(Expression<Func<TAnalog, TResult>> expression)
+		{
+			var setup = DoSetup(condition => Mock.Setup(mock, GetSetupExpression<TResult>(expression), condition));
+			return new NonVoidSetupPhrase<T, TResult>(setup);
+		}
+
+		protected virtual LambdaExpression GetSetupExpression<TResult>(Expression<Func<TAnalog, TResult>> expression)
+		{
+			return expression;
+		}
+
+		public ISetupGetter<T, TProperty> SetupGet<TProperty>(Expression<Func<TAnalog, TProperty>> expression)
+		{
+			var setup = DoSetup(condition => Mock.SetupGet(mock, GetSetupGetExpression<TProperty>(expression), condition));
+			return new NonVoidSetupPhrase<T, TProperty>(setup);
+		}
+
+		protected virtual LambdaExpression GetSetupGetExpression<TProperty>(Expression<Func<TAnalog, TProperty>> expression)
+		{
+			return expression;
+		}
+
+		public ISetupSetter<T, TProperty> SetupSet<TProperty>(Action<TAnalog> setterExpression)
+		{
+			return new SetterSetupPhrase<T, TProperty>(SetupSetMethodCall(setterExpression));
+		}
+
+		protected abstract LambdaExpression GetSetupSetExpression(Action<TAnalog> setterExpression);
+		
+
+		public ISetup<T> SetupSet(Action<TAnalog> setterExpression)
+		{
+			return new VoidSetupPhrase<T>(SetupSetMethodCall(setterExpression));
+		}
+
+		private MethodCall SetupSetMethodCall(Action<TAnalog> setterExpression)
+		{
+			Guard.NotNull(setterExpression, nameof(setterExpression));
+			return DoSetup(condition => Mock.SetupSet(mock, GetSetupSetExpression(setterExpression), condition));
+		}
+	}
+
+	internal sealed class MockSequencePhrase<T> : MockSequencePhraseBase<T, T>
+		where T : class
+	{
+		public MockSequencePhrase(Mock<T> mock, IMockSequence mockSequence) : base(mock, mockSequence) { }
+		
+		protected override LambdaExpression GetSetupSetExpression(Action<T> setterExpression)
+		{
+			return ExpressionReconstructor.Instance.ReconstructExpression(setterExpression, this.mock.ConstructorArguments);
+		}
+		
+	}
+
+}

--- a/src/Moq/Language/ISequenceSetupConditionResult.cs
+++ b/src/Moq/Language/ISequenceSetupConditionResult.cs
@@ -13,7 +13,8 @@ namespace Moq.Language
 	/// Implements the fluent API.
 	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
-	public interface ISetupConditionResultProtected<T, TAnalog> where T : class where TAnalog : class
+	public interface ISequenceSetupConditionResult
+		<T, TAnalog> where T : class where TAnalog : class
 	{
 		/// <summary>
 		/// The expectation will be considered only in the former condition.

--- a/src/Moq/Language/ISetupConditionResultProtected.cs
+++ b/src/Moq/Language/ISetupConditionResultProtected.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.ComponentModel;
+using System.Linq.Expressions;
+
+using Moq.Language.Flow;
+
+namespace Moq.Language
+{
+	/// <summary>
+	/// Implements the fluent API.
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public interface ISetupConditionResultProtected<T, TAnalog> where T : class where TAnalog : class
+	{
+		/// <summary>
+		/// The expectation will be considered only in the former condition.
+		/// </summary>
+		/// <param name="expression"></param>
+		/// <returns></returns>
+		ISetup<T> Setup(Expression<Action<TAnalog>> expression);
+
+		/// <summary>
+		/// The expectation will be considered only in the former condition.
+		/// </summary>
+		/// <typeparam name="TResult"></typeparam>
+		/// <param name="expression"></param>
+		/// <returns></returns>
+		ISetup<T, TResult> Setup<TResult>(Expression<Func<TAnalog, TResult>> expression);
+
+		/// <summary>
+		/// Setups the get.
+		/// </summary>
+		/// <typeparam name="TProperty">The type of the property.</typeparam>
+		/// <param name="expression">The expression.</param>
+		/// <returns></returns>
+		ISetupGetter<T, TProperty> SetupGet<TProperty>(Expression<Func<TAnalog, TProperty>> expression);
+
+		/// <summary>
+		/// Setups the set.
+		/// </summary>
+		/// <typeparam name="TProperty">The type of the property.</typeparam>
+		/// <param name="setterExpression">The setter expression.</param>
+		/// <returns></returns>
+		ISetupSetter<T, TProperty> SetupSet<TProperty>(Action<TAnalog> setterExpression);
+
+		/// <summary>
+		/// Setups the set.
+		/// </summary>
+		/// <param name="setterExpression">The setter expression.</param>
+		/// <returns></returns>
+		ISetup<T> SetupSet(Action<TAnalog> setterExpression);
+	}
+}

--- a/src/Moq/MockSequence.cs
+++ b/src/Moq/MockSequence.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 
 using Moq.Language;
 using Moq.Language.Flow;
+using Moq.Protected;
 
 namespace Moq
 {
@@ -46,6 +47,18 @@ namespace Moq
 				condition: () => expectationPosition == sequenceStep,
 				success: NextStep));
 		}
+
+		internal ISetupConditionResultProtected<TMock,TAnalog> For<TMock,TAnalog>(IProtectedAsMock<TMock, TAnalog> protectedAsMock)
+			where TMock : class
+			where TAnalog : class
+		{
+			var expectationPosition = sequenceLength++;
+
+			return new WhenPhraseProtected<TMock, TAnalog>(protectedAsMock, new Condition(
+				condition: () => expectationPosition == sequenceStep,
+				success: NextStep));
+		}
+
 	}
 
 	/// <summary>
@@ -65,6 +78,20 @@ namespace Moq
 			Guard.NotNull(sequence, nameof(sequence));
 
 			return sequence.For(mock);
+		}
+
+		/// <summary>
+		/// Perform an expectation in the trace.
+		/// </summary>
+		public static ISetupConditionResultProtected<TMock,TAnalog> InSequence<TMock,TAnalog>(
+			this IProtectedAsMock<TMock,TAnalog> protectedAsMock,
+			MockSequence sequence)
+			where TMock : class 
+			where TAnalog : class
+		{
+			Guard.NotNull(sequence, nameof(sequence));
+
+			return sequence.For(protectedAsMock);
 		}
 	}
 }

--- a/src/Moq/MockSequence.cs
+++ b/src/Moq/MockSequence.cs
@@ -35,7 +35,7 @@ namespace Moq
 		/// 
 		/// </summary>
 		/// <returns></returns>
-		protected override bool ConditionImpl(ITrackedSetup trackedSetup)
+		protected sealed override bool ConditionImpl(ITrackedSetup trackedSetup)
 		{
 			var setupIndex = trackedSetup.SetupIndex;
 			if(setupIndex == expectedSetupIndex)

--- a/src/Moq/MockSequence.cs
+++ b/src/Moq/MockSequence.cs
@@ -1,8 +1,10 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
-
+using System.Linq;
 using Moq.Language;
 using Moq.Language.Flow;
 using Moq.Protected;
@@ -12,18 +14,16 @@ namespace Moq
 	/// <summary>
 	/// Helper class to setup a full trace between many mocks
 	/// </summary>
-	public class MockSequence
+	public class MockSequence : VerifiableSequence
 	{
-		int sequenceStep;
-		int sequenceLength;
+		int expectedSequenceIndex;
 
 		/// <summary>
 		/// Initialize a trace setup
 		/// </summary>
 		public MockSequence()
 		{
-			sequenceLength = 0;
-			sequenceStep = 0;
+			expectedSequenceIndex = 0;
 		}
 
 		/// <summary>
@@ -31,34 +31,36 @@ namespace Moq
 		/// </summary>
 		public bool Cyclic { get; set; }
 
-		private void NextStep()
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="sequenceIndex"></param>
+		/// <returns></returns>
+		public override bool Condition(int sequenceIndex)
 		{
-			sequenceStep++;
-			if (Cyclic)
-				sequenceStep = sequenceStep % sequenceLength;
+			if(sequenceIndex == expectedSequenceIndex)
+			{
+				if(expectedSequenceIndex == numberOfSetups - 1 && Cyclic)
+				{
+					expectedSequenceIndex = 0;
+				}
+				else
+				{
+					expectedSequenceIndex++;
+				}
+				
+				return true;
+			}
+			return false;
 		}
 
-		internal ISetupConditionResult<TMock> For<TMock>(Mock<TMock> mock)
-			where TMock : class
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="sequenceIndex"></param>
+		public override void SequenceSetupExecuted(int sequenceIndex)
 		{
-			var expectationPosition = sequenceLength++;
-
-			return new WhenPhrase<TMock>(mock, new Condition(
-				condition: () => expectationPosition == sequenceStep,
-				success: NextStep));
 		}
-
-		internal ISetupConditionResultProtected<TMock,TAnalog> For<TMock,TAnalog>(IProtectedAsMock<TMock, TAnalog> protectedAsMock)
-			where TMock : class
-			where TAnalog : class
-		{
-			var expectationPosition = sequenceLength++;
-
-			return new WhenPhraseProtected<TMock, TAnalog>(protectedAsMock, new Condition(
-				condition: () => expectationPosition == sequenceStep,
-				success: NextStep));
-		}
-
 	}
 
 	/// <summary>
@@ -68,11 +70,15 @@ namespace Moq
 	public static class MockSequenceHelper
 	{
 		/// <summary>
-		/// Perform an expectation in the trace.
+		///  todo
 		/// </summary>
-		public static ISetupConditionResult<TMock> InSequence<TMock>(
+		/// <typeparam name="TMock"></typeparam>
+		/// <param name="mock"></param>
+		/// <param name="sequence"></param>
+		/// <returns></returns>
+		public static ISequenceSetupConditionResult<TMock,TMock> InSequence<TMock>(
 			this Mock<TMock> mock,
-			MockSequence sequence)
+			VerifiableSequence sequence)
 			where TMock : class
 		{
 			Guard.NotNull(sequence, nameof(sequence));
@@ -83,10 +89,10 @@ namespace Moq
 		/// <summary>
 		/// Perform an expectation in the trace.
 		/// </summary>
-		public static ISetupConditionResultProtected<TMock,TAnalog> InSequence<TMock,TAnalog>(
-			this IProtectedAsMock<TMock,TAnalog> protectedAsMock,
-			MockSequence sequence)
-			where TMock : class 
+		public static ISequenceSetupConditionResult<TMock, TAnalog> InSequence<TMock, TAnalog>(
+			this IProtectedAsMock<TMock, TAnalog> protectedAsMock,
+			VerifiableSequence sequence)
+			where TMock : class
 			where TAnalog : class
 		{
 			Guard.NotNull(sequence, nameof(sequence));
@@ -94,4 +100,238 @@ namespace Moq
 			return sequence.For(protectedAsMock);
 		}
 	}
+
+	/// <summary>
+	/// 
+	/// </summary>
+	internal interface IMockSequence
+	{
+		/// <summary>
+		/// 
+		/// </summary>
+		int SetupIndex { get; set; }
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="setup"></param>
+		/// <param name="index"></param>
+		/// <param name="mock"></param>
+		void AddSetup(ISetup setup, int index,Mock mock);
+		
+		bool Condition(int index);
+		
+		void SequenceSetupExecuted(int index);
+	}
+
+	/// <summary>
+	/// 
+	/// </summary>
+	public abstract class VerifiableSequence : IMockSequence
+	{
+		/// <summary>
+		/// 
+		/// </summary>
+		public int SetupIndex { get; set; }
+
+		private Dictionary<Mock, List<Moq.ISetup>> mockSetups = new Dictionary<Mock, List<ISetup>>();
+		/// <summary>
+		/// 
+		/// </summary>
+		protected int numberOfSetups = 0;
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="setup"></param>
+		/// <param name="index"></param>
+		/// <param name="mock"></param>
+		public void AddSetup(ISetup setup, int index, Mock mock)
+		{
+			numberOfSetups++;
+			if (!mockSetups.TryGetValue(mock, out var setups))
+			{
+				setups = new List<Moq.ISetup>();
+				mockSetups.Add(mock, setups);
+			}
+			setups.Add(setup);
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="verifyAll"></param>
+		public void VerifySequence(bool verifyAll = true)
+		{
+			VerifySetups(GetCurrentSetups(), verifyAll);
+		}
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="verifyAll"></param>
+		/// <param name="sequences"></param>
+		public static void VerifySequences(bool verifyAll,params VerifiableSequence[] sequences)
+		{
+			foreach(var sequence in sequences)
+			{
+				sequence.VerifySequence(verifyAll);
+			}
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="mock"></param>
+		/// <param name="verifyAll"></param>
+		public void VerifySequenceAndMock(Mock mock, bool verifyAll = true)
+		{
+			VerifySequenceAndMocks(new Mock[] { mock }, verifyAll);
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="verifyAll"></param>
+		public void VerifySequenceAndAllMocks(bool verifyAll = true)
+		{
+			VerifySequenceAndMocks(mockSetups.Keys.ToArray(), verifyAll);
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="verifyAll"></param>
+		/// <param name="sequences"></param>
+		public static void VerifySequencesAndAllMocks(bool verifyAll, params VerifiableSequence[] sequences)
+		{
+			foreach (var sequence in sequences)
+			{
+				sequence.VerifySequenceAndAllMocks(verifyAll);
+			}
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="mock"></param>
+		public void MockVerify(Mock mock)
+		{
+			VerifySetups(GetCurrentSetups(mock), false);
+			mock.Verify();
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="mock"></param>
+		public void MockVerifyAll(Mock mock)
+		{
+			VerifySetups(GetCurrentSetups(mock), true);
+			mock.VerifyAll();
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="setups"></param>
+		/// <param name="verifyAll"></param>
+		private void VerifySetups(IEnumerable<Moq.ISetup> setups, bool verifyAll)
+		{
+			foreach (var setupForVerification in setups)
+			{
+				if (verifyAll)
+				{
+					setupForVerification.VerifyAll();
+				}
+				else
+				{
+					if (setupForVerification.IsVerifiable)
+					{
+						setupForVerification.Verify();//using recursive true as that is what Mock.Verify()/VerifyAll() does
+					}
+				}
+			}
+		}
+
+		private void VerifySequenceAndMocks(Mock[] mocks, bool verifyAll)
+		{
+			VerifySequence(verifyAll);
+
+			if (verifyAll)
+			{
+				Mock.VerifyAll(mocks);
+			}
+			else
+			{
+				Mock.Verify(mocks);
+			}
+		}
+
+		private List<Moq.ISetup> GetCurrentSetups()
+		{
+			List<Moq.ISetup> currentSetups = new List<ISetup>();
+			foreach (var entry in mockSetups)
+			{
+				currentSetups.AddRange(GetCurrentSetups(entry.Key, entry.Value));
+			}
+			return currentSetups;
+		}
+
+		private List<ISetup> GetCurrentSetups(Mock mock, List<ISetup> storedSetups)
+		{
+			var currentMockSetups = mock.MutableSetups;
+			var removals = new List<Moq.ISetup>();
+			foreach (var storedSetup in storedSetups)
+			{
+				if (!currentMockSetups.Contains(storedSetup))
+				{
+					removals.Add(storedSetup);
+				}
+			}
+			foreach (var removal in removals)
+			{
+				storedSetups.Remove(removal);
+			}
+			return storedSetups;
+		}
+
+		private List<ISetup> GetCurrentSetups(Mock mock)
+		{
+			if (mockSetups.ContainsKey(mock))
+			{
+				return GetCurrentSetups(mock, mockSetups[mock]);
+			}
+			else
+			{
+				throw new ArgumentException("Mock is not in a sequence");
+			}
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="sequenceIndex"></param>
+		/// <returns></returns>
+		public abstract bool Condition(int sequenceIndex);
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="sequenceIndex"></param>
+		/// <returns></returns>
+		public abstract void SequenceSetupExecuted(int sequenceIndex);
+
+		internal ISequenceSetupConditionResult<TMock,TMock> For<TMock>(Mock<TMock> mock)
+			where TMock : class
+		{
+			return new MockSequencePhrase<TMock>(mock, this);
+		}
+
+		internal ISequenceSetupConditionResult<TMock, TAnalog> For<TMock,TAnalog>(IProtectedAsMock<TMock, TAnalog> mock)
+			where TMock : class
+			where TAnalog : class
+		{
+			return new MockProtectedSequencePhrase<TMock,TAnalog>(mock, this);
+		}
+	}
+
 }

--- a/src/Moq/MockSequence.cs
+++ b/src/Moq/MockSequence.cs
@@ -358,17 +358,20 @@ namespace Moq
 			List<ITrackedSetup> currentSetups = new List<ITrackedSetup>();
 			foreach (var entry in trackedSetups)
 			{
-				currentSetups.AddRange(GetCurrentSetups(entry.Key, entry.Value));
+				currentSetups.AddRange(GetCurrentSetups(entry.Value));
 			}
 			return currentSetups;
 		}
 
-		private List<TrackedSetup> GetCurrentSetups(Mock mock, List<TrackedSetup> storedSetups)
+		private List<TrackedSetup> GetCurrentSetups(List<TrackedSetup> storedSetups)
 		{
-			var currentMockSetups = mock.MutableSetups;
 			var removals = new List<TrackedSetup>();
 			foreach (var storedSetup in storedSetups)
 			{
+				var setup = storedSetup.Setup;
+				var setupMock = setup.Mock;
+				var currentMockSetups = setupMock.MutableSetups;
+
 				if (!currentMockSetups.Contains(storedSetup.Setup))
 				{
 					removals.Add(storedSetup);
@@ -385,7 +388,7 @@ namespace Moq
 		{
 			if (trackedSetups.ContainsKey(mock))
 			{
-				return GetCurrentSetups(mock, trackedSetups[mock]);
+				return GetCurrentSetups(trackedSetups[mock]);
 			}
 			else
 			{

--- a/src/Moq/MockSequence.cs
+++ b/src/Moq/MockSequence.cs
@@ -193,6 +193,10 @@ namespace Moq
 		}
 
 		private int executionCount = 0;
+		/// <summary>
+		/// 
+		/// </summary>
+		protected bool ThrowIfConditionNotMetWhenLoose { get; set; } = true;
 
 		/// <summary>
 		/// 
@@ -396,7 +400,13 @@ namespace Moq
 		/// <returns></returns>
 		public bool Condition(int setupIndex)
 		{
-			return ConditionImpl(GetTrackedSetup(setupIndex));
+			var trackedSetup = GetTrackedSetup(setupIndex);
+			var pass = ConditionImpl(trackedSetup);
+			if(!pass && ThrowIfConditionNotMetWhenLoose && trackedSetup.Mock.Behavior == MockBehavior.Loose)
+			{
+				throw new Exception("todo");//todo MockException
+			}
+			return pass;
 		}
 
 		/// <summary>

--- a/src/Moq/MockSequence.cs
+++ b/src/Moq/MockSequence.cs
@@ -201,7 +201,7 @@ namespace Moq
 		/// <summary>
 		/// 
 		/// </summary>
-		public int SetupIndex { get; set; }
+		int IMockSequence.SetupIndex { get; set; }
 
 		private Dictionary<Mock, List<TrackedSetup>> trackedSetups = new Dictionary<Mock, List<TrackedSetup>>();
 		
@@ -216,7 +216,7 @@ namespace Moq
 		/// <param name="setup"></param>
 		/// <param name="setupIndex"></param>
 		/// <param name="mock"></param>
-		public void AddSetup(ISetup setup, int setupIndex, Mock mock)
+		void IMockSequence.AddSetup(ISetup setup, int setupIndex, Mock mock)
 		{
 			numberOfSetups++;
 			if (!trackedSetups.TryGetValue(mock, out var setups))
@@ -398,13 +398,13 @@ namespace Moq
 		/// </summary>
 		/// <param name="setupIndex"></param>
 		/// <returns></returns>
-		public bool Condition(int setupIndex)
+		bool IMockSequence.Condition(int setupIndex)
 		{
 			var trackedSetup = GetTrackedSetup(setupIndex);
 			var pass = ConditionImpl(trackedSetup);
 			if(!pass && ThrowIfConditionNotMetWhenLoose && trackedSetup.Mock.Behavior == MockBehavior.Loose)
 			{
-				throw new Exception("todo");//todo MockException
+				throw new Exception("todo");//todo
 			}
 			return pass;
 		}

--- a/src/Moq/Protected/IProtectedAsMock.cs
+++ b/src/Moq/Protected/IProtectedAsMock.cs
@@ -25,6 +25,10 @@ namespace Moq.Protected
 		where TAnalog : class
 	{
 		/// <summary>
+		///  gets the mock
+		/// </summary>
+		Mock<T> Mocked { get; }
+		/// <summary>
 		/// Specifies a setup on the mocked type for a call to a <see langword="void"/> method.
 		/// </summary>
 		/// <param name="expression">Lambda expression that specifies the expected method invocation.</param>

--- a/tests/Moq.Tests/MockSequenceFixture.cs
+++ b/tests/Moq.Tests/MockSequenceFixture.cs
@@ -2,6 +2,9 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using Moq.Protected;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace Moq.Tests
@@ -148,6 +151,411 @@ namespace Moq.Tests
 
 		}
 
+		[Fact]
+		public void VerifySequenceVerifyAllVerifiesAllSetupsRegardlessOfMarkedAsVerified()
+		{
+			void PerformTest(Action<IFoo,Protected> act)
+			{
+				var a = new Mock<IFoo>(MockBehavior.Strict);
+				var protectedAs = new Mock<Protected>().Protected().As<ProtectedLike>();
+				var sequence = new MockSequence();
+				a.InSequence(sequence).Setup(x => x.Do(100)).Returns(101);
+				a.InSequence(sequence).Setup(x => x.Do(200)).Returns(201);
+				protectedAs.InSequence(sequence).Setup(y => y.ProtectedDo(300)).Returns(301);
+
+				act(a.Object, protectedAs.Mocked.Object);
+				sequence.VerifySequence(true);
+			}
+
+			PerformTest((foo, @protected) =>
+			{
+				foo.Do(100);
+				foo.Do(200);
+				@protected.InvokeProtectedDo(300);
+			});
+
+			Assert.Throws<MockException>(() => PerformTest((foo, @protected) =>
+			{
+				foo.Do(100);
+				foo.Do(200);
+			}));
+
+		}
+
+		[Fact]
+		public void VerifySequenceVerifiesVerifiableSetups()
+		{
+			var a = new Mock<IFoo>(MockBehavior.Strict);
+			var protectedAs = new Mock<Protected>().Protected().As<ProtectedLike>();
+			var sequence = new MockSequence();
+			a.InSequence(sequence).Setup(x => x.Do(100)).Returns(101).Verifiable();
+			a.InSequence(sequence).Setup(x => x.Do(200)).Returns(201).Verifiable();
+			protectedAs.InSequence(sequence).Setup(y => y.ProtectedDo(300)).Returns(301);
+
+			a.Object.Do(100);
+			a.Object.Do(200);
+
+			sequence.VerifySequence(false);
+
+		}
+
+		[Fact]
+		public void VerifySequencesVerifyAllVerifiesAllSetupsInAllSequencesRegardlessOrVerifiable()
+		{
+			void PerformTest(Action<IFoo, Protected> act)
+			{
+				var a = new Mock<IFoo>(MockBehavior.Strict);
+				var protectedAs = new Mock<Protected>().Protected().As<ProtectedLike>();
+				var sequence1 = new MockSequence();
+				a.InSequence(sequence1).Setup(x => x.Do(100)).Returns(101).Verifiable();
+				a.InSequence(sequence1).Setup(x => x.Do(200)).Returns(201).Verifiable();
+				protectedAs.InSequence(sequence1).Setup(y => y.ProtectedDo(300)).Returns(301);
+
+				var sequence2 = new MockSequence();
+				a.InSequence(sequence2).Setup(x => x.Do(1)).Returns(101).Verifiable();
+				a.InSequence(sequence2).Setup(x => x.Do(2)).Returns(201).Verifiable();
+				protectedAs.InSequence(sequence2).Setup(y => y.ProtectedDo(3)).Returns(301);
+
+				act(a.Object, protectedAs.Mocked.Object);
+				VerifiableSequence.VerifySequences(true, sequence1, sequence2);
+			}
+
+			PerformTest((foo, @protected) =>
+			{
+				foo.Do(100);
+				foo.Do(200);
+				foo.Do(1);
+				@protected.InvokeProtectedDo(300);
+				foo.Do(2);
+				@protected.InvokeProtectedDo(3);
+			});
+
+			Assert.Throws<MockException>(() => PerformTest((foo, @protected) =>
+			{
+				foo.Do(100);
+				foo.Do(200);
+				foo.Do(1);
+				@protected.InvokeProtectedDo(300);
+				foo.Do(2);
+			}));
+
+		}
+
+		[Fact]
+		public void VerifySequencesVerifiesAllVerifiableSetupsInAllSequences()
+		{
+			var a = new Mock<IFoo>(MockBehavior.Strict);
+			var foo = a.Object;
+			var protectedAs = new Mock<Protected>().Protected().As<ProtectedLike>();
+			var sequence1 = new MockSequence();
+			a.InSequence(sequence1).Setup(x => x.Do(100)).Returns(101).Verifiable();
+			a.InSequence(sequence1).Setup(x => x.Do(200)).Returns(201).Verifiable();
+			protectedAs.InSequence(sequence1).Setup(y => y.ProtectedDo(300)).Returns(301);
+
+			var sequence2 = new MockSequence();
+			a.InSequence(sequence2).Setup(x => x.Do(1)).Returns(101).Verifiable();
+			a.InSequence(sequence2).Setup(x => x.Do(2)).Returns(201).Verifiable();
+			protectedAs.InSequence(sequence2).Setup(y => y.ProtectedDo(3)).Returns(301);
+
+			foo.Do(100);
+			foo.Do(200);
+			foo.Do(1);
+			protectedAs.Mocked.Object.InvokeProtectedDo(300);
+			foo.Do(2);
+
+			VerifiableSequence.VerifySequences(false, sequence1, sequence2);
+		}
+
+		[Fact]
+		public void VerifySequenceAndMocksVerifyAllVerifiesTheSequenceAndTheMocksRegardlessOfVerifiable()
+		{
+			var a = new Mock<IFoo>(MockBehavior.Strict);
+			a.Setup(f => f.Do(1)).Returns(1);
+			var sequence = new MockSequence();
+			Assert.Throws<MockException>(() => sequence.VerifySequenceAndMocks(true, a));
+
+			a.Object.Do(1);
+			sequence.VerifySequenceAndMocks(true, a);
+
+			a.InSequence(sequence).Setup(f => f.Do(2)).Returns(2);
+
+			Assert.Throws<MockException>(() => sequence.VerifySequenceAndMocks(true, a));
+		}
+
+		[Fact]
+		public void VerifySequenceAndMocksVerifiesVerfiableSetupsOfTheSequenceAndTheMocks()
+		{
+			var a = new Mock<IFoo>(MockBehavior.Strict);
+			a.Setup(f => f.Do(1)).Returns(1);
+			var sequence = new MockSequence();
+			sequence.VerifySequenceAndMocks(false, a);
+
+			a.InSequence(sequence).Setup(f => f.Do(2)).Returns(2);
+
+			sequence.VerifySequenceAndMocks(false, a);
+		}
+
+		[Fact]
+		public void VerifySequenceAndAllMocksVerifyAllVerifiesTheSequenceAndAllMocksOfTheSequenceRegardlessOfVerifiable()
+		{
+			var a = new Mock<IFoo>(MockBehavior.Strict);
+			a.Setup(f => f.Do(1)).Returns(1);
+			var sequence = new MockSequence();
+			// does not throw as the mock is not in the sequence
+			sequence.VerifySequenceAndAllMocks(true);
+
+			a.InSequence(sequence).Setup(f => f.Do(2)).Returns(2);
+			a.Object.Do(2);
+
+			// throws for the mock
+			Assert.Throws<MockException>(() => sequence.VerifySequenceAndAllMocks(true));
+
+			a.Object.Do(1);
+			sequence.VerifySequenceAndAllMocks(true);
+
+			a.InSequence(sequence).Setup(f => f.Do(3)).Returns(3);
+
+			// throws for the sequence
+			Assert.Throws<MockException>(() => sequence.VerifySequenceAndAllMocks(true));
+		}
+
+		[Fact]
+		public void VerifySequenceAndAllMocksVerifiesVerifiableSetupsOfTheSequenceAndAllMocksOfTheSequence()
+		{
+			var a = new Mock<IFoo>(MockBehavior.Strict);
+			a.Setup(f => f.Do(1)).Returns(1).Verifiable();
+			a.Setup(f => f.Do(0)).Returns(0);
+			var sequence = new MockSequence();
+			// does not throw as the mock is not in the sequence
+			sequence.VerifySequenceAndAllMocks(false);
+
+			// throws for the mock
+			a.InSequence(sequence).Setup(f => f.Do(2)).Returns(2);
+			Assert.Throws<MockException>(() => sequence.VerifySequenceAndAllMocks(false));
+
+			a.Object.Do(1);
+			sequence.VerifySequenceAndAllMocks(false);
+
+			a.InSequence(sequence).Setup(f => f.Do(3)).Returns(3).Verifiable();
+
+			// throws for the sequence
+			Assert.Throws<MockException>(() => sequence.VerifySequenceAndAllMocks(false));
+		}
+
+		[Fact]
+		public void VerifySequencesAndAllMocksVerifyAllVerifiesAllSequencesAndAllTheirMocksRegardlessOfVerifiable()
+		{
+			var a = new Mock<IFoo>(MockBehavior.Strict);
+			var foo = a.Object;
+			a.Setup(f => f.Do(1)).Returns(1);
+			var sequence1 = new MockSequence();
+			var protectedAs = new Mock<Protected>().Protected().As<ProtectedLike>();
+			var @protected = protectedAs.Mocked.Object;
+			protectedAs.Setup(p => p.ProtectedDo(1)).Returns(1);
+			var sequence2 = new MockSequence();
+
+			void PerformVerification()
+			{
+				VerifiableSequence.VerifySequencesAndAllMocks(true, sequence1, sequence2);
+			}
+
+			// does not throw as no mocks in the sequence
+			PerformVerification();
+			
+			a.InSequence(sequence1).Setup(f => f.Do(2)).Returns(2);
+			foo.Do(2);
+
+			// throws for the mock
+			Assert.Throws<MockException>(PerformVerification);
+
+			foo.Do(1);
+			PerformVerification();
+
+			protectedAs.InSequence(sequence2).Setup(p => p.ProtectedDo(2)).Returns(2);
+			@protected.InvokeProtectedDo(2);
+
+			// throws for the mock
+			Assert.Throws<MockException>(PerformVerification);
+
+			@protected.InvokeProtectedDo(1);
+			PerformVerification();
+
+			a.InSequence(sequence1).Setup(f => f.Do(3)).Returns(3);
+			// throws for sequences
+			Assert.Throws<MockException>(PerformVerification);
+
+			foo.Do(3);
+			PerformVerification();
+
+			protectedAs.InSequence(sequence2).Setup(p => p.ProtectedDo(3)).Returns(3);
+			// throws for sequences
+			Assert.Throws<MockException>(PerformVerification);
+
+			@protected.InvokeProtectedDo(3);
+			PerformVerification();
+
+		}
+
+		[Fact]
+		public void VerifySequencesAndAllMocksVerifiesAllVerifiableSetupsAllSequencesAndAllTheirMocks()
+		{
+			var a = new Mock<IFoo>(MockBehavior.Strict);
+			var foo = a.Object;
+			a.Setup(f => f.Do(1)).Returns(1).Verifiable();
+			var sequence1 = new MockSequence();
+			var protectedAs = new Mock<Protected>().Protected().As<ProtectedLike>();
+			var @protected = protectedAs.Mocked.Object;
+			protectedAs.Setup(p => p.ProtectedDo(1)).Returns(1);
+			var sequence2 = new MockSequence();
+
+			void PerformVerification()
+			{
+				VerifiableSequence.VerifySequencesAndAllMocks(false, sequence1, sequence2);
+			}
+
+			// no mocks in sequences
+			PerformVerification();
+
+			a.InSequence(sequence1).Setup(f => f.Do(2)).Returns(2);
+
+			//throws for mock
+			Assert.Throws<MockException>(PerformVerification);
+
+			foo.Do(1);
+			PerformVerification();
+
+			protectedAs.InSequence(sequence2).Setup(p => p.ProtectedDo(2)).Returns(2).Verifiable();
+			@protected.InvokeProtectedDo(2);
+			// does not throw as mock setup is not verifiable
+			PerformVerification();
+
+			a.InSequence(sequence1).Setup(f => f.Do(3)).Returns(3).Verifiable();
+			//throws for sequence
+			Assert.Throws<MockException>(PerformVerification);
+
+			foo.Do(2);//satisfy the sequence
+			foo.Do(3);
+			PerformVerification();
+
+		}
+
+		[Fact]
+		public void VerifiableSequencePermitsDifferentSequenceLogic()
+		{
+			void PerformTest(Action<IFoo, Protected> act)
+			{
+				var a = new Mock<IFoo>(MockBehavior.Strict);
+				var protectedAs = new Mock<Protected>().Protected().As<ProtectedLike>();
+				var sequence = new ConsecutiveInvocationsSequence();
+				a.InSequence(sequence).Setup(x => x.Do(100)).Returns(101);
+				a.InSequence(sequence.ConsecutiveInvocations(2)).Setup(x => x.Do(200)).Returns(201);
+				protectedAs.InSequence(sequence.ConsecutiveInvocations(3)).Setup(y => y.ProtectedDo(300)).Returns(301);
+				protectedAs.InSequence(sequence).Setup(y => y.ProtectedDo(400)).Returns(401);
+				act(a.Object, protectedAs.Mocked.Object);
+			}
+
+			PerformTest((foo, @protected) =>
+			{
+				foo.Do(100);
+				foo.Do(200);
+				foo.Do(200);
+				@protected.InvokeProtectedDo(300);
+				@protected.InvokeProtectedDo(300);
+				@protected.InvokeProtectedDo(300);
+				@protected.InvokeProtectedDo(400);
+			});
+
+			Assert.Throws<MockException>(() => PerformTest((foo, @protected) =>
+			{
+				foo.Do(100);
+				foo.Do(200);
+				foo.Do(200);
+				foo.Do(200);
+			}));
+		}
+
+		[Fact]
+		public void VerifyExtensionVerifiesVerifiableSetupsOfTheMockAndAllSetupsApplicableToTheMockFromTheSequences()
+		{
+			var a = new Mock<IFoo>(MockBehavior.Strict);
+			var foo = a.Object;
+			var seq = new MockSequence();
+			a.Setup(f => f.Do(0)).Returns(0).Verifiable();
+			a.InSequence(seq).Setup(f => f.Do(1)).Returns(1).Verifiable();
+			a.InSequence(seq).Setup(f => f.Do(2)).Returns(2).Verifiable();
+			
+			Assert.Throws<MockException>(() => a.Verify(seq));
+			foo.Do(0);
+			Assert.Throws<MockException>(() => a.Verify(seq));
+			foo.Do(1);
+			Assert.Throws<MockException>(() => a.Verify(seq));
+			foo.Do(2);
+			a.Verify(seq);
+
+			a.Setup(f => f.Do(3)).Returns(3);
+			a.Verify(seq);
+
+			var seq2 = new MockSequence();
+			var protectedAs = new Mock<Protected>().Protected().As<ProtectedLike>();
+			protectedAs.InSequence(seq2).Setup(p => p.ProtectedDo(0)).Returns(0).Verifiable();
+			a.InSequence(seq2).Setup(f => f.Do(4)).Returns(4);
+
+			a.Verify(seq, seq2);
+		}
+
+		[Fact]
+		public void VerifyAllExtensionVerifiesAllSetupsOfTheMockAndAllSetupsApplicableToTheMockFromTheSequences()
+		{
+			var a = new Mock<IFoo>(MockBehavior.Strict);
+			var foo = a.Object;
+			var seq = new MockSequence();
+			a.Setup(f => f.Do(0)).Returns(0);
+			a.InSequence(seq).Setup(f => f.Do(1)).Returns(1);
+			a.InSequence(seq).Setup(f => f.Do(2)).Returns(2);
+
+			Assert.Throws<MockException>(() => a.VerifyAll(seq));
+			foo.Do(0);
+			Assert.Throws<MockException>(() => a.VerifyAll(seq));
+			foo.Do(1);
+			Assert.Throws<MockException>(() => a.VerifyAll(seq));
+			foo.Do(2);
+			a.VerifyAll(seq);
+
+			a.Setup(f => f.Do(3)).Returns(3);
+			Assert.Throws<MockException>(() => a.VerifyAll(seq));
+			foo.Do(3);
+
+			var seq2 = new MockSequence();
+			var protectedAs = new Mock<Protected>().Protected().As<ProtectedLike>();
+			protectedAs.InSequence(seq2).Setup(p => p.ProtectedDo(0)).Returns(0);
+			a.InSequence(seq2).Setup(f => f.Do(4)).Returns(4);
+
+			Assert.Throws<MockException>(() => a.VerifyAll(seq, seq2));
+			protectedAs.Mocked.Object.InvokeProtectedDo(0);
+			Assert.Throws<MockException>(() => a.VerifyAll(seq, seq2));
+			foo.Do(4);
+			a.VerifyAll(seq, seq2);
+		}
+
+		[Fact]
+		public void VerifiableSequencesCanProvideCustomVerifySequenceLogic()
+		{
+			var a = new Mock<IFoo>(MockBehavior.Strict);
+			var foo = a.Object;
+			var seq = new CustomVerificationSequence();
+			a.InSequence(seq).Setup(f => f.Do(1)).Returns(1);
+			a.InSequence(seq).Setup(f => f.Do(2)).Returns(2);
+
+			foo.Do(1);
+			foo.Do(2);
+			foo.Do(1);
+
+			Assert.Throws<Exception>(() => seq.VerifySequence(true));
+			foo.Do(2);
+			seq.VerifySequence(true);
+
+		}
+
 		public abstract class Protected
 		{
 			protected abstract int ProtectedDo(int arg);
@@ -165,6 +573,76 @@ namespace Moq.Tests
 		public interface IFoo
 		{
 			int Do(int arg);
+		}
+
+		public class ConsecutiveInvocationsSequence : VerifiableSequence
+		{
+			private int consecutiveInvocations = 1;
+			private Queue<int> order = new Queue<int>();
+			
+			public ConsecutiveInvocationsSequence ConsecutiveInvocations(int consecutiveInvocations)
+			{
+				this.consecutiveInvocations = consecutiveInvocations;
+				return this;
+			}
+			
+			protected override bool ConditionImpl(ITrackedSetup trackedSetup)
+			{
+				var expectedSetupIndex = order.Dequeue();
+				return expectedSetupIndex == trackedSetup.SetupIndex;
+			}
+
+			protected override void AddedSetup(ITrackedSetup trackedSetup)
+			{
+				for(var i = 0; i < consecutiveInvocations; i++)
+				{
+					order.Enqueue(trackedSetup.SetupIndex);
+				}
+				
+				consecutiveInvocations = 1;
+			}
+		}
+
+		public class CustomVerificationSequence : VerifiableSequence
+		{
+			private int CompletedCycles = 2;
+			
+			int expectedSetupIndex;
+
+			/// <summary>
+			/// 
+			/// </summary>
+			/// <returns></returns>
+			protected override bool ConditionImpl(ITrackedSetup trackedSetup)
+			{
+				var setupIndex = trackedSetup.SetupIndex;
+				if (setupIndex == expectedSetupIndex)
+				{
+					if (expectedSetupIndex == numberOfSetups - 1)
+					{
+						expectedSetupIndex = 0;
+					}
+					else
+					{
+						expectedSetupIndex++;
+					}
+
+					return true;
+				}
+				return false;
+			}
+
+			public override void VerifySequence(bool verifyAll = true)
+			{
+				base.VerifySequence(verifyAll);
+				foreach(var trackedSetup in GetCurrentSetups())
+				{
+					if((verifyAll || trackedSetup.Setup.IsVerifiable) && trackedSetup.ExecutionIndices.Count != CompletedCycles)
+					{
+						throw new Exception($"Setup did not participate in {CompletedCycles} cycles");
+					}
+				}
+			}
 		}
 	}
 }

--- a/tests/Moq.Tests/MockSequenceFixture.cs
+++ b/tests/Moq.Tests/MockSequenceFixture.cs
@@ -129,7 +129,7 @@ namespace Moq.Tests
 			Assert.Equal(101, a.Object.Do(100));
 			Assert.Equal(201, a.Object.Do(200));
 			Assert.Equal(301, protectedAs.Mocked.Object.InvokeProtectedDo(300));
-			
+
 		}
 
 		[Fact]

--- a/tests/Moq.Tests/MockSequenceFixture.cs
+++ b/tests/Moq.Tests/MockSequenceFixture.cs
@@ -567,7 +567,7 @@ namespace Moq.Tests
 			a.InSequence(seq).Setup(f => f.Do(2)).Returns(2);
 
 			foo.Do(1);
-			var mockException = Assert.Throws<MockException>(() => foo.Do(1));
+			var mockException = Assert.Throws<Exception>(() => foo.Do(1));
 			var msg = mockException.Message;
 		}
 

--- a/tests/Moq.Tests/MockSequenceFixture.cs
+++ b/tests/Moq.Tests/MockSequenceFixture.cs
@@ -556,6 +556,20 @@ namespace Moq.Tests
 
 		}
 
+		[Fact]
+		public void ShouldThrowForLooseWhenConditionIsNotGivenDefaultThrowIfConditionNotMetWhenLoose()
+		{
+			var a = new Mock<IFoo>(MockBehavior.Loose);
+			var foo = a.Object;
+			var seq = new MockSequence();
+			a.InSequence(seq).Setup(f => f.Do(1)).Returns(1);
+			a.InSequence(seq).Setup(f => f.Do(2)).Returns(2);
+
+			// have the setup so will check the invocations for the matching setup
+			// but is that set when Condition fails
+			Assert.Throws<Exception>(() => foo.Do(2));
+		}
+
 		public abstract class Protected
 		{
 			protected abstract int ProtectedDo(int arg);

--- a/tests/Moq.Tests/MockSequenceFixture.cs
+++ b/tests/Moq.Tests/MockSequenceFixture.cs
@@ -562,12 +562,13 @@ namespace Moq.Tests
 			var a = new Mock<IFoo>(MockBehavior.Loose);
 			var foo = a.Object;
 			var seq = new MockSequence();
+			
 			a.InSequence(seq).Setup(f => f.Do(1)).Returns(1);
 			a.InSequence(seq).Setup(f => f.Do(2)).Returns(2);
 
-			// have the setup so will check the invocations for the matching setup
-			// but is that set when Condition fails
-			Assert.Throws<Exception>(() => foo.Do(2));
+			foo.Do(1);
+			var mockException = Assert.Throws<MockException>(() => foo.Do(1));
+			var msg = mockException.Message;
 		}
 
 		public abstract class Protected

--- a/tests/Moq.Tests/MockSequenceFixture.cs
+++ b/tests/Moq.Tests/MockSequenceFixture.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using Moq.Protected;
 using Xunit;
 
 namespace Moq.Tests
@@ -113,6 +114,52 @@ namespace Moq.Tests
 			a.InSequence(sequence).Setup(x => x.Do(200)).Returns(201);
 
 			Assert.Throws<MockException>(() => a.Object.Do(200));
+		}
+
+		[Fact]
+		public void WorksWithProtectedAsSuccess()
+		{
+			var a = new Mock<IFoo>(MockBehavior.Strict);
+			var protectedAs = new Mock<Protected>().Protected().As<ProtectedLike>();
+			var sequence = new MockSequence();
+			a.InSequence(sequence).Setup(x => x.Do(100)).Returns(101);
+			a.InSequence(sequence).Setup(x => x.Do(200)).Returns(201);
+			protectedAs.InSequence(sequence).Setup(y => y.ProtectedDo(300)).Returns(301);
+
+			Assert.Equal(101, a.Object.Do(100));
+			Assert.Equal(201, a.Object.Do(200));
+			Assert.Equal(301, protectedAs.Mocked.Object.InvokeProtectedDo(300));
+			
+		}
+
+		[Fact]
+		public void WorksWithProtectedAsFailure()
+		{
+			var a = new Mock<IFoo>(MockBehavior.Strict);
+			var protectedAs = new Mock<Protected>().Protected().As<ProtectedLike>();
+
+			var sequence = new MockSequence();
+			a.InSequence(sequence).Setup(x => x.Do(100)).Returns(101);
+			protectedAs.InSequence(sequence).Setup(y => y.ProtectedDo(300)).Returns(301);
+			a.InSequence(sequence).Setup(x => x.Do(200)).Returns(201);
+
+			Assert.Equal(101, a.Object.Do(100));
+			Assert.Throws<MockException>(() => a.Object.Do(200));
+
+		}
+
+		public abstract class Protected
+		{
+			protected abstract int ProtectedDo(int arg);
+			public int InvokeProtectedDo(int arg)
+			{
+				return ProtectedDo(arg);
+			}
+		}
+
+		public interface ProtectedLike
+		{
+			int ProtectedDo(int arg);
 		}
 
 		public interface IFoo


### PR DESCRIPTION
Will resolve #1173 when implementations are provided for two Setup methods as described below.

For discussion

There is common code with existing WhenPhrase and Mock methods that differ only in the condition - for instance
```
//When

		public ISetup<T> Setup(Expression<Action<T>> expression)
		{
			var setup = Mock.Setup(mock, expression, this.condition);
			return new VoidSetupPhrase<T>(setup);
		}
//Mock<T>

		public ISetup<T, TResult> Setup<TResult>(Expression<Func<T, TResult>> expression)
		{
			var setup = Mock.Setup(this, expression, null);
			return new NonVoidSetupPhrase<T, TResult>(setup);
		}
```

The code in this pull request follows suit.  WhenPhraseProtected differs to ProtectedAsMock only by condition.

---

Note that WhenPhraseProtected throws NotImplementedException for SetupSet methods
These can be added to match https://github.com/moq/moq4/pull/1165