### PR TITLE
Add new overload for throwsasync to allow Func<Exception>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 #### Added
 
 * `SetupSet`, `VerifySet` methods for `mock.Protected().As<>()` (@tonyhallett, #1165)
+* New `ThrowsAsync` method overloads that allow specifying a function to provide an exception, for example `.ThrowsAsync(() => new InvalidOperationException())`. (@adam-knights, #1190)
 
 #### Fixed
 

--- a/src/Moq/ReturnsExtensions.cs
+++ b/src/Moq/ReturnsExtensions.cs
@@ -83,12 +83,7 @@ namespace Moq
 		/// <param name="exception">Exception instance to throw.</param>
 		public static IReturnsResult<TMock> ThrowsAsync<TMock>(this IReturns<TMock, Task> mock, Exception exception) where TMock : class
 		{
-			return mock.Returns(() =>
-			{
-				var tcs = new TaskCompletionSource<bool>();
-				tcs.SetException(exception);
-				return tcs.Task;
-			});
+			return mock.ThrowsAsync(() => exception);
 		}
 
 		/// <summary>
@@ -100,12 +95,7 @@ namespace Moq
 		/// <param name="exception">Exception instance to throw.</param>
 		public static IReturnsResult<TMock> ThrowsAsync<TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Exception exception) where TMock : class
 		{
-			return mock.Returns(() =>
-			{
-				var tcs = new TaskCompletionSource<TResult>();
-				tcs.SetException(exception);
-				return tcs.Task;
-			});
+			return mock.ThrowsAsync(() => exception);
 		}
 
 		/// <summary>
@@ -117,10 +107,70 @@ namespace Moq
 		/// <param name="exception">Exception instance to throw.</param>
 		public static IReturnsResult<TMock> ThrowsAsync<TMock, TResult>(this IReturns<TMock, ValueTask<TResult>> mock, Exception exception) where TMock : class
 		{
+			return mock.ThrowsAsync(() => exception);
+		}
+
+		/// <summary>
+		/// Specifies a function that will calculate the exception to throw when the asynchronous method is invoked.
+		/// </summary>
+		/// <typeparam name="TMock">Mocked type.</typeparam>
+		/// <param name="mock">Returns verb which represents the mocked type and the task return type</param>
+		/// <param name="exceptionFunction">Exception instance to throw.</param>
+		public static IReturnsResult<TMock> ThrowsAsync<TMock>(this IReturns<TMock, Task> mock, Func<Exception> exceptionFunction) where TMock : class
+		{
+			if (exceptionFunction == null)
+			{
+				return mock.ThrowsAsync(() => default);
+			}
+
+			return mock.Returns(() =>
+			{
+				var tcs = new TaskCompletionSource<bool>();
+				tcs.SetException(exceptionFunction());
+				return tcs.Task;
+			});
+		}
+
+		/// <summary>
+		/// Specifies a function that will calculate the exception to throw when the asynchronous method is invoked.
+		/// </summary>
+		/// <typeparam name="TMock">Mocked type.</typeparam>
+		/// <typeparam name="TResult">Type of the return value.</typeparam>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="exceptionFunction">The function that will calculate the exception to throw.</param>
+		public static IReturnsResult<TMock> ThrowsAsync<TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<Exception> exceptionFunction) where TMock : class
+		{
+			if (exceptionFunction == null)
+			{
+				return mock.ThrowsAsync(() => default);
+			}
+
 			return mock.Returns(() =>
 			{
 				var tcs = new TaskCompletionSource<TResult>();
-				tcs.SetException(exception);
+				tcs.SetException(exceptionFunction());
+				return tcs.Task;
+			});
+		}
+
+		/// <summary>
+		/// Specifies a function that will calculate the exception to throw when the asynchronous method is invoked.
+		/// </summary>
+		/// <typeparam name="TMock">Mocked type.</typeparam>
+		/// <typeparam name="TResult">Type of the return value.</typeparam>
+		/// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
+		/// <param name="exceptionFunction">The function that will calculate the exception to throw.</param>
+		public static IReturnsResult<TMock> ThrowsAsync<TMock, TResult>(this IReturns<TMock, ValueTask<TResult>> mock, Func<Exception> exceptionFunction) where TMock : class
+		{
+			if (exceptionFunction == null)
+			{
+				return mock.ThrowsAsync(() => default);
+			}
+
+			return mock.Returns(() =>
+			{
+				var tcs = new TaskCompletionSource<TResult>();
+				tcs.SetException(exceptionFunction());
 				return new ValueTask<TResult>(tcs.Task);
 			});
 		}

--- a/tests/Moq.Tests/ReturnsExtensionsFixture.cs
+++ b/tests/Moq.Tests/ReturnsExtensionsFixture.cs
@@ -317,6 +317,97 @@ namespace Moq.Tests
 			Assert.Equal(exception, task.Exception.InnerException);
 		}
 
