### PR TITLE
Add new Throws overloads that allow arguments to be passed to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 #### Added
 
 * `SetupSet`, `VerifySet` methods for `mock.Protected().As<>()` (@tonyhallett, #1165)
+* New `Throws` method overloads that allow specifying a function with or without paramaters, to provide an exception, for example `.Throws(() => new InvalidOperationException())`
+and `Setup(x => x.GetFooAsync(It.IsAny<string>()).Result).Throws((string s) => new InvalidOperationException(s))`. (@adam-knights, #1191)
 
 #### Fixed
 

--- a/src/Moq/Behaviors/ThrowComputedException.cs
+++ b/src/Moq/Behaviors/ThrowComputedException.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.Diagnostics;
+
+namespace Moq.Behaviors
+{
+	internal sealed class ThrowComputedException : Behavior
+	{
+		private readonly Func<IInvocation, Exception> exceptionFactory;
+
+		public ThrowComputedException(Func<IInvocation, Exception> exceptionFactory)
+		{
+			Debug.Assert(exceptionFactory != null);
+
+			this.exceptionFactory = exceptionFactory;
+		}
+
+		public override void Execute(Invocation invocation)
+		{
+			throw this.exceptionFactory.Invoke(invocation);
+		}
+	}
+}

--- a/src/Moq/Language/Flow/SetupPhrase.cs
+++ b/src/Moq/Language/Flow/SetupPhrase.cs
@@ -159,6 +159,114 @@ namespace Moq.Language.Flow
 			return this;
 		}
 
+		public IThrowsResult Throws(Delegate exceptionFunction)
+		{
+			this.Setup.SetThrowComputedExceptionBehavior(exceptionFunction);
+			return this;
+		}
+
+		public IThrowsResult Throws<TException>(Func<TException> exceptionFunction) where TException : Exception
+		{
+			this.Setup.SetThrowComputedExceptionBehavior(exceptionFunction);
+			return this;
+		}
+		
+		public IThrowsResult Throws<T, TException>(Func<T, TException> exceptionFunction) where TException : Exception
+		{
+			this.Setup.SetThrowComputedExceptionBehavior(exceptionFunction);
+			return this;
+		}
+
+		public IThrowsResult Throws<T1, T2, TException>(Func<T1, T2, TException> exceptionFunction) where TException : Exception
+		{
+			this.Setup.SetThrowComputedExceptionBehavior(exceptionFunction);
+			return this;
+		}
+
+		public IThrowsResult Throws<T1, T2, T3, TException>(Func<T1, T2, T3, TException> exceptionFunction) where TException : Exception
+		{
+			this.Setup.SetThrowComputedExceptionBehavior(exceptionFunction);
+			return this;
+		}
+
+		public IThrowsResult Throws<T1, T2, T3, T4, TException>(Func<T1, T2, T3, T4, TException> exceptionFunction) where TException : Exception
+		{
+			this.Setup.SetThrowComputedExceptionBehavior(exceptionFunction);
+			return this;
+		}
+
+		public IThrowsResult Throws<T1, T2, T3, T4, T5, TException>(Func<T1, T2, T3, T4, T5, TException> exceptionFunction) where TException : Exception
+		{
+			this.Setup.SetThrowComputedExceptionBehavior(exceptionFunction);
+			return this;
+		}
+
+		public IThrowsResult Throws<T1, T2, T3, T4, T5, T6, TException>(Func<T1, T2, T3, T4, T5, T6, TException> exceptionFunction) where TException : Exception
+		{
+			this.Setup.SetThrowComputedExceptionBehavior(exceptionFunction);
+			return this;
+		}
+
+		public IThrowsResult Throws<T1, T2, T3, T4, T5, T6, T7, TException>(Func<T1, T2, T3, T4, T5, T6, T7, TException> exceptionFunction) where TException : Exception
+		{
+			this.Setup.SetThrowComputedExceptionBehavior(exceptionFunction);
+			return this;
+		}
+
+		public IThrowsResult Throws<T1, T2, T3, T4, T5, T6, T7, T8, TException>(Func<T1, T2, T3, T4, T5, T6, T7, T8, TException> exceptionFunction) where TException : Exception
+		{
+			this.Setup.SetThrowComputedExceptionBehavior(exceptionFunction);
+			return this;
+		}
+
+		public IThrowsResult Throws<T1, T2, T3, T4, T5, T6, T7, T8, T9, TException>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TException> exceptionFunction) where TException : Exception
+		{
+			this.Setup.SetThrowComputedExceptionBehavior(exceptionFunction);
+			return this;
+		}
+
+		public IThrowsResult Throws<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TException>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TException> exceptionFunction) where TException : Exception
+		{
+			this.Setup.SetThrowComputedExceptionBehavior(exceptionFunction);
+			return this;
+		}
+
+		public IThrowsResult Throws<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TException>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TException> exceptionFunction) where TException : Exception
+		{
+			this.Setup.SetThrowComputedExceptionBehavior(exceptionFunction);
+			return this;
+		}
+
+		public IThrowsResult Throws<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TException>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TException> exceptionFunction) where TException : Exception
+		{
+			this.Setup.SetThrowComputedExceptionBehavior(exceptionFunction);
+			return this;
+		}
+
+		public IThrowsResult Throws<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TException>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TException> exceptionFunction) where TException : Exception
+		{
+			this.Setup.SetThrowComputedExceptionBehavior(exceptionFunction);
+			return this;
+		}
+
+		public IThrowsResult Throws<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TException>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TException> exceptionFunction) where TException : Exception
+		{
+			this.Setup.SetThrowComputedExceptionBehavior(exceptionFunction);
+			return this;
+		}
+
+		public IThrowsResult Throws<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TException>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TException> exceptionFunction) where TException : Exception
+		{
+			this.Setup.SetThrowComputedExceptionBehavior(exceptionFunction);
+			return this;
+		}
+
+		public IThrowsResult Throws<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TException>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TException> exceptionFunction) where TException : Exception
+		{
+			this.Setup.SetThrowComputedExceptionBehavior(exceptionFunction);
+			return this;
+		}
+
 		public void Verifiable()
 		{
 			this.setup.MarkAsVerifiable();

--- a/src/Moq/Language/Flow/SetupSequencePhrase.cs
+++ b/src/Moq/Language/Flow/SetupSequencePhrase.cs
@@ -37,6 +37,14 @@ namespace Moq.Language.Flow
 			return this;
 		}
 
+		public ISetupSequentialAction Throws<TException>(Func<TException> exceptionFunction) where TException : Exception
+		{
+			Guard.NotNull(exceptionFunction, nameof(exceptionFunction));
+
+			this.setup.AddBehavior(new ThrowComputedException(_ => exceptionFunction()));
+			return this;
+		}
+
 		public override string ToString()
 		{
 			return setup.Expression.ToStringFixed();
@@ -90,6 +98,14 @@ namespace Moq.Language.Flow
 		public ISetupSequentialResult<TResult> Throws<TException>()
 			where TException : Exception, new()
 			=> this.Throws(new TException());
+
+		public ISetupSequentialResult<TResult> Throws<TException>(Func<TException> exceptionFunction) where TException : Exception
+		{
+			Guard.NotNull(exceptionFunction, nameof(exceptionFunction));
+
+			this.setup.AddBehavior(new ThrowComputedException(_ => exceptionFunction()));
+			return this;
+		}
 
 		public override string ToString()
 		{

--- a/src/Moq/Language/ISetupSequentialAction.cs
+++ b/src/Moq/Language/ISetupSequentialAction.cs
@@ -55,5 +55,20 @@ namespace Moq.Language
 		/// </code>
 		/// </example>
 		ISetupSequentialAction Throws(Exception exception);
+
+		/// <summary>
+		/// Configures the next call in the sequence to throw a calculated exception.
+		/// </summary>
+		/// <example>
+		/// The following code configures the first call to <c>Execute()</c>
+		/// to do nothing, and the second call to throw a calculated exception.
+		/// <code>
+		/// mock.SetupSequence(m => m.Execute())
+		///    .Pass()
+		///    .Throws(() => new InvalidOperationException());
+		/// </code>
+		/// </example>
+		ISetupSequentialAction Throws<TException>(Func<TException> exceptionFunction)
+			where TException : Exception;
 	}
 }

--- a/src/Moq/Language/ISetupSequentialResult.cs
+++ b/src/Moq/Language/ISetupSequentialResult.cs
@@ -37,6 +37,11 @@ namespace Moq.Language
 		ISetupSequentialResult<TResult> Throws<TException>() where TException : Exception, new();
 
 		/// <summary>
+		/// Uses delegate to throws an exception
+		/// </summary>
+		ISetupSequentialResult<TResult> Throws<TException>(Func<TException> exceptionFunction) where TException : Exception;
+
+		/// <summary>
 		/// Calls original method
 		/// </summary>
 		ISetupSequentialResult<TResult> CallBase();

--- a/src/Moq/Language/IThrows.Generated.cs
+++ b/src/Moq/Language/IThrows.Generated.cs
@@ -1,0 +1,567 @@
+﻿// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.ComponentModel;
+using Moq.Language.Flow;
+
+namespace Moq.Language
+{
+	partial interface IThrows
+	{ 
+		/// <summary>
+		/// Specifies a function that will calculate the exception to throw when the method is invoked, 
+		/// retrieving the arguments for the invocation.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="TException">Type of exception that will be calculated and thrown when the setup is matched.</typeparam>
+		/// <param name="exceptionFunction">The function that will calculate the exception to be thrown.</param>
+		/// <example>
+		/// <para>
+		/// The thrown exception is calculated from the value of the actual method invocation arguments. 
+		/// Notice how the arguments are retrieved by simply declaring them as part of the lambda 
+		/// expression:
+		/// </para>
+		/// <code>
+		/// mock.Setup(x => x.Execute(
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;()))
+		///     .Throws((string arg1, string arg2) => new Exception(arg1 + arg2));
+		/// </code>
+		/// </example>
+		IThrowsResult Throws<T1, T2, TException>(Func<T1, T2, TException> exceptionFunction) where TException : Exception;
+
+		/// <summary>
+		/// Specifies a function that will calculate the exception to throw when the method is invoked, 
+		/// retrieving the arguments for the invocation.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="TException">Type of exception that will be calculated and thrown when the setup is matched.</typeparam>
+		/// <param name="exceptionFunction">The function that will calculate the exception to be thrown.</param>
+		/// <example>
+		/// <para>
+		/// The thrown exception is calculated from the value of the actual method invocation arguments. 
+		/// Notice how the arguments are retrieved by simply declaring them as part of the lambda 
+		/// expression:
+		/// </para>
+		/// <code>
+		/// mock.Setup(x => x.Execute(
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;()))
+		///     .Throws((string arg1, string arg2, string arg3) => new Exception(arg1 + arg2 + arg3));
+		/// </code>
+		/// </example>
+		IThrowsResult Throws<T1, T2, T3, TException>(Func<T1, T2, T3, TException> exceptionFunction) where TException : Exception;
+
+		/// <summary>
+		/// Specifies a function that will calculate the exception to throw when the method is invoked, 
+		/// retrieving the arguments for the invocation.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="TException">Type of exception that will be calculated and thrown when the setup is matched.</typeparam>
+		/// <param name="exceptionFunction">The function that will calculate the exception to be thrown.</param>
+		/// <example>
+		/// <para>
+		/// The thrown exception is calculated from the value of the actual method invocation arguments. 
+		/// Notice how the arguments are retrieved by simply declaring them as part of the lambda 
+		/// expression:
+		/// </para>
+		/// <code>
+		/// mock.Setup(x => x.Execute(
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;()))
+		///     .Throws((string arg1, string arg2, string arg3, string arg4) => new Exception(arg1 + arg2 + arg3 + arg4));
+		/// </code>
+		/// </example>
+		IThrowsResult Throws<T1, T2, T3, T4, TException>(Func<T1, T2, T3, T4, TException> exceptionFunction) where TException : Exception;
+
+		/// <summary>
+		/// Specifies a function that will calculate the exception to throw when the method is invoked, 
+		/// retrieving the arguments for the invocation.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="TException">Type of exception that will be calculated and thrown when the setup is matched.</typeparam>
+		/// <param name="exceptionFunction">The function that will calculate the exception to be thrown.</param>
+		/// <example>
+		/// <para>
+		/// The thrown exception is calculated from the value of the actual method invocation arguments. 
+		/// Notice how the arguments are retrieved by simply declaring them as part of the lambda 
+		/// expression:
+		/// </para>
+		/// <code>
+		/// mock.Setup(x => x.Execute(
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;()))
+		///     .Throws((string arg1, string arg2, string arg3, string arg4, string arg5) => new Exception(arg1 + arg2 + arg3 + arg4 + arg5));
+		/// </code>
+		/// </example>
+		IThrowsResult Throws<T1, T2, T3, T4, T5, TException>(Func<T1, T2, T3, T4, T5, TException> exceptionFunction) where TException : Exception;
+
+		/// <summary>
+		/// Specifies a function that will calculate the exception to throw when the method is invoked, 
+		/// retrieving the arguments for the invocation.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="T6">The type of the sixth argument of the invoked method.</typeparam>
+		/// <typeparam name="TException">Type of exception that will be calculated and thrown when the setup is matched.</typeparam>
+		/// <param name="exceptionFunction">The function that will calculate the exception to be thrown.</param>
+		/// <example>
+		/// <para>
+		/// The thrown exception is calculated from the value of the actual method invocation arguments. 
+		/// Notice how the arguments are retrieved by simply declaring them as part of the lambda 
+		/// expression:
+		/// </para>
+		/// <code>
+		/// mock.Setup(x => x.Execute(
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;()))
+		///     .Throws((string arg1, string arg2, string arg3, string arg4, string arg5, string arg6) => new Exception(arg1 + arg2 + arg3 + arg4 + arg5 + arg6));
+		/// </code>
+		/// </example>
+		IThrowsResult Throws<T1, T2, T3, T4, T5, T6, TException>(Func<T1, T2, T3, T4, T5, T6, TException> exceptionFunction) where TException : Exception;
+
+		/// <summary>
+		/// Specifies a function that will calculate the exception to throw when the method is invoked, 
+		/// retrieving the arguments for the invocation.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="T6">The type of the sixth argument of the invoked method.</typeparam>
+		/// <typeparam name="T7">The type of the seventh argument of the invoked method.</typeparam>
+		/// <typeparam name="TException">Type of exception that will be calculated and thrown when the setup is matched.</typeparam>
+		/// <param name="exceptionFunction">The function that will calculate the exception to be thrown.</param>
+		/// <example>
+		/// <para>
+		/// The thrown exception is calculated from the value of the actual method invocation arguments. 
+		/// Notice how the arguments are retrieved by simply declaring them as part of the lambda 
+		/// expression:
+		/// </para>
+		/// <code>
+		/// mock.Setup(x => x.Execute(
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;()))
+		///     .Throws((string arg1, string arg2, string arg3, string arg4, string arg5, string arg6, string arg7) => new Exception(arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7));
+		/// </code>
+		/// </example>
+		IThrowsResult Throws<T1, T2, T3, T4, T5, T6, T7, TException>(Func<T1, T2, T3, T4, T5, T6, T7, TException> exceptionFunction) where TException : Exception;
+
+		/// <summary>
+		/// Specifies a function that will calculate the exception to throw when the method is invoked, 
+		/// retrieving the arguments for the invocation.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="T6">The type of the sixth argument of the invoked method.</typeparam>
+		/// <typeparam name="T7">The type of the seventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T8">The type of the eighth argument of the invoked method.</typeparam>
+		/// <typeparam name="TException">Type of exception that will be calculated and thrown when the setup is matched.</typeparam>
+		/// <param name="exceptionFunction">The function that will calculate the exception to be thrown.</param>
+		/// <example>
+		/// <para>
+		/// The thrown exception is calculated from the value of the actual method invocation arguments. 
+		/// Notice how the arguments are retrieved by simply declaring them as part of the lambda 
+		/// expression:
+		/// </para>
+		/// <code>
+		/// mock.Setup(x => x.Execute(
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;()))
+		///     .Throws((string arg1, string arg2, string arg3, string arg4, string arg5, string arg6, string arg7, string arg8) => new Exception(arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8));
+		/// </code>
+		/// </example>
+		IThrowsResult Throws<T1, T2, T3, T4, T5, T6, T7, T8, TException>(Func<T1, T2, T3, T4, T5, T6, T7, T8, TException> exceptionFunction) where TException : Exception;
+
+		/// <summary>
+		/// Specifies a function that will calculate the exception to throw when the method is invoked, 
+		/// retrieving the arguments for the invocation.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="T6">The type of the sixth argument of the invoked method.</typeparam>
+		/// <typeparam name="T7">The type of the seventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T8">The type of the eighth argument of the invoked method.</typeparam>
+		/// <typeparam name="T9">The type of the ninth argument of the invoked method.</typeparam>
+		/// <typeparam name="TException">Type of exception that will be calculated and thrown when the setup is matched.</typeparam>
+		/// <param name="exceptionFunction">The function that will calculate the exception to be thrown.</param>
+		/// <example>
+		/// <para>
+		/// The thrown exception is calculated from the value of the actual method invocation arguments. 
+		/// Notice how the arguments are retrieved by simply declaring them as part of the lambda 
+		/// expression:
+		/// </para>
+		/// <code>
+		/// mock.Setup(x => x.Execute(
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;()))
+		///     .Throws((string arg1, string arg2, string arg3, string arg4, string arg5, string arg6, string arg7, string arg8, string arg9) => new Exception(arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8 + arg9));
+		/// </code>
+		/// </example>
+		IThrowsResult Throws<T1, T2, T3, T4, T5, T6, T7, T8, T9, TException>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, TException> exceptionFunction) where TException : Exception;
+
+		/// <summary>
+		/// Specifies a function that will calculate the exception to throw when the method is invoked, 
+		/// retrieving the arguments for the invocation.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="T6">The type of the sixth argument of the invoked method.</typeparam>
+		/// <typeparam name="T7">The type of the seventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T8">The type of the eighth argument of the invoked method.</typeparam>
+		/// <typeparam name="T9">The type of the ninth argument of the invoked method.</typeparam>
+		/// <typeparam name="T10">The type of the tenth argument of the invoked method.</typeparam>
+		/// <typeparam name="TException">Type of exception that will be calculated and thrown when the setup is matched.</typeparam>
+		/// <param name="exceptionFunction">The function that will calculate the exception to be thrown.</param>
+		/// <example>
+		/// <para>
+		/// The thrown exception is calculated from the value of the actual method invocation arguments. 
+		/// Notice how the arguments are retrieved by simply declaring them as part of the lambda 
+		/// expression:
+		/// </para>
+		/// <code>
+		/// mock.Setup(x => x.Execute(
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;()))
+		///     .Throws((string arg1, string arg2, string arg3, string arg4, string arg5, string arg6, string arg7, string arg8, string arg9, string arg10) => new Exception(arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8 + arg9 + arg10));
+		/// </code>
+		/// </example>
+		IThrowsResult Throws<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TException>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TException> exceptionFunction) where TException : Exception;
+
+		/// <summary>
+		/// Specifies a function that will calculate the exception to throw when the method is invoked, 
+		/// retrieving the arguments for the invocation.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="T6">The type of the sixth argument of the invoked method.</typeparam>
+		/// <typeparam name="T7">The type of the seventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T8">The type of the eighth argument of the invoked method.</typeparam>
+		/// <typeparam name="T9">The type of the ninth argument of the invoked method.</typeparam>
+		/// <typeparam name="T10">The type of the tenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh argument of the invoked method.</typeparam>
+		/// <typeparam name="TException">Type of exception that will be calculated and thrown when the setup is matched.</typeparam>
+		/// <param name="exceptionFunction">The function that will calculate the exception to be thrown.</param>
+		/// <example>
+		/// <para>
+		/// The thrown exception is calculated from the value of the actual method invocation arguments. 
+		/// Notice how the arguments are retrieved by simply declaring them as part of the lambda 
+		/// expression:
+		/// </para>
+		/// <code>
+		/// mock.Setup(x => x.Execute(
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;()))
+		///     .Throws((string arg1, string arg2, string arg3, string arg4, string arg5, string arg6, string arg7, string arg8, string arg9, string arg10, string arg11) => new Exception(arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8 + arg9 + arg10 + arg11));
+		/// </code>
+		/// </example>
+		IThrowsResult Throws<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TException>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TException> exceptionFunction) where TException : Exception;
+
+		/// <summary>
+		/// Specifies a function that will calculate the exception to throw when the method is invoked, 
+		/// retrieving the arguments for the invocation.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="T6">The type of the sixth argument of the invoked method.</typeparam>
+		/// <typeparam name="T7">The type of the seventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T8">The type of the eighth argument of the invoked method.</typeparam>
+		/// <typeparam name="T9">The type of the ninth argument of the invoked method.</typeparam>
+		/// <typeparam name="T10">The type of the tenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T12">The type of the twelfth argument of the invoked method.</typeparam>
+		/// <typeparam name="TException">Type of exception that will be calculated and thrown when the setup is matched.</typeparam>
+		/// <param name="exceptionFunction">The function that will calculate the exception to be thrown.</param>
+		/// <example>
+		/// <para>
+		/// The thrown exception is calculated from the value of the actual method invocation arguments. 
+		/// Notice how the arguments are retrieved by simply declaring them as part of the lambda 
+		/// expression:
+		/// </para>
+		/// <code>
+		/// mock.Setup(x => x.Execute(
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;()))
+		///     .Throws((string arg1, string arg2, string arg3, string arg4, string arg5, string arg6, string arg7, string arg8, string arg9, string arg10, string arg11, string arg12) => new Exception(arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8 + arg9 + arg10 + arg11 + arg12));
+		/// </code>
+		/// </example>
+		IThrowsResult Throws<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TException>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TException> exceptionFunction) where TException : Exception;
+
+		/// <summary>
+		/// Specifies a function that will calculate the exception to throw when the method is invoked, 
+		/// retrieving the arguments for the invocation.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="T6">The type of the sixth argument of the invoked method.</typeparam>
+		/// <typeparam name="T7">The type of the seventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T8">The type of the eighth argument of the invoked method.</typeparam>
+		/// <typeparam name="T9">The type of the ninth argument of the invoked method.</typeparam>
+		/// <typeparam name="T10">The type of the tenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T12">The type of the twelfth argument of the invoked method.</typeparam>
+		/// <typeparam name="T13">The type of the thirteenth argument of the invoked method.</typeparam>
+		/// <typeparam name="TException">Type of exception that will be calculated and thrown when the setup is matched.</typeparam>
+		/// <param name="exceptionFunction">The function that will calculate the exception to be thrown.</param>
+		/// <example>
+		/// <para>
+		/// The thrown exception is calculated from the value of the actual method invocation arguments. 
+		/// Notice how the arguments are retrieved by simply declaring them as part of the lambda 
+		/// expression:
+		/// </para>
+		/// <code>
+		/// mock.Setup(x => x.Execute(
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;()))
+		///     .Throws((string arg1, string arg2, string arg3, string arg4, string arg5, string arg6, string arg7, string arg8, string arg9, string arg10, string arg11, string arg12, string arg13) => new Exception(arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8 + arg9 + arg10 + arg11 + arg12 + arg13));
+		/// </code>
+		/// </example>
+		IThrowsResult Throws<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TException>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TException> exceptionFunction) where TException : Exception;
+
+		/// <summary>
+		/// Specifies a function that will calculate the exception to throw when the method is invoked, 
+		/// retrieving the arguments for the invocation.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="T6">The type of the sixth argument of the invoked method.</typeparam>
+		/// <typeparam name="T7">The type of the seventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T8">The type of the eighth argument of the invoked method.</typeparam>
+		/// <typeparam name="T9">The type of the ninth argument of the invoked method.</typeparam>
+		/// <typeparam name="T10">The type of the tenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T12">The type of the twelfth argument of the invoked method.</typeparam>
+		/// <typeparam name="T13">The type of the thirteenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T14">The type of the fourteenth argument of the invoked method.</typeparam>
+		/// <typeparam name="TException">Type of exception that will be calculated and thrown when the setup is matched.</typeparam>
+		/// <param name="exceptionFunction">The function that will calculate the exception to be thrown.</param>
+		/// <example>
+		/// <para>
+		/// The thrown exception is calculated from the value of the actual method invocation arguments. 
+		/// Notice how the arguments are retrieved by simply declaring them as part of the lambda 
+		/// expression:
+		/// </para>
+		/// <code>
+		/// mock.Setup(x => x.Execute(
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;()))
+		///     .Throws((string arg1, string arg2, string arg3, string arg4, string arg5, string arg6, string arg7, string arg8, string arg9, string arg10, string arg11, string arg12, string arg13, string arg14) => new Exception(arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8 + arg9 + arg10 + arg11 + arg12 + arg13 + arg14));
+		/// </code>
+		/// </example>
+		IThrowsResult Throws<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TException>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TException> exceptionFunction) where TException : Exception;
+
+		/// <summary>
+		/// Specifies a function that will calculate the exception to throw when the method is invoked, 
+		/// retrieving the arguments for the invocation.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="T6">The type of the sixth argument of the invoked method.</typeparam>
+		/// <typeparam name="T7">The type of the seventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T8">The type of the eighth argument of the invoked method.</typeparam>
+		/// <typeparam name="T9">The type of the ninth argument of the invoked method.</typeparam>
+		/// <typeparam name="T10">The type of the tenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T12">The type of the twelfth argument of the invoked method.</typeparam>
+		/// <typeparam name="T13">The type of the thirteenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T14">The type of the fourteenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T15">The type of the fifteenth argument of the invoked method.</typeparam>
+		/// <typeparam name="TException">Type of exception that will be calculated and thrown when the setup is matched.</typeparam>
+		/// <param name="exceptionFunction">The function that will calculate the exception to be thrown.</param>
+		/// <example>
+		/// <para>
+		/// The thrown exception is calculated from the value of the actual method invocation arguments. 
+		/// Notice how the arguments are retrieved by simply declaring them as part of the lambda 
+		/// expression:
+		/// </para>
+		/// <code>
+		/// mock.Setup(x => x.Execute(
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;()))
+		///     .Throws((string arg1, string arg2, string arg3, string arg4, string arg5, string arg6, string arg7, string arg8, string arg9, string arg10, string arg11, string arg12, string arg13, string arg14, string arg15) => new Exception(arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8 + arg9 + arg10 + arg11 + arg12 + arg13 + arg14 + arg15));
+		/// </code>
+		/// </example>
+		IThrowsResult Throws<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TException>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TException> exceptionFunction) where TException : Exception;
+
+		/// <summary>
+		/// Specifies a function that will calculate the exception to throw when the method is invoked, 
+		/// retrieving the arguments for the invocation.
+		/// </summary>
+		/// <typeparam name="T1">The type of the first argument of the invoked method.</typeparam>
+		/// <typeparam name="T2">The type of the second argument of the invoked method.</typeparam>
+		/// <typeparam name="T3">The type of the third argument of the invoked method.</typeparam>
+		/// <typeparam name="T4">The type of the fourth argument of the invoked method.</typeparam>
+		/// <typeparam name="T5">The type of the fifth argument of the invoked method.</typeparam>
+		/// <typeparam name="T6">The type of the sixth argument of the invoked method.</typeparam>
+		/// <typeparam name="T7">The type of the seventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T8">The type of the eighth argument of the invoked method.</typeparam>
+		/// <typeparam name="T9">The type of the ninth argument of the invoked method.</typeparam>
+		/// <typeparam name="T10">The type of the tenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T11">The type of the eleventh argument of the invoked method.</typeparam>
+		/// <typeparam name="T12">The type of the twelfth argument of the invoked method.</typeparam>
+		/// <typeparam name="T13">The type of the thirteenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T14">The type of the fourteenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T15">The type of the fifteenth argument of the invoked method.</typeparam>
+		/// <typeparam name="T16">The type of the sixteenth argument of the invoked method.</typeparam>
+		/// <typeparam name="TException">Type of exception that will be calculated and thrown when the setup is matched.</typeparam>
+		/// <param name="exceptionFunction">The function that will calculate the exception to be thrown.</param>
+		/// <example>
+		/// <para>
+		/// The thrown exception is calculated from the value of the actual method invocation arguments. 
+		/// Notice how the arguments are retrieved by simply declaring them as part of the lambda 
+		/// expression:
+		/// </para>
+		/// <code>
+		/// mock.Setup(x => x.Execute(
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;(), 
+		///                      It.IsAny&lt;string&gt;()))
+		///     .Throws((string arg1, string arg2, string arg3, string arg4, string arg5, string arg6, string arg7, string arg8, string arg9, string arg10, string arg11, string arg12, string arg13, string arg14, string arg15, string arg16) => new Exception(arg1 + arg2 + arg3 + arg4 + arg5 + arg6 + arg7 + arg8 + arg9 + arg10 + arg11 + arg12 + arg13 + arg14 + arg15 + arg16));
+		/// </code>
+		/// </example>
+		IThrowsResult Throws<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TException>(Func<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TException> exceptionFunction) where TException : Exception;
+	}
+}

--- a/src/Moq/Language/IThrows.cs
+++ b/src/Moq/Language/IThrows.cs
@@ -12,7 +12,7 @@ namespace Moq.Language
 	/// Defines the <c>Throws</c> verb.
 	/// </summary>
 	[EditorBrowsable(EditorBrowsableState.Never)]
-	public interface IThrows : IFluentInterface
+	public partial interface IThrows : IFluentInterface
 	{
 		/// <summary>
 		/// Specifies the exception to throw when the method is invoked.
@@ -41,5 +41,61 @@ namespace Moq.Language
 		/// </code>
 		/// </example>
 		IThrowsResult Throws<TException>() where TException : Exception, new();
+
+		/// <summary>
+		/// Specifies a function that will calculate the exception to throw when the method is invoked.
+		/// </summary>
+		/// <param name="exceptionFunction">The function that will calculate the exception to be thrown.</param>
+		/// <example>
+		/// Throw a calculated exception when the method is called:
+		/// <code>
+		/// delegate Exception ExecuteFunc(string name);
+		///
+		/// String s = ...;
+		/// mock.Setup(x => x.Execute(s))
+		///     .Throws(new ExecuteFunc((string s) => new Exception(s)));
+		/// </code>
+		/// </example>
+		IThrowsResult Throws(Delegate exceptionFunction);
+
+		/// <summary>
+		/// Specifies a function that will calculate the exception to throw when the method is invoked.
+		/// </summary>
+		/// <typeparam name="TException">Type of exception that will be calculated and thrown when the setup is matched.</typeparam>
+		/// <param name="exceptionFunction">The function that will calculate the exception to be thrown.</param>
+		/// <example>
+		/// Throw a calculated exception when the method is called:
+		/// <code>
+		/// mock.Setup(x => x.Execute("ping"))
+		///     .Throws(() => new Exception($"bad {returnValues[0]}"));
+		/// </code>
+		/// The lambda expression to retrieve the exception is lazy-executed, 
+		/// meaning that its exception may change depending on the moment the method 
+		/// is executed and the value the <c>returnValues</c> array has at 
+		/// that moment.
+		/// </example>
+		IThrowsResult Throws<TException>(Func<TException> exceptionFunction) where TException : Exception;
+
+		/// <summary>
+		/// Specifies a function that will calculate the exception to throw when the method is invoked, 
+		/// retrieving the arguments for the invocation.
+		/// </summary>
+		/// <typeparam name="T">The type of the argument of the invoked method.</typeparam>
+		/// <typeparam name="TException">Type of exception that will be calculated and thrown when the setup is matched.</typeparam>
+		/// <param name="exceptionFunction">The function that will calculate the exception to be thrown.</param>
+		/// <example>
+		/// Throw a calculated exception which is evaluated lazily at the time of the invocation.
+		/// <para>
+		/// The lookup list can change between invocations and the setup 
+		/// will return different values accordingly. Also, notice how the specific 
+		/// string argument is retrieved by simply declaring it as part of the lambda 
+		/// expression:
+		/// </para>
+		/// <code>
+		/// mock.Setup(x => x.Execute(It.IsAny&lt;string&gt;()))
+		///     .Throws((string command) => new Exception(command));
+		/// </code>
+		/// </example>
+		IThrowsResult Throws<T, TException>(Func<T, TException> exceptionFunction) where TException : Exception;
 	}
 }

--- a/src/Moq/Language/IThrows.tt
+++ b/src/Moq/Language/IThrows.tt
@@ -1,0 +1,61 @@
+﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ output extension=".Generated.cs" #>
+<#@ Assembly Name="System.Core" #>
+<#@ Import Namespace="System.Linq" #>
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.ComponentModel;
+using Moq.Language.Flow;
+
+namespace Moq.Language
+{
+	partial interface IThrows
+	{ <#
+for (var typeCount = 2; typeCount <= GenericTypeMax; typeCount++)
+{
+	var typeList = GetGenericList(typeCount, GenericTypeFormat);
+#>
+
+		/// <summary>
+		/// Specifies a function that will calculate the exception to throw when the method is invoked, 
+		/// retrieving the arguments for the invocation.
+		/// </summary>
+<#
+	for (var typeIndex = 1; typeIndex <= typeCount; typeIndex++)
+	{
+#>
+		/// <typeparam name="T<#= typeIndex #>">The type of the <#= ConvertToOrdinal(typeIndex) #> argument of the invoked method.</typeparam>
+<#
+	}
+#>
+		/// <typeparam name="TException">Type of exception that will be calculated and thrown when the setup is matched.</typeparam>
+		/// <param name="exceptionFunction">The function that will calculate the exception to be thrown.</param>
+		/// <example>
+		/// <para>
+		/// The thrown exception is calculated from the value of the actual method invocation arguments. 
+		/// Notice how the arguments are retrieved by simply declaring them as part of the lambda 
+		/// expression:
+		/// </para>
+		/// <code>
+		/// mock.Setup(x => x.Execute(
+<#
+	for (var typeIndex = 1; typeIndex < typeCount; typeIndex++)
+	{
+#>
+		///                      It.IsAny&lt;string&gt;(), 
+<#
+	}
+#>
+		///                      It.IsAny&lt;string&gt;()))
+		///     .Throws((<#= GetGenericList(typeCount, "string arg{0}") #>) => new Exception(<#= GetGenericList(typeCount, "arg{0}", " + ") #>));
+		/// </code>
+		/// </example>
+		IThrowsResult Throws<<#= typeList #>, TException>(Func<<#= typeList #>, TException> exceptionFunction) where TException : Exception;
+<#
+}
+#>
+	}
+}
+<#@ Include File="..\Includes\GenericTypeParameters.tt" #>

--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -96,6 +96,16 @@
 			<DependentUpon>IReturns.tt</DependentUpon>
 		</Compile>
 
+		<None Update="Language\IThrows.tt">
+			<Generator>TextTemplatingFileGenerator</Generator>
+			<LastGenOutput>IThrows.Generated.cs</LastGenOutput>
+		</None>
+		<Compile Update="Language\IThrows.Generated.cs">
+			<AutoGen>True</AutoGen>
+			<DesignTime>True</DesignTime>
+			<DependentUpon>IThrows.tt</DependentUpon>
+		</Compile>
+
 		<None Update="ReturnsExtensions.tt">
 			<Generator>TextTemplatingFileGenerator</Generator>
 			<LastGenOutput>ReturnsExtensions.Generated.cs</LastGenOutput>

--- a/tests/Moq.Tests/SequentialActionExtensionsFixture.cs
+++ b/tests/Moq.Tests/SequentialActionExtensionsFixture.cs
@@ -39,6 +39,36 @@ namespace Moq.Tests
 			Assert.Throws<ArgumentException>(() => mock.Object.Do());
 		}
 
+		[Fact]
+		public void PerformSequenceWithCalculatedExceptions()
+		{
+			var mock = new Mock<IFoo>();
+
+			mock.SetupSequence(m => m.Do())
+				.Pass()
+				.Throws<InvalidOperationException>(() => new InvalidOperationException())
+				.Throws(() => new ArgumentException());
+
+			mock.Object.Do();
+			Assert.Throws<InvalidOperationException>(() => mock.Object.Do());
+			Assert.Throws<ArgumentException>(() => mock.Object.Do());
+		}
+
+		[Fact]
+		public void PerformSequenceWithThrowCalculatedExceptionFirst()
+		{
+			var mock = new Mock<IFoo>();
+
+			mock.SetupSequence(m => m.Do())
+				.Throws<InvalidOperationException>(() => new InvalidOperationException())
+				.Pass()
+				.Throws(new ArgumentException());
+
+			Assert.Throws<InvalidOperationException>(() => mock.Object.Do());
+			mock.Object.Do();
+			Assert.Throws<ArgumentException>(() => mock.Object.Do());
+		}
+
 		public interface IFoo
 		{
 			void Do();

--- a/tests/Moq.Tests/SetupTaskResultFixture.cs
+++ b/tests/Moq.Tests/SetupTaskResultFixture.cs
@@ -27,7 +27,9 @@ namespace Moq.Tests
 
 			IPerson Friend { get; set; }
 			Task<IPerson> GetFriendTaskAsync();
+			Task<IPerson> GetFriendTaskAsync(string friendName);
 			ValueTask<IPerson> GetFriendValueTaskAsync();
+			ValueTask<IPerson> GetFriendValueTaskAsync(string friendName);
 		}
 
 		[Fact]
@@ -129,6 +131,24 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public async Task Setup__completed_Task_from_Func__Throws()
+		{
+			var person = new Mock<IPerson>();
+			person.Setup(p => p.GetFriendTaskAsync().Result).Throws(() => Exception);
+			var exception = await Assert.ThrowsAsync<Exception>(async () => await person.Object.GetFriendTaskAsync());
+			Assert.Same(Exception, exception);
+		}
+
+		[Fact]
+		public async Task Setup__completed_Task_from_Func_with_params__Throws()
+		{
+			var person = new Mock<IPerson>();
+			person.Setup(p => p.GetFriendTaskAsync(NameOfFriend).Result).Throws((string s) => new Exception(NameOfFriend));
+			var exception = await Assert.ThrowsAsync<Exception>(async () => await person.Object.GetFriendTaskAsync(NameOfFriend));
+			Assert.Equal(NameOfFriend, exception.Message);
+		}
+
+		[Fact]
 		public async Task Setup__completed_ValueTask__Returns()
 		{
 			var person = new Mock<IPerson>();
@@ -156,6 +176,24 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public async Task Setup__completed_ValueTask_from_Func__Throws()
+		{
+			var person = new Mock<IPerson>();
+			person.Setup(p => p.GetFriendValueTaskAsync().Result).Throws(() => Exception);
+			var exception = await Assert.ThrowsAsync<Exception>(async () => await person.Object.GetFriendValueTaskAsync());
+			Assert.Same(Exception, exception);
+		}
+
+		[Fact]
+		public async Task Setup__completed_ValueTask_from_Func_with_params__Throws()
+		{
+			var person = new Mock<IPerson>();
+			person.Setup(p => p.GetFriendValueTaskAsync(NameOfFriend).Result).Throws((string s) => new Exception(NameOfFriend));
+			var exception = await Assert.ThrowsAsync<Exception>(async () => await person.Object.GetFriendValueTaskAsync(NameOfFriend));
+			Assert.Equal(NameOfFriend, exception.Message);
+		}
+
+		[Fact]
 		public async Task SetupGet__property_of__completed_Task__Returns()
 		{
 			var person = new Mock<IPerson>();
@@ -169,6 +207,16 @@ namespace Moq.Tests
 		{
 			var person = new Mock<IPerson>();
 			person.SetupGet(p => p.GetFriendTaskAsync().Result.Name).Throws(Exception);
+			var friend = await person.Object.GetFriendTaskAsync();
+			var exception = Assert.Throws<Exception>(() => friend.Name);
+			Assert.Same(Exception, exception);
+		}
+
+		[Fact]
+		public async Task SetupGet__property_of__completed_Task_from_func__Throws()
+		{
+			var person = new Mock<IPerson>();
+			person.SetupGet(p => p.GetFriendTaskAsync().Result.Name).Throws(() => Exception);
 			var friend = await person.Object.GetFriendTaskAsync();
 			var exception = Assert.Throws<Exception>(() => friend.Name);
 			Assert.Same(Exception, exception);
@@ -194,6 +242,16 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public async Task SetupGet__property_of__completed_ValueTask_from_func__Throws()
+		{
+			var person = new Mock<IPerson>();
+			person.SetupGet(p => p.GetFriendValueTaskAsync().Result.Name).Throws(() => Exception);
+			var friend = await person.Object.GetFriendValueTaskAsync();
+			var exception = Assert.Throws<Exception>(() => friend.Name);
+			Assert.Same(Exception, exception);
+		}
+
+		[Fact]
 		public async Task SetupSequence__completed_Task__Returns()
 		{
 			var person = new Mock<IPerson>();
@@ -209,6 +267,17 @@ namespace Moq.Tests
 		{
 			var person = new Mock<IPerson>();
 			person.SetupSequence(p => p.GetFriendTaskAsync().Result).Throws(Exception).Throws(SecondException);
+			var exception = await Assert.ThrowsAsync<Exception>(async () => await person.Object.GetFriendTaskAsync());
+			var secondException = await Assert.ThrowsAsync<Exception>(async () => await person.Object.GetFriendTaskAsync());
+			Assert.Same(Exception, exception);
+			Assert.Same(SecondException, secondException);
+		}
+
+		[Fact]
+		public async Task SetupSequence__completed_Task_from_func__Throws()
+		{
+			var person = new Mock<IPerson>();
+			person.SetupSequence(p => p.GetFriendTaskAsync().Result).Throws(() => Exception).Throws(() => SecondException);
 			var exception = await Assert.ThrowsAsync<Exception>(async () => await person.Object.GetFriendTaskAsync());
 			var secondException = await Assert.ThrowsAsync<Exception>(async () => await person.Object.GetFriendTaskAsync());
 			Assert.Same(Exception, exception);
@@ -238,6 +307,17 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public async Task SetupSequence__completed_ValueTask_from_func__Throws()
+		{
+			var person = new Mock<IPerson>();
+			person.SetupSequence(p => p.GetFriendValueTaskAsync().Result).Throws(() => Exception).Throws(() => SecondException);
+			var exception = await Assert.ThrowsAsync<Exception>(async () => await person.Object.GetFriendValueTaskAsync());
+			var secondException = await Assert.ThrowsAsync<Exception>(async () => await person.Object.GetFriendValueTaskAsync());
+			Assert.Same(Exception, exception);
+			Assert.Same(SecondException, secondException);
+		}
+
+		[Fact]
 		public async Task SetupSequence__property_of__completed_Task__Returns()
 		{
 			var person = new Mock<IPerson>();
@@ -260,6 +340,18 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public async Task SetupSequence__property_of__completed_Task_from_func__Throws()
+		{
+			var person = new Mock<IPerson>();
+			person.SetupSequence(p => p.GetFriendTaskAsync().Result.Name).Throws(() => Exception).Throws(() => SecondException);
+			var friend = await person.Object.GetFriendTaskAsync();
+			var exception = Assert.Throws<Exception>(() => friend.Name);
+			var secondException = Assert.Throws<Exception>(() => friend.Name);
+			Assert.Same(Exception, exception);
+			Assert.Same(SecondException, secondException);
+		}
+
+		[Fact]
 		public async Task SetupSequence__property_of__completed_ValueTask__Returns()
 		{
 			var person = new Mock<IPerson>();
@@ -274,6 +366,18 @@ namespace Moq.Tests
 		{
 			var person = new Mock<IPerson>();
 			person.SetupSequence(p => p.GetFriendValueTaskAsync().Result.Name).Throws(Exception).Throws(SecondException);
+			var friend = await person.Object.GetFriendValueTaskAsync();
+			var exception = Assert.Throws<Exception>(() => friend.Name);
+			var secondException = Assert.Throws<Exception>(() => friend.Name);
+			Assert.Same(Exception, exception);
+			Assert.Same(SecondException, secondException);
+		}
+
+		[Fact]
+		public async Task SetupSequence__property_of__completed_ValueTask_from_func__Throws()
+		{
+			var person = new Mock<IPerson>();
+			person.SetupSequence(p => p.GetFriendValueTaskAsync().Result.Name).Throws(() => Exception).Throws(() => SecondException);
 			var friend = await person.Object.GetFriendValueTaskAsync();
 			var exception = Assert.Throws<Exception>(() => friend.Name);
 			var secondException = Assert.Throws<Exception>(() => friend.Name);
@@ -316,10 +420,30 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public async Task SetupSet__property_of__completed_Task_from_func__Throws()
+		{
+			var person = new Mock<IPerson>();
+			person.SetupSet(p => p.GetFriendTaskAsync().Result.Name = It.IsAny<string>()).Throws(() => Exception);
+			var friend = await person.Object.GetFriendTaskAsync();
+			var exception = Assert.Throws<Exception>(() => friend.Name = NameOfFriend);
+			Assert.Same(Exception, exception);
+		}
+
+		[Fact]
 		public async Task SetupSet__property_of__completed_ValueTask__Throws()
 		{
 			var person = new Mock<IPerson>();
 			person.SetupSet(p => p.GetFriendValueTaskAsync().Result.Name = It.IsAny<string>()).Throws(Exception);
+			var friend = await person.Object.GetFriendValueTaskAsync();
+			var exception = Assert.Throws<Exception>(() => friend.Name = NameOfFriend);
+			Assert.Same(Exception, exception);
+		}
+
+		[Fact]
+		public async Task SetupSet__property_of__completed_ValueTask_from_func__Throws()
+		{
+			var person = new Mock<IPerson>();
+			person.SetupSet(p => p.GetFriendValueTaskAsync().Result.Name = It.IsAny<string>()).Throws(() => Exception);
 			var friend = await person.Object.GetFriendValueTaskAsync();
 			var exception = Assert.Throws<Exception>(() => friend.Name = NameOfFriend);
 			Assert.Same(Exception, exception);

--- a/tests/Moq.Tests/ThrowsFixture.cs
+++ b/tests/Moq.Tests/ThrowsFixture.cs
@@ -1,0 +1,113 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.Collections.Generic;
+
+using Xunit;
+
+namespace Moq.Tests
+{
+	public class ThrowsFixture
+	{
+		[Fact]
+		public void PassesOneArgumentToThrows()
+		{
+			var mock = new Mock<IFoo>();
+			mock.Setup(x => x.Execute(It.IsAny<string>()))
+				.Throws((string s) => new Exception(s));
+
+			var exception = Assert.Throws<Exception>(() => mock.Object.Execute("blah1"));
+			Assert.Equal("blah1", exception.Message);
+		}
+
+		[Fact]
+		public void PassesTwoArgumentsToThrows()
+		{
+			var mock = new Mock<IFoo>();
+			mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string>()))
+				.Throws((string s1, string s2) => new Exception(s1 + s2));
+
+			var exception = Assert.Throws<Exception>(() => mock.Object.Execute("blah1", "blah2"));
+			Assert.Equal("blah1blah2", exception.Message);
+		}
+
+		[Fact]
+		public void PassesThreeArgumentsToThrows()
+		{
+			var mock = new Mock<IFoo>();
+			mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+				.Throws((string s1, string s2, string s3) => new Exception(s1 + s2 + s3));
+
+			var exception = Assert.Throws<Exception>(() => mock.Object.Execute("blah1", "blah2", "blah3"));
+			Assert.Equal("blah1blah2blah3", exception.Message);
+		}
+
+		[Fact]
+		public void PassesFourArgumentsToThrows()
+		{
+			var mock = new Mock<IFoo>();
+			mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+				.Throws((string s1, string s2, string s3, string s4) => new Exception(s1 + s2 + s3 + s4));
+
+			var exception = Assert.Throws<Exception>(() => mock.Object.Execute("blah1", "blah2", "blah3", "blah4"));
+			Assert.Equal("blah1blah2blah3blah4", exception.Message);
+		}
+
+		[Fact]
+		public void PassesFiveArgumentsToThrows()
+		{
+			var mock = new Mock<IFoo>();
+			mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+				.Throws((string s1, string s2, string s3, string s4, string s5) => new Exception(s1 + s2 + s3 + s4 + s5));
+
+			var exception = Assert.Throws<Exception>(() => mock.Object.Execute("blah1", "blah2", "blah3", "blah4", "blah5"));
+			Assert.Equal("blah1blah2blah3blah4blah5", exception.Message);
+		}
+
+		[Fact]
+		public void PassesSixArgumentsToThrows()
+		{
+			var mock = new Mock<IFoo>();
+			mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+				.Throws((string s1, string s2, string s3, string s4, string s5, string s6) => new Exception(s1 + s2 + s3 + s4 + s5 + s6));
+
+			var exception = Assert.Throws<Exception>(() => mock.Object.Execute("blah1", "blah2", "blah3", "blah4", "blah5", "blah6"));
+			Assert.Equal("blah1blah2blah3blah4blah5blah6", exception.Message);
+		}
+
+		[Fact]
+		public void PassesSevenArgumentsToThrows()
+		{
+			var mock = new Mock<IFoo>();
+			mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+				.Throws((string s1, string s2, string s3, string s4, string s5, string s6, string s7) => new Exception(s1 + s2 + s3 + s4 + s5 + s6 + s7));
+
+			var exception = Assert.Throws<Exception>(() => mock.Object.Execute("blah1", "blah2", "blah3", "blah4", "blah5", "blah6", "blah7"));
+			Assert.Equal("blah1blah2blah3blah4blah5blah6blah7", exception.Message);
+		}
+
+		[Fact]
+		public void PassesEightArgumentsToThrows()
+		{
+			var mock = new Mock<IFoo>();
+			mock.Setup(x => x.Execute(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+				.Throws((string s1, string s2, string s3, string s4, string s5, string s6, string s7, string s8) => new Exception(s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8));
+
+			var exception = Assert.Throws<Exception>(() => mock.Object.Execute("blah1", "blah2", "blah3", "blah4", "blah5", "blah6", "blah7", "blah8"));
+			Assert.Equal("blah1blah2blah3blah4blah5blah6blah7blah8", exception.Message);
+		}
+
+		public interface IFoo
+		{
+			string Execute(string command);
+			string Execute(string arg1, string arg2);
+			string Execute(string arg1, string arg2, string arg3);
+			string Execute(string arg1, string arg2, string arg3, string arg4);
+			string Execute(string arg1, string arg2, string arg3, string arg4, string arg5);
+			string Execute(string arg1, string arg2, string arg3, string arg4, string arg5, string arg6);
+			string Execute(string arg1, string arg2, string arg3, string arg4, string arg5, string arg6, string arg7);
+			string Execute(string arg1, string arg2, string arg3, string arg4, string arg5, string arg6, string arg7, string arg8);
+		}
+	}
+}


### PR DESCRIPTION
This implements https://github.com/moq/moq4/issues/1048 (In `Throws`, we discussed in https://github.com/moq/moq4/pull/1190 that we would leave `ThrowsAsync` alone for now).

The existing method `SetReturnComputedValueBehavior` in `MethodCall.cs` is slightly refactored so that those functions the new `SetThrowComputedExceptionBehavior` needs are available, some bits were not needed. I tried to find a balance here between duplication and the new function having its slightly different path and checks, but am more than happy to tweak this as needed. The diff here isn't great, probably better viewed side by side.