### PR TITLE
add SetupIndexer to Mock and ProtectedAsMock

### DIFF
--- a/src/Moq/Guard.cs
+++ b/src/Moq/Guard.cs
@@ -2,8 +2,10 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -239,6 +241,43 @@ namespace Moq
 					Resources.PropertySetNotFound,
 					property.DeclaringType.Name, property.Name));
 			}
+		}
+
+		public static void IsIndexerGetter(LambdaExpression expression,string paramName)
+		{
+			if (expression.Body is MethodCallExpression methodCall)
+			{
+				var method = methodCall.Method;
+				var isGetAccessor = method.IsGetAccessor();
+				var isIndexerAccessor = method.IsIndexerAccessor();
+				if (isGetAccessor && isIndexerAccessor)
+				{
+					return;
+				}
+			}
+
+			throw new ArgumentException(
+				string.Format(
+					CultureInfo.CurrentCulture,
+					Resources.SetupNotIndexerGetter,
+					expression.ToStringFixed()),
+				paramName);
+
+		}
+
+		public static void AreConstantExpressions(IEnumerable<Expression> expressions,string paramName)
+		{
+			var notConstantExpression = expressions.FirstOrDefault(arg => !(arg is ConstantExpression));
+			if(notConstantExpression != null)
+			{
+				throw new ArgumentException(
+				string.Format(
+					CultureInfo.CurrentCulture,
+					Resources.ArgumentsNotConstantExpressions,
+					notConstantExpression.ToStringFixed()),
+				paramName);
+			}
+			
 		}
 	}
 }

--- a/src/Moq/Properties/Resources.Designer.cs
+++ b/src/Moq/Properties/Resources.Designer.cs
@@ -88,6 +88,15 @@ namespace Moq.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Argument is not or cannot be evaluated to a constant expressions: {0}.
+        /// </summary>
+        internal static string ArgumentsNotConstantExpressions {
+            get {
+                return ResourceManager.GetString("ArgumentsNotConstantExpressions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Can only add interfaces to the mock..
         /// </summary>
         internal static string AsMustBeInterface {
@@ -523,6 +532,15 @@ namespace Moq.Properties {
         internal static string SetupNotEventRemove {
             get {
                 return ResourceManager.GetString("SetupNotEventRemove", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Expression is not an indexer getter: {0}.
+        /// </summary>
+        internal static string SetupNotIndexerGetter {
+            get {
+                return ResourceManager.GetString("SetupNotIndexerGetter", resourceCulture);
             }
         }
         

--- a/src/Moq/Properties/Resources.resx
+++ b/src/Moq/Properties/Resources.resx
@@ -351,4 +351,10 @@ This could be caused by an unrecognized type conversion, coercion, narrowing, or
   <data name="UseItIsOtherOverload" xml:space="preserve">
     <value>It is impossible to call the provided strongly-typed predicate due to the use of a type matcher. Provide a weakly-typed predicate with two parameters (object, Type) instead.</value>
   </data>
+  <data name="ArgumentsNotConstantExpressions" xml:space="preserve">
+    <value>Argument is not or cannot be evaluated to a constant expressions: {0}</value>
+  </data>
+  <data name="SetupNotIndexerGetter" xml:space="preserve">
+    <value>Expression is not an indexer getter: {0}</value>
+  </data>
 </root>

--- a/src/Moq/Protected/IProtectedAsMock.cs
+++ b/src/Moq/Protected/IProtectedAsMock.cs
@@ -57,6 +57,16 @@ namespace Moq.Protected
 		Mock<T> SetupProperty<TProperty>(Expression<Func<TAnalog, TProperty>> expression, TProperty initialValue = default(TProperty));
 
 		/// <summary>
+		/// Specifies that the given indexer should have "property behavior"
+		/// meaning that setting its value will cause it to be saved and later returned when the property is requested.
+		/// (This is also known as "stubbing".)
+		/// </summary>
+		/// <typeparam name="TProperty">Type of the indexer. Typically omitted as it can be inferred from the expression.</typeparam>
+		/// <param name="expression">Getter lambda expression that specifies the property.</param>
+		/// <param name="initialValue">Initial value for the property.</param>
+		Mock<T> SetupIndexer<TProperty>(Expression<Func<TAnalog, TProperty>> expression, TProperty initialValue = default(TProperty));
+		
+		/// <summary>
 		/// Return a sequence of values, once per call.
 		/// </summary>
 		/// <typeparam name="TResult">Type of the return value. Typically omitted as it can be inferred from the expression.</typeparam>

--- a/src/Moq/Protected/ProtectedAsMock.cs
+++ b/src/Moq/Protected/ProtectedAsMock.cs
@@ -2,6 +2,7 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
@@ -18,12 +19,14 @@ namespace Moq.Protected
 		where TAnalog : class
 	{
 		private Mock<T> mock;
+		private IndexerSetup indexerSetup;
 
 		private static DuckReplacer DuckReplacerInstance = new DuckReplacer(typeof(TAnalog), typeof(T));
 
 		public ProtectedAsMock(Mock<T> mock)
 		{
 			Debug.Assert(mock != null);
+			this.indexerSetup = new IndexerSetup(mock);
 
 			this.mock = mock;
 		}
@@ -97,6 +100,14 @@ namespace Moq.Protected
 			}
 
 			return this.mock.SetupProperty<TProperty>(rewrittenExpression, initialValue);
+		}
+
+		public Mock<T> SetupIndexer<TProperty>(Expression<Func<TAnalog, TProperty>> expression, TProperty initialValue = default(TProperty))
+		{
+			Guard.NotNull(expression, nameof(expression));
+			indexerSetup.Setup(expression, initialValue, nameof(expression), ReplaceDuck);
+
+			return this.mock;
 		}
 
 		public ISetupSequentialResult<TResult> SetupSequence<TResult>(Expression<Func<TAnalog, TResult>> expression)
@@ -362,6 +373,168 @@ namespace Moq.Protected
 
 				// TODO: parameter lists should be compared, too, to properly support indexers.
 			}
+		}
+		private class IndexerSetup
+		{
+			private readonly Mock<T> mock;
+
+			private static MethodInfo itIsAnyMethod;
+			static IndexerSetup()
+			{
+				itIsAnyMethod = typeof(It).GetMethod("IsAny");
+			}
+			public IndexerSetup(Mock<T> mock)
+			{
+				this.mock = mock;
+			}
+
+			private MethodCallExpression GetGetter<TProperty>(Expression<Func<T, TProperty>> expression, string expressionParameterName)
+			{
+				Guard.IsIndexerGetter(expression, expressionParameterName);
+				return expression.Body as MethodCallExpression;
+			}
+
+			public void Setup<TProperty>(Expression<Func<TAnalog, TProperty>> expression, TProperty initialValue, string expressionParameterName, Func<LambdaExpression,LambdaExpression> duckReplacer)
+			{
+				var duckExpression = (Expression<Func<T,TProperty>>)duckReplacer(expression);
+				var methodCall = GetGetter(duckExpression, expressionParameterName);
+				var arguments = methodCall.Arguments.Select(a => a.PartialEval());
+				Guard.AreConstantExpressions(arguments, nameof(expressionParameterName));
+
+				List<IndexerArgsToValue<TProperty>> IndexerArgsToValues = new List<IndexerArgsToValue<TProperty>>();
+				IndexerArgsToValues.Add(
+					new IndexerArgsToValue<TProperty>(
+						arguments.Cast<ConstantExpression>().Select(exp => exp.Value).ToList(),
+						initialValue
+					)
+				);
+				TProperty getterValue = default(TProperty);
+
+				var method = methodCall.Method;
+				var setterMethod = GetSetter(method);
+				var setterItIsAny = GetSetterItIsAny(setterMethod);
+
+				var parameter = Expression.Parameter(typeof(T));
+				Expression[] gettertItAnyArguments = setterItIsAny.Take(setterItIsAny.Length - 1).ToArray();
+
+				var getterSetup = SetUp(method, gettertItAnyArguments);
+				getterSetup.SetCallbackBehavior(new Action<IInvocation>(invocation =>
+				{
+					var arguments = invocation.Arguments;
+					getterValue = default(TProperty);
+					foreach (var indexerArgsToValue in IndexerArgsToValues)
+					{
+						var match = indexerArgsToValue.HasArgs(arguments.ToList());
+						if (match)
+						{
+							getterValue = indexerArgsToValue.value;
+							break;
+						}
+					}
+				}));
+				getterSetup.SetReturnComputedValueBehavior(new Func<IInvocation, TProperty>((_) => getterValue));
+
+				SetUp(setterMethod, setterItIsAny, duckReplacer).SetCallbackBehavior(new Action<IInvocation>(invocation =>
+				{
+					var arguments = invocation.Arguments;
+					var keys = arguments.Take(arguments.Count - 1).ToList();
+					var value = arguments.Last();
+					IndexerArgsToValue<TProperty> matching = default;
+					var matched = false;
+					foreach (var indexerArgsToValue in IndexerArgsToValues)
+					{
+						if (indexerArgsToValue.HasArgs(keys))
+						{
+							matching = indexerArgsToValue;
+							matched = true;
+							break;
+						}
+					}
+					if (matched)
+					{
+						IndexerArgsToValues.Remove(matching);
+
+					}
+
+					IndexerArgsToValues.Add(new IndexerArgsToValue<TProperty>(keys, (TProperty)value));
+				}));
+
+			}
+
+			private MethodCall SetUp(MethodInfo method, Expression[] itIsAnyExpressions, Func<LambdaExpression, LambdaExpression> duckReplacer = null)
+			{
+				Type parameterType = typeof(T);
+				if (duckReplacer != null)
+				{
+					parameterType = typeof(TAnalog);
+				}
+				var parameter = Expression.Parameter(parameterType);
+				var methodCallExpression = Expression.Call(parameter, method, itIsAnyExpressions);
+				var lambda = Expression.Lambda(methodCallExpression, parameter);
+				if (duckReplacer != null)
+				{
+					lambda = duckReplacer(lambda);
+				}
+				return Mock.Setup(mock, lambda, null);
+			}
+
+			private MethodInfo GetSetter(MethodInfo getter)
+			{
+				var methodName = getter.Name;
+				var types = getter.GetParameters().Select(p => p.ParameterType).Concat(new Type[] { getter.ReturnType }).ToArray();
+				return typeof(TAnalog).GetMethod(
+					$"s{methodName.Substring(1)}",
+					BindingFlags.Public | BindingFlags.Instance,
+					null,
+					types,
+					null
+				);
+			}
+
+			private Expression[] GetSetterItIsAny(MethodInfo setterMethod)
+			{
+				var parameters = setterMethod.GetParameters();
+				return parameters.Select(p =>
+				{
+					var pType = p.ParameterType;
+					var itIsAny = itIsAnyMethod.MakeGenericMethod(pType);
+					return Expression.Call(itIsAny);
+
+				}).ToArray();
+
+
+			}
+
+			private struct IndexerArgsToValue<TProperty>
+			{
+				public List<object> args;
+				public TProperty value;
+
+				public IndexerArgsToValue(List<object> args, TProperty value)
+				{
+					this.args = args;
+					this.value = value;
+				}
+
+				public bool HasArgs(IList<object> otherArgs)
+				{
+					if (args.Count != otherArgs.Count)
+					{
+						return false;
+					}
+
+					for (var i = 0; i < args.Count; i++)
+					{
+						if (!object.Equals(args[i], otherArgs[i]))
+						{
+							return false;
+						}
+					}
+					return true;
+				}
+
+			}
+
 		}
 	}
 }


### PR DESCRIPTION
There is duplication with the private classes IndexerSetup nested within Mock and ProtectedAsMock.  
If it is agreed to add the new functionality then let's discuss further.

Closes #1178 