### PR TITLE
Fix virtual properties and automocking for `mock.Protected().As<>()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 #### Fixed
 
+* Virtual properties and automocking not working for `mock.Protected().As<>()` (@tonyhallett, #1185)
+
 * Issue mocking VB.NET class with overloaded property/indexer in base class (@myurashchyk, #1153)
 
 

--- a/src/Moq/Protected/ProtectedAsMock.cs
+++ b/src/Moq/Protected/ProtectedAsMock.cs
@@ -230,7 +230,7 @@ namespace Moq.Protected
 				}
 				else
 				{
-					return node;
+					return base.VisitMember(node);
 				}
 			}
 
@@ -280,7 +280,7 @@ namespace Moq.Protected
 			{
 				var candidateTargetProperties =
 				    this.targetType
-				    .GetProperties(BindingFlags.NonPublic | BindingFlags.Instance)
+				    .GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
 				    .Where(ctp => IsCorrespondingProperty(duckProperty, ctp))
 				    .ToArray();
 

--- a/src/Moq/Protected/ProtectedAsMock.cs
+++ b/src/Moq/Protected/ProtectedAsMock.cs
@@ -217,7 +217,7 @@ namespace Moq.Protected
 				}
 				else
 				{
-					return node;
+					return base.VisitMethodCall(node);
 				}
 			}
 

--- a/tests/Moq.Tests/ProtectedAsMockFixture.cs
+++ b/tests/Moq.Tests/ProtectedAsMockFixture.cs
@@ -131,6 +131,13 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public void Setup_can_automock()
+		{
+			this.protectedMock.Setup(m => m.Nested.Method(1)).Returns(123);
+			Assert.Equal(123, mock.Object.GetNested().Method(1));
+		}
+
+		[Fact]
 		public void SetupGet_can_setup_readonly_property()
 		{
 			this.protectedMock.SetupGet(m => m.ReadOnlyPropertyImpl).Returns(42);
@@ -320,7 +327,9 @@ namespace Moq.Tests
 		public interface INested
 		{
 			int Value { get; }
+			int Method(int value);
 		}
+
 		public abstract class Foo
 		{
 			protected Foo()

--- a/tests/Moq.Tests/ProtectedAsMockFixture.cs
+++ b/tests/Moq.Tests/ProtectedAsMockFixture.cs
@@ -151,6 +151,25 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public void SetUpGet_can_automock()
+		{
+			this.protectedMock.SetupGet(m => m.Nested.Value).Returns(42);
+
+			var actual = mock.Object.GetNested().Value;
+
+			Assert.Equal(42, actual);
+		}
+
+		[Fact] void SetupGet_can_setup_virtual_property()
+		{
+			this.protectedMock.SetupGet(m => m.Virtual).Returns(42);
+
+			var actual = mock.Object.GetVirtual();
+
+			Assert.Equal(42, actual);
+		}
+
+		[Fact]
 		public void SetupProperty_can_setup_readwrite_property()
 		{
 			this.protectedMock.SetupProperty(m => m.ReadWritePropertyImpl, 42);
@@ -298,6 +317,10 @@ namespace Moq.Tests
 			Assert.Contains("Was not queried.", exception.Message);
 		}
 
+		public interface INested
+		{
+			int Value { get; }
+		}
 		public abstract class Foo
 		{
 			protected Foo()
@@ -336,6 +359,32 @@ namespace Moq.Tests
 			protected abstract void DoSomethingImpl(int arg);
 
 			protected abstract int GetSomethingImpl();
+
+			protected abstract INested Nested { get; set; }
+
+			public INested GetNested()
+			{
+				return Nested;
+			}
+
+			private int virtualProperty;
+			public virtual int Virtual
+			{
+				protected get
+				{
+					return virtualProperty;
+				}
+				set
+				{
+					virtualProperty = value;
+				}
+
+			}
+
+			public int GetVirtual()
+			{
+				return Virtual;
+			}
 		}
 
 		public interface Fooish
@@ -347,6 +396,8 @@ namespace Moq.Tests
 			void DoSomethingImpl(int arg);
 			int GetSomethingImpl();
 			void NonExistentMethod();
+			INested Nested { get; set; }
+			int Virtual { get; set; }
 		}
 
 		public abstract class MessageHandlerBase


### PR DESCRIPTION
Fix #1162 

As per https://github.com/moq/moq4/pull/1165#discussion_r672094882