### PR TITLE
Use `value` argument in `mock.Protected().SetupSet` and `...VerifySet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 #### Fixed
 
+* Parameter is invalid in Protected().SetupSet() ... VerifySet (@tonyhallett, #1186)
+
 * Virtual properties and automocking not working for `mock.Protected().As<>()` (@tonyhallett, #1185)
 
 * Issue mocking VB.NET class with overloaded property/indexer in base class (@myurashchyk, #1153)

--- a/src/Moq/Protected/ProtectedMock.cs
+++ b/src/Moq/Protected/ProtectedMock.cs
@@ -125,7 +125,7 @@ namespace Moq.Protected
 			ThrowIfPublicSetter(property, typeof(T).Name);
 			Guard.CanWrite(property);
 
-			var expression = GetSetterExpression(property, ItExpr.IsAny<TProperty>());
+			var expression = GetSetterExpression(property, ToExpressionArg(property.PropertyType, value));
 
 			var setup = Mock.SetupSet(mock, expression, condition: null);
 			return new SetterSetupPhrase<T, TProperty>(setup);
@@ -300,7 +300,7 @@ namespace Moq.Protected
 			ThrowIfPublicSetter(property, typeof(T).Name);
 			Guard.CanWrite(property);
 
-			var expression = GetSetterExpression(property, ItExpr.IsAny<TProperty>());
+			var expression = GetSetterExpression(property, ToExpressionArg(property.PropertyType, value));
 			// TODO should consider property indexers
 			// TODO should receive the parameter here
 			Mock.VerifySet(mock, expression, times, null);
@@ -510,7 +510,7 @@ namespace Moq.Protected
 			return types;
 		}
 
-		private static Expression ToExpressionArg(ParameterInfo paramInfo, object arg)
+		private static Expression ToExpressionArg(Type type, object arg)
 		{
 			if (arg is LambdaExpression lambda)
 			{
@@ -522,7 +522,7 @@ namespace Moq.Protected
 				return expression;
 			}
 
-			return Expression.Constant(arg, paramInfo.ParameterType);
+			return Expression.Constant(arg, type);
 		}
 
 		private static IEnumerable<Expression> ToExpressionArgs(MethodInfo method, object[] args)
@@ -530,7 +530,7 @@ namespace Moq.Protected
 			ParameterInfo[] methodParams = method.GetParameters();
 			for (int i = 0; i < args.Length; i++)
 			{
-				yield return ToExpressionArg(methodParams[i], args[i]);
+				yield return ToExpressionArg(methodParams[i].ParameterType, args[i]);
 			}
 		}
 	}

--- a/tests/Moq.Tests/ProtectedMockFixture.cs
+++ b/tests/Moq.Tests/ProtectedMockFixture.cs
@@ -351,6 +351,20 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public void SetupSetUsesTheValueParameter()
+		{
+			var mock = new Mock<FooBase>();
+			var value = string.Empty;
+			mock.Protected().SetupSet<string>("ProtectedValue", "foo").Callback(v => value = v);
+
+			mock.Object.SetProtectedValue("not foo");
+			Assert.Equal(string.Empty, value);
+
+			mock.Object.SetProtectedValue("foo");
+			Assert.Equal("foo", value);
+		}
+
+		[Fact]
 		public void ThrowsIfNullArgs()
 		{
 			Assert.Throws<ArgumentException>(() => new Mock<FooBase>().Protected()
@@ -808,7 +822,8 @@ namespace Moq.Tests
 			var mock = new Mock<FooBase>();
 			mock.Object.ProtectedInternalValue = "foo";
 
-			mock.Protected().VerifySet<string>("ProtectedInternalValue", Times.Once(), "bar");
+			Assert.Throws<MockException>(() => mock.Protected().VerifySet<string>("ProtectedInternalValue", Times.Once(), "bar"));
+			mock.Protected().VerifySet<string>("ProtectedInternalValue", Times.Once(), "foo");
 		}
 
 		[Fact]
@@ -837,7 +852,7 @@ namespace Moq.Tests
 			mock.Object.SetProtectedValue("foo");
 			mock.Object.SetProtectedValue("foo");
 
-			mock.Protected().VerifySet<string>("ProtectedValue", Times.Exactly(2), ItExpr.IsAny<int>());
+			mock.Protected().VerifySet<string>("ProtectedValue", Times.Exactly(2), ItExpr.IsAny<string>());
 		}
 
 		public class MethodOverloads


### PR DESCRIPTION
Fixes #1184.