### PR TITLE
fix ProtectedMock fails when arguments are of type Expression #1188

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 #### Fixed
 
+* mock.Protected().SetupSet fails when argument is of type Expression (@tonyhallett, #1189)
 * Parameter is invalid in Protected().SetupSet() ... VerifySet (@tonyhallett, #1186)
 
 * Virtual properties and automocking not working for `mock.Protected().As<>()` (@tonyhallett, #1185)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 
 #### Fixed
 
-* mock.Protected().SetupSet fails when argument is of type Expression (@tonyhallett, #1189)
+* mock.Protected() setup methods fail when argument is of type Expression (@tonyhallett, #1189)
 * Parameter is invalid in Protected().SetupSet() ... VerifySet (@tonyhallett, #1186)
 
 * Virtual properties and automocking not working for `mock.Protected().As<>()` (@tonyhallett, #1185)

--- a/src/Moq/Protected/ProtectedMock.cs
+++ b/src/Moq/Protected/ProtectedMock.cs
@@ -467,7 +467,7 @@ namespace Moq.Protected
 				{
 					types[index] = ((MethodCallExpression)expr).Method.ReturnType;
 				}
-				else if(ItRefAnyField(expr) is var itRefAnyField && itRefAnyField != null)
+				else if (ItRefAnyField(expr) is FieldInfo itRefAnyField)
 				{
 					types[index] = itRefAnyField.FieldType.MakeByRefType();
 				}

--- a/src/Moq/Protected/ProtectedMock.cs
+++ b/src/Moq/Protected/ProtectedMock.cs
@@ -499,6 +499,11 @@ namespace Moq.Protected
 			return types;
 		}
 
+		private static bool IsItRefAny(Expression expression)
+		{
+			return ItRefAnyField(expression) != null;
+		}
+
 		private static FieldInfo ItRefAnyField(Expression expr)
 		{
 			FieldInfo itRefAnyField = null;
@@ -528,24 +533,24 @@ namespace Moq.Protected
 
 		private static Expression ToExpressionArg(Type type, object arg)
 		{
-			if (arg is LambdaExpression lambda && !typeof(LambdaExpression).IsAssignableFrom(type))
-			{
-				return lambda.Body;
-			}
-
 			if (arg is Expression expression)
 			{
-				if (!typeof(Expression).IsAssignableFrom(type))
+				if (!type.IsAssignableFrom(expression.GetType()))
 				{
+					if(arg is LambdaExpression lambda)
+					{
+						expression = lambda.Body;
+					}
 					return expression;
 				}
 
-				if (expression.IsMatch(out _))
+				var requiresExpressionMatch = type.IsAssignableFrom(typeof(MethodCallExpression));
+				if (requiresExpressionMatch && expression.IsMatch(out _))
 				{
 					return expression;
 				}
 				
-				if (ItRefAnyField(expression) != null)
+				if (IsItRefAny(expression))
 				{
 					return expression;
 				}

--- a/src/Moq/Protected/ProtectedMock.cs
+++ b/src/Moq/Protected/ProtectedMock.cs
@@ -543,18 +543,17 @@ namespace Moq.Protected
 					}
 					return expression;
 				}
-
-				var requiresExpressionMatch = type.IsAssignableFrom(typeof(MethodCallExpression));
-				if (requiresExpressionMatch && expression.IsMatch(out _))
-				{
-					return expression;
-				}
 				
 				if (IsItRefAny(expression))
 				{
 					return expression;
 				}
-				
+
+				if (expression.IsMatch(out _))
+				{
+					return expression;
+				}
+
 			}
 
 			return Expression.Constant(arg, type);

--- a/tests/Moq.Tests/ProtectedMockFixture.cs
+++ b/tests/Moq.Tests/ProtectedMockFixture.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq.Expressions;
+
 using Moq.Protected;
 
 using Xunit;
@@ -970,6 +971,7 @@ namespace Moq.Tests
 		public class FooBase
 		{
 			protected virtual ConstantExpression ExpressionProperty { get; set; }
+
 			public void SetExpressionProperty(ConstantExpression expression)
 			{
 				ExpressionProperty = expression;

--- a/tests/Moq.Tests/ProtectedMockFixture.cs
+++ b/tests/Moq.Tests/ProtectedMockFixture.cs
@@ -860,17 +860,64 @@ namespace Moq.Tests
 		public void SetupShouldWorkWithExpressionTypes()
 		{
 			var mock = new Mock<FooBase>();
+			var mocked = mock.Object;
+			var protectedMock = mock.Protected();
 
 			var expression = Expression.Constant(1);
-			ConstantExpression setExpression = null;
-			mock.Protected().SetupSet<ConstantExpression>("ExpressionProperty", expression).Callback(expr => setExpression = expr);
-			mock.Object.SetExpressionProperty(expression);
-			Assert.Equal(expression, setExpression);
+			Expression setExpression1 = null;
+			protectedMock.SetupSet<Expression>("ExpressionProperty", expression).Callback(expr => setExpression1 = expr);
+			mocked.SetExpressionProperty(expression);
+			Assert.Same(expression, setExpression1);
 
-			ConstantExpression setExpression2 = null;
-			mock.Protected().SetupSet<ConstantExpression>("ExpressionProperty", ItExpr.Is<ConstantExpression>( e => (int)e.Value == 2)).Callback(expr => setExpression2 = expr);
-			mock.Object.SetExpressionProperty(Expression.Constant(2));
-			Assert.NotNull(setExpression2);
+			var expression2 = Expression.Constant(2);
+			Expression setExpression2 = null;
+			protectedMock.SetupSet<Expression>("ExpressionProperty", ItExpr.Is<ConstantExpression>(e => (int)e.Value == 2)).Callback(expr => setExpression2 = expr);
+			mocked.SetExpressionProperty(expression2);
+			Assert.Same(expression2, setExpression2);
+
+			var constantExpression = Expression.Constant(1);
+			ConstantExpression setConstantExpression = null;
+			protectedMock.SetupSet<ConstantExpression>("NotAMatcherExpressionProperty", constantExpression).Callback(expr => setConstantExpression = expr);
+			mocked.SetNotAMatcherExpressionProperty(constantExpression);
+			Assert.Same(constantExpression, setConstantExpression);
+
+			var constantExpression2 = Expression.Constant(2);
+			ConstantExpression setConstantExpression2 = null;
+			protectedMock.SetupSet<ConstantExpression>("NotAMatcherExpressionProperty", ItExpr.Is<ConstantExpression>(e => (int)e.Value == 2)).Callback(expr => setConstantExpression2 = expr);
+			mocked.SetNotAMatcherExpressionProperty(constantExpression2);
+			Assert.Same(constantExpression2, setConstantExpression2);
+
+			var method = typeof(FooBase).GetMethod(nameof(FooBase.MethodForReflection));
+			var methodCallExpression = Expression.Call(method);
+			MethodCallExpression setMethodCallExpression = null;
+			protectedMock.SetupSet<MethodCallExpression>("MatcherExpressionProperty", methodCallExpression).Callback(expr => setMethodCallExpression = expr);
+			mocked.SetMatcherExpressionProperty(methodCallExpression);
+			Assert.Same(methodCallExpression, setMethodCallExpression);
+
+			var methodCallExpression2 = Expression.Call(typeof(FooBase).GetMethod(nameof(FooBase.MethodForReflection2)));
+			MethodCallExpression setMethodCallExpression2 = null;
+			protectedMock.SetupSet<MethodCallExpression>("MatcherExpressionProperty", ItExpr.Is<MethodCallExpression>(e => e.Method != method)).Callback(expr => setMethodCallExpression2 = expr);
+			mocked.SetMatcherExpressionProperty(methodCallExpression2);
+			Assert.Same(methodCallExpression2, setMethodCallExpression2);
+
+			Expression<Func<int, bool>> lambdaExpression = i => i < 5;
+			LambdaExpression setLambdaExpression = null;
+			protectedMock.SetupSet<LambdaExpression>("LambdaExpressionProperty", lambdaExpression).Callback(expr => setLambdaExpression = expr);
+			mocked.SetLambdaExpressionProperty(lambdaExpression);
+			Assert.Same(lambdaExpression, setLambdaExpression);
+
+			Expression<Func<int, int>> lambdaExpression2 = i => i;
+			LambdaExpression setLambdaExpression2 = null;
+			protectedMock.SetupSet<LambdaExpression>("LambdaExpressionProperty", ItExpr.Is<LambdaExpression>(e => e == lambdaExpression2)).Callback(expr => setLambdaExpression2 = expr);
+			mocked.SetLambdaExpressionProperty(lambdaExpression2);
+			Assert.Same(lambdaExpression2, setLambdaExpression2);
+
+		}
+
+		public class ExpectedException : Exception
+		{
+			private static ExpectedException instance = new ExpectedException();
+			public static ExpectedException Instance => instance;
 		}
 
 		public class MethodOverloads
@@ -970,11 +1017,34 @@ namespace Moq.Tests
 
 		public class FooBase
 		{
-			protected virtual ConstantExpression ExpressionProperty { get; set; }
+			public static void MethodForReflection() { }
+			public static void MethodForReflection2() { }
+			protected virtual Expression ExpressionProperty { get; set; }
 
-			public void SetExpressionProperty(ConstantExpression expression)
+			public void SetExpressionProperty(Expression expression)
 			{
 				ExpressionProperty = expression;
+			}
+
+			protected virtual ConstantExpression NotAMatcherExpressionProperty { get; set; }
+
+			public void SetNotAMatcherExpressionProperty(ConstantExpression expression)
+			{
+				NotAMatcherExpressionProperty = expression;
+			}
+
+			protected virtual MethodCallExpression MatcherExpressionProperty { get; set; }
+
+			public void SetMatcherExpressionProperty(MethodCallExpression expression)
+			{
+				MatcherExpressionProperty = expression;
+			}
+
+			protected virtual LambdaExpression LambdaExpressionProperty { get; set; }
+			
+			public void SetLambdaExpressionProperty(LambdaExpression expression)
+			{
+				LambdaExpressionProperty = expression;
 			}
 
 			public virtual string PublicValue { get; set; }

--- a/tests/Moq.Tests/ProtectedMockFixture.cs
+++ b/tests/Moq.Tests/ProtectedMockFixture.cs
@@ -2,7 +2,7 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
-
+using System.Linq.Expressions;
 using Moq.Protected;
 
 using Xunit;
@@ -855,6 +855,23 @@ namespace Moq.Tests
 			mock.Protected().VerifySet<string>("ProtectedValue", Times.Exactly(2), ItExpr.IsAny<string>());
 		}
 
+		[Fact]
+		public void SetupShouldWorkWithExpressionTypes()
+		{
+			var mock = new Mock<FooBase>();
+
+			var expression = Expression.Constant(1);
+			ConstantExpression setExpression = null;
+			mock.Protected().SetupSet<ConstantExpression>("ExpressionProperty", expression).Callback(expr => setExpression = expr);
+			mock.Object.SetExpressionProperty(expression);
+			Assert.Equal(expression, setExpression);
+
+			ConstantExpression setExpression2 = null;
+			mock.Protected().SetupSet<ConstantExpression>("ExpressionProperty", ItExpr.Is<ConstantExpression>( e => (int)e.Value == 2)).Callback(expr => setExpression2 = expr);
+			mock.Object.SetExpressionProperty(Expression.Constant(2));
+			Assert.NotNull(setExpression2);
+		}
+
 		public class MethodOverloads
 		{
 			public void ExecuteDo(int a, int b)
@@ -952,6 +969,12 @@ namespace Moq.Tests
 
 		public class FooBase
 		{
+			protected virtual ConstantExpression ExpressionProperty { get; set; }
+			public void SetExpressionProperty(ConstantExpression expression)
+			{
+				ExpressionProperty = expression;
+			}
+
 			public virtual string PublicValue { get; set; }
 
 			protected internal virtual string ProtectedInternalValue { get; set; }


### PR DESCRIPTION
fix #1188 