+		[Fact]
+		public void ThrowsAsyncFunc_on_NoParametersNonGenericTaskReturnType()
+		{
+			var mock = new Mock<IAsyncInterface>();
+			var exception = new InvalidOperationException();
+			mock.Setup(x => x.NoParametersNonGenericTaskReturnType()).ThrowsAsync(() => exception);
+
+			var task = mock.Object.NoParametersNonGenericTaskReturnType();
+
+			Assert.True(task.IsFaulted);
+			Assert.Equal(exception, task.Exception.InnerException);
+		}
+
+		[Fact]
+		public void ThrowsAsyncFunc_on_NoParametersRefReturnType()
+		{
+			var mock = new Mock<IAsyncInterface>();
+			var exception = new InvalidOperationException();
+			mock.Setup(x => x.NoParametersRefReturnType()).ThrowsAsync(() => exception);
+
+			var task = mock.Object.NoParametersRefReturnType();
+
+			Assert.True(task.IsFaulted);
+			Assert.Equal(exception, task.Exception.InnerException);
+		}
+
+		[Fact]
+		public void ThrowsAsyncFunc_on_NoParametersValueReturnType()
+		{
+			var mock = new Mock<IAsyncInterface>();
+			var exception = new InvalidOperationException();
+			mock.Setup(x => x.NoParametersValueReturnType()).ThrowsAsync(() => exception);
+
+			var task = mock.Object.NoParametersValueReturnType();
+
+			Assert.True(task.IsFaulted);
+			Assert.Equal(exception, task.Exception.InnerException);
+		}
+
+		[Fact]
+		public void ThrowsAsyncFunc_on_RefParameterRefReturnType()
+		{
+			var mock = new Mock<IAsyncInterface>();
+			var exception = new InvalidOperationException();
+			mock.Setup(x => x.RefParameterRefReturnType("Param1")).ThrowsAsync(() => exception);
+
+			var task = mock.Object.RefParameterRefReturnType("Param1");
+
+			Assert.True(task.IsFaulted);
+			Assert.Equal(exception, task.Exception.InnerException);
+		}
+
+		[Fact]
+		public void ThrowsAsyncFunc_on_RefParameterValueReturnType()
+		{
+			var mock = new Mock<IAsyncInterface>();
+			var exception = new InvalidOperationException();
+			mock.Setup(x => x.RefParameterValueReturnType("Param1")).ThrowsAsync(() => exception);
+
+			var task = mock.Object.RefParameterValueReturnType("Param1");
+
+			Assert.True(task.IsFaulted);
+			Assert.Equal(exception, task.Exception.InnerException);
+		}
+
+		[Fact]
+		public void ThrowsAsyncFunc_on_ValueParameterRefReturnType()
+		{
+			var mock = new Mock<IAsyncInterface>();
+			var exception = new InvalidOperationException();
+			mock.Setup(x => x.ValueParameterRefReturnType(36)).ThrowsAsync(() => exception);
+
+			var task = mock.Object.ValueParameterRefReturnType(36);
+
+			Assert.True(task.IsFaulted);
+			Assert.Equal(exception, task.Exception.InnerException);
+		}
+
+		[Fact]
+		public void ThrowsAsyncFunc_on_ValueParameterValueReturnType()
+		{
+			var mock = new Mock<IAsyncInterface>();
+			var exception = new InvalidOperationException();
+			mock.Setup(x => x.ValueParameterValueReturnType(36)).ThrowsAsync(() => exception);
+
+			var task = mock.Object.ValueParameterValueReturnType(36);
+
+			Assert.True(task.IsFaulted);
+			Assert.Equal(exception, task.Exception.InnerException);
+		}
+
 		// The test below is dependent on the timings (too much of a 'works-on-my-machine' smell)
 		//[Theory]
 		//[InlineData(true)]


### PR DESCRIPTION
Related to https://github.com/moq/moq4/issues/1048. This gets us a step towards the enhancement, in this first instance we now allow `ThrowsAsync(() => new Exception())`. And we refactor to use this in the existing methods.

In a future PR we could add support for input arguments to fully cover https://github.com/moq/moq4/issues/1048 - I thought I'd make this change first to make it smaller, before having to also edit `ReturnsExtensions.tt` etc.

---
Note: Git isn't doing the best job of the diff here, probably better viewed side by side. Details...

Three new functions were added underneath the existing ThrowsAync functions.
The original functions were changed to call the new functions using `() => exception`, in the same way `ReturnsAsync` does on line 28.

---
I'm happy to add this to moq5 too, either after or before this is merged... didn't want to setup two PRs until this one had some feedback :).