### PR TITLE
new mock sequence - for discussion

### DIFF
--- a/src/Moq/Interception/Mock.cs
+++ b/src/Moq/Interception/Mock.cs
@@ -1,6 +1,8 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using System;
+
 namespace Moq
 {
 	partial class Mock : IInterceptor

--- a/src/Moq/InvocationCollection.cs
+++ b/src/Moq/InvocationCollection.cs
@@ -65,6 +65,7 @@ namespace Moq
 
 				this.invocations[this.count] = invocation;
 				this.count++;
+				owner.AddedInvocation(invocation);
 			}
 		}
 

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -45,6 +45,11 @@ namespace Moq
 			get => this.failMessage;
 		}
 
+		internal void SetCondition(Condition condition)
+		{
+			this.condition = condition;
+		}
+
 		public override Condition Condition => this.condition;
 
 		private static string GetUserCodeCallSite()

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -192,6 +192,21 @@ namespace Moq
 
 		internal abstract InvocationCollection MutableInvocations { get; }
 
+		private readonly List<Action<Invocation>> invocationListeners = new List<Action<Invocation>>();
+
+		internal void AddInvocationListener(Action<Invocation> listener)
+		{
+			invocationListeners.Add(listener);
+		}
+
+		internal virtual void AddedInvocation(Invocation invocation)
+		{
+			foreach(var listener in invocationListeners)
+			{
+				listener(invocation);
+			}
+		}
+
 		/// <summary>
 		///   Returns the mocked object value.
 		/// </summary>

--- a/src/Moq/MockSequenceBase.cs
+++ b/src/Moq/MockSequenceBase.cs
@@ -171,7 +171,7 @@ namespace Moq
 		/// </summary>
 		/// <param name="setup"></param>
 		/// <param name="trackedSetupCallback"></param>
-		protected void InterceptSetup(Action setup, Func<ITrackedSetup<TContext>,int,TContext> trackedSetupCallback)
+		protected void InterceptSetup(Action setup, Func<ISequenceSetup<TContext>,TContext> trackedSetupCallback)
 		{
 			setupCount++;
 			List<List<SetupWithDepth>> allSetupsBefore = mocks.Select(m => MoqSetupFinder.GetAllSetups(m)).ToList();
@@ -187,10 +187,12 @@ namespace Moq
 					ListenForInvocations(result.NewSetups.Select(s => s.Setup.Mock));
 					var terminalTrackedSetup = ResolveSetups(setupsExceptTerminal, terminalSetup);
 					SetCondition(terminalTrackedSetup);
-					var context = trackedSetupCallback(terminalTrackedSetup, setupCount);
-					var sequenceSetup = new SequenceSetup<TContext> { Context = context, TrackedSetup = terminalTrackedSetup, SetupIndex = setupCount };
+					var sequenceSetup = new SequenceSetup<TContext> { TrackedSetup = terminalTrackedSetup, SetupIndex = setupCount };
+					var context = trackedSetupCallback(sequenceSetup);
+					sequenceSetup.Context = context;
 					sequenceSetups.Add(sequenceSetup);
 					terminalTrackedSetup.sequenceSetupsInternal.Add(sequenceSetup);
+
 					return;
 				}
 

--- a/src/Moq/MockSequenceBase.cs
+++ b/src/Moq/MockSequenceBase.cs
@@ -145,7 +145,7 @@ namespace Moq
 		{
 			if(mocks.Length == 0)
 			{
-				throw new SequenceException("No mocks");
+				throw new ArgumentException("No mocks", nameof(mocks));
 			}
 			this.mocks = mocks;
 			this.strict = strict;
@@ -207,7 +207,7 @@ namespace Moq
 
 			}
 
-			throw new SequenceException("No setup");
+			throw new ArgumentException("No setup performed",nameof(setup));
 		}
 
 		private TrackedSetup<TContext> ResolveSetups(IEnumerable<SetupWithDepth> setupsExceptTerminal,SetupWithDepth terminal)

--- a/src/Moq/MockSequenceBase.cs
+++ b/src/Moq/MockSequenceBase.cs
@@ -96,7 +96,16 @@ namespace Moq
 	/// <summary>
 	/// 
 	/// </summary>
-	public class StrictSequenceException : Exception
+	public partial class SequenceException : Exception
+	{
+		internal SequenceException() { }
+		internal SequenceException(string message) : base(message) { }
+	}
+
+	/// <summary>
+	/// 
+	/// </summary>
+	public class StrictSequenceException : SequenceException
 	{
 		/// <summary>
 		/// 
@@ -136,7 +145,7 @@ namespace Moq
 		{
 			if(mocks.Length == 0)
 			{
-				throw new Exception("No mocks");
+				throw new SequenceException("No mocks");
 			}
 			this.mocks = mocks;
 			this.strict = strict;
@@ -198,7 +207,7 @@ namespace Moq
 
 			}
 
-			throw new Exception("No setup");
+			throw new SequenceException("No setup");
 		}
 
 		private TrackedSetup<TContext> ResolveSetups(IEnumerable<SetupWithDepth> setupsExceptTerminal,SetupWithDepth terminal)

--- a/src/Moq/MockSequenceBase.cs
+++ b/src/Moq/MockSequenceBase.cs
@@ -1,0 +1,427 @@
+﻿// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Moq
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	public interface ITrackedSetup<TContext>
+	{
+		/// <summary>
+		/// 
+		/// </summary>
+		ISetup Setup { get; }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		IReadOnlyList<int> ExecutionIndices { get; }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		IReadOnlyList<ISequenceSetup<TContext>> SequenceSetups { get; }
+	}
+
+	/// <summary>
+	/// 
+	/// </summary>
+	/// <typeparam name="TContext"></typeparam>
+	public interface ISequenceSetup<TContext>
+	{
+		/// <summary>
+		/// 
+		/// </summary>
+		ITrackedSetup<TContext> TrackedSetup { get; }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		TContext Context { get; }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		int SetupIndex { get; }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		int ExecutionCount { get; set; }
+
+	}
+
+	internal class SequenceSetup<TContext> : ISequenceSetup<TContext>
+	{
+		public ITrackedSetup<TContext> TrackedSetup { get; set; }
+		public TContext Context { get; set; }
+		public int SetupIndex { get; set; }
+		public int ExecutionCount { get; set; }
+	}
+
+	internal class TrackedSetup<TContext> : ITrackedSetup<TContext>
+	{
+		public Setup SetupInternal { get; set; }
+		public ISetup Setup => SetupInternal;
+		internal readonly List<int> executionIndicesInternal = new List<int>();
+		public IReadOnlyList<int> ExecutionIndices => executionIndicesInternal;
+		internal readonly List<ISequenceSetup<TContext>> sequenceSetupsInternal = new List<ISequenceSetup<TContext>>();
+		public IReadOnlyList<ISequenceSetup<TContext>> SequenceSetups => sequenceSetupsInternal;
+	}
+
+	/// <summary>
+	/// 
+	/// </summary>
+	public class SequenceInvocation
+	{
+		/// <summary>
+		/// 
+		/// </summary>
+		public Mock Mock { get; set; }
+		/// <summary>
+		/// 
+		/// </summary>
+		public IInvocation Invocation { get; set; }
+		/// <summary>
+		/// 
+		/// </summary>
+		public bool Matched { get; set; }
+	}
+
+	/// <summary>
+	/// 
+	/// </summary>
+	public class StrictSequenceException : Exception
+	{
+		/// <summary>
+		/// 
+		/// </summary>
+		public IEnumerable<SequenceInvocation> UnmatchedSequenceInvocations { get; set; }
+	}
+
+	/// <summary>
+	/// 
+	/// </summary>
+	public abstract class MockSequenceBase<TContext>
+	{
+		private readonly bool strict;
+		private int setupCount = -1;
+		private int executionCount = -1;
+		private readonly Mock[] mocks;
+		private readonly List<Mock> listenedToMocks = new List<Mock>();
+		private readonly List<ITrackedSetup<TContext>> trackedSetups = new List<ITrackedSetup<TContext>>();
+		private readonly List<ISequenceSetup<TContext>> sequenceSetups = new List<ISequenceSetup<TContext>>();
+		internal readonly List<SequenceInvocation> sequenceInvocations = new List<SequenceInvocation>();
+		internal readonly List<TrackedSetup<TContext>> allTrackedSetups = new List<TrackedSetup<TContext>>();
+		/// <summary>
+		/// 
+		/// </summary>
+		protected IReadOnlyList<ITrackedSetup<TContext>> TrackedSetups => trackedSetups;
+		/// <summary>
+		/// 
+		/// </summary>
+		protected IReadOnlyList<ISequenceSetup<TContext>> SequenceSetups => sequenceSetups;
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="strict"></param>
+		/// <param name="mocks"></param>
+		public MockSequenceBase(bool strict,params Mock[] mocks)
+		{
+			if(mocks.Length == 0)
+			{
+				throw new Exception("No mocks");
+			}
+			this.mocks = mocks;
+			this.strict = strict;
+			ListenForInvocations();
+		}
+
+		private void ListenForInvocations()
+		{
+			ListenForInvocations(mocks);
+		}
+
+		private void ListenForInvocations(IEnumerable<Mock> mocks)
+		{
+			foreach (var mock in mocks)
+			{
+				ListenForInvocation(mock);
+			}
+		}
+
+		private void ListenForInvocation(Mock mock)
+		{
+			ListenForInvocations(mock.MutableSetups.Where(s => s.InnerMock != null).Select(s=>s.InnerMock));
+			if (!listenedToMocks.Contains(mock))
+			{
+				mock.AddInvocationListener(invocation => sequenceInvocations.Add(new SequenceInvocation { Invocation = invocation, Mock = mock }));
+				listenedToMocks.Add(mock);
+			}
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="setup"></param>
+		/// <param name="trackedSetupCallback"></param>
+		protected void InterceptSetup(Action setup, Func<ITrackedSetup<TContext>,int,TContext> trackedSetupCallback)
+		{
+			setupCount++;
+			List<List<SetupWithDepth>> allSetupsBefore = mocks.Select(m => MoqSetupFinder.GetAllSetups(m)).ToList();
+			setup();
+			List<List<SetupWithDepth>> allSetupsAfter = mocks.Select(m => MoqSetupFinder.GetAllSetups(m)).ToList();
+			for(var i = 0; i < allSetupsBefore.Count; i++)
+			{
+				var result = allSetupsBefore[i].NewSetups(allSetupsAfter[i]);
+				if (!result.NoChange)
+				{
+					var terminalSetup = result.TerminalSetup;
+					var setupsExceptTerminal = result.NewSetups.Except(new SetupWithDepth[] { terminalSetup });
+					ListenForInvocations(result.NewSetups.Select(s => s.Setup.Mock));
+					var terminalTrackedSetup = ResolveSetups(setupsExceptTerminal, terminalSetup);
+					SetCondition(terminalTrackedSetup);
+					var context = trackedSetupCallback(terminalTrackedSetup, setupCount);
+					var sequenceSetup = new SequenceSetup<TContext> { Context = context, TrackedSetup = terminalTrackedSetup, SetupIndex = setupCount };
+					sequenceSetups.Add(sequenceSetup);
+					terminalTrackedSetup.sequenceSetupsInternal.Add(sequenceSetup);
+					return;
+				}
+
+			}
+
+			throw new Exception("No setup");
+		}
+
+		private TrackedSetup<TContext> ResolveSetups(IEnumerable<SetupWithDepth> setupsExceptTerminal,SetupWithDepth terminal)
+		{
+			foreach(var setup in setupsExceptTerminal)
+			{
+				ResolveSetup(setup);
+			}
+			return ResolveSetup(terminal, true);
+		}
+		
+		private TrackedSetup<TContext> ResolveSetup(SetupWithDepth setupWithDepth, bool sequenceSetup = false)
+		{
+			var setup = setupWithDepth.Setup;
+			var trackedSetup = allTrackedSetups.FirstOrDefault(ts => ts.SetupInternal.Expectation.Equals(setup.Expectation));
+			if(trackedSetup == null)
+			{
+				trackedSetup = new TrackedSetup<TContext> { SetupInternal = setup };
+				allTrackedSetups.Add(trackedSetup);
+				if (sequenceSetup)
+				{
+					trackedSetups.Add(trackedSetup);
+				}
+			}
+			else
+			{
+				setupWithDepth.ContainingMutableSetups.Remove(setup);
+			}
+			return trackedSetup;
+		}
+
+		private void SetCondition(TrackedSetup<TContext> trackedSetup)
+		{
+			var setup = trackedSetup.Setup;
+			if(setup is MethodCall methodCall)
+			{
+				methodCall.SetCondition(
+					new Condition(() =>
+					{
+						var potentialSuccessIndex = executionCount + 1;
+						var success = Condition(trackedSetup, potentialSuccessIndex);
+						if (success)
+						{
+							executionCount++;
+						}
+						return success;
+					}, 
+					() => {
+						/*
+							Invocation.MatchingSetup is not set until the condition has returned true. 
+							If need to move the test in to the condition part
+							Will need to change Setup.Matches to attach the Invocation to the Condition
+						*/
+						if (strict)
+						{
+							if (!InvocationsHaveMatchingSequenceSetup())
+							{
+								StrictnessFailure(UnmatchedInvocations());
+							}
+						}
+						
+						trackedSetup.executionIndicesInternal.Add(executionCount);
+						SetupExecuted(trackedSetup);
+					})
+				);
+			} // should be throwing otherwise ?
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="unmatchedInvocations"></param>
+		protected virtual void StrictnessFailure(IEnumerable<SequenceInvocation> unmatchedInvocations)
+		{
+			throw new StrictSequenceException { UnmatchedSequenceInvocations = unmatchedInvocations };
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="trackedSetup"></param>
+		/// <param name="invocationIndex"></param>
+		/// <returns></returns>
+		protected abstract bool Condition(ITrackedSetup<TContext> trackedSetup, int invocationIndex);
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="trackedSetup"></param>
+		protected virtual void SetupExecuted(ITrackedSetup<TContext> trackedSetup)
+		{
+
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <returns></returns>
+		protected IEnumerable<SequenceInvocation> UnmatchedInvocations()
+		{
+			return sequenceInvocations.Where(si => !si.Matched);
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <returns></returns>
+		protected bool InvocationsHaveMatchingSequenceSetup()
+		{
+			foreach(var sequenceInvocation in UnmatchedInvocations())
+			{
+				if (!InvocationHasMatchingSequenceSetup(sequenceInvocation))
+				{
+					return false;
+				}
+			}
+			return true;
+		}
+
+		private bool InvocationHasMatchingSequenceSetup(SequenceInvocation sequenceInvocation)
+		{
+			var invocation = sequenceInvocation.Invocation;
+			if (invocation.MatchingSetup == null)
+			{
+				return false;
+			}
+
+			foreach (var trackedSetup in allTrackedSetups)
+			{
+				if (invocation.MatchingSetup == trackedSetup.Setup)
+				{
+					sequenceInvocation.Matched = true;
+					break;
+				}
+			}
+			return sequenceInvocation.Matched;
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		public void Verify()
+		{
+			if (strict && !InvocationsHaveMatchingSequenceSetup())
+			{
+				throw new StrictSequenceException { UnmatchedSequenceInvocations = UnmatchedInvocations() };
+			}
+			VerifyImpl();
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		protected abstract void VerifyImpl();
+		
+	}
+
+	internal class SetupWithDepth : IEquatable<SetupWithDepth>
+	{
+		public int Depth { get; set; }
+		public Setup Setup { get; set; }
+		public SetupCollection ContainingMutableSetups { get; set; }
+
+		public bool Equals(SetupWithDepth other)
+		{
+			return Setup == other.Setup;
+		}
+
+		public override int GetHashCode()
+		{
+			return Setup.GetHashCode();
+		}
+		
+	}
+
+	internal static class SetupWithDepthExtensions
+	{
+		public class SetupDepthComparisonResult
+		{
+			public bool NoChange { get; set; }
+			public List<SetupWithDepth> NewSetups { get; set; }
+			public SetupWithDepth TerminalSetup { get; set; }
+		}
+
+		public static SetupDepthComparisonResult NewSetups(this List<SetupWithDepth> before, List<SetupWithDepth> after)
+		{
+			if (after.Count == before.Count)
+			{
+				return new SetupDepthComparisonResult { NoChange = true };
+			}
+
+			var difference = after.Except(before, EqualityComparer<SetupWithDepth>.Default);
+			var orderedByDepth = difference.OrderBy(sd => sd.Depth).ToList();
+			var terminalSetup = orderedByDepth.Last();
+			return new SetupDepthComparisonResult
+			{
+				NewSetups = orderedByDepth,
+				TerminalSetup = terminalSetup
+			};
+		}
+	}
+
+	internal static class MoqSetupFinder
+	{
+		private static void GetAllSetups(SetupCollection setups, List<SetupWithDepth> setupsWithDepth, int depth)
+		{
+			setupsWithDepth.AddRange(setups.ToArray().Select(s => new SetupWithDepth { Depth = depth, Setup = s, ContainingMutableSetups = setups }));
+			foreach (var setup in setups)
+			{
+				if (setup.InnerMock != null)
+				{
+					GetAllSetups(setup.InnerMock.MutableSetups, setupsWithDepth, depth + 1);
+				}
+			}
+		}
+		private static void GetAllSetups(SetupCollection setups, List<SetupWithDepth> setupsWithDepth)
+		{
+			GetAllSetups(setups, setupsWithDepth, 0);
+		}
+		public static List<SetupWithDepth> GetAllSetups(Mock mock)
+		{
+			var setupsWithDepth = new List<SetupWithDepth>();
+			GetAllSetups(mock.MutableSetups, setupsWithDepth);
+			return setupsWithDepth;
+		}
+	}
+
+}

--- a/src/Moq/NewMockSequence.cs
+++ b/src/Moq/NewMockSequence.cs
@@ -9,17 +9,9 @@ namespace Moq
 	/// <summary>
 	/// 
 	/// </summary>
-	public class SequenceVerificationException : Exception
-	{
-
-	}
-
-	/// <summary>
-	/// 
-	/// </summary>
 	public partial class SequenceException : Exception
 	{
-		internal SequenceException(Times times, int executedCount, ISetup setup) : base($"{setup} {times.GetExceptionMessage(executedCount)}") { }
+		internal SequenceException(Times times, int executedCount, ISetup setup = null) : base($"{(setup == null ? "" : $"{setup} ")}{times.GetExceptionMessage(executedCount)}") { }
 	}
 
 	/// <summary>
@@ -54,7 +46,7 @@ namespace Moq
 		/// <param name="times"></param>
 		public void Verify(Times times)
 		{
-			Verify(times, sequenceSetup.ExecutionCount);
+			Verify(times, sequenceSetup.ExecutionCount,sequenceSetup.TrackedSetup.Setup);
 		}
 
 		/// <summary>
@@ -80,15 +72,15 @@ namespace Moq
 
 		private void VerifySequenceSetup(ISequenceSetup<Times> sequenceSetup)
 		{
-			Verify(sequenceSetup.Context, sequenceSetup.ExecutionCount);
+			Verify(sequenceSetup.Context, sequenceSetup.ExecutionCount, sequenceSetup.TrackedSetup.Setup);
 		}
 
-		private void Verify(Times times, int executionCount)
+		private void Verify(Times times, int executionCount, ISetup setup = null)
 		{
 			var success = times.Validate(executionCount);
 			if (!success)
 			{
-				throw new SequenceVerificationException();
+				throw new SequenceException(times, executionCount, setup);
 			}
 		}
 
@@ -133,7 +125,7 @@ namespace Moq
 				var trackedSetup = sequenceSetup.TrackedSetup;
 				if(lastTrackedSetup == trackedSetup)
 				{
-					throw new SequenceException("Consecutive setups are the same");
+					throw new ArgumentException("Consecutive setups are the same",nameof(setup));
 				}
 				lastTrackedSetup = trackedSetup;
 				verifiableSetup = new VerifiableSetup(sequenceSetup);

--- a/src/Moq/NewMockSequence.cs
+++ b/src/Moq/NewMockSequence.cs
@@ -82,6 +82,8 @@ namespace Moq
 		}
 
 		private int currentSequenceSetupIndex;
+		private ITrackedSetup<Times> lastSetup;
+
 		/// <summary>
 		/// 
 		/// </summary>
@@ -101,6 +103,11 @@ namespace Moq
 			VerifiableSetup verifiableSetup = null;
 			base.InterceptSetup(setup, (ts, setupOrder) =>
 			{
+				if(lastSetup == ts)
+				{
+					throw new Exception("Consecutive setups are the same");
+				}
+				lastSetup = ts;
 				verifiableSetup = new VerifiableSetup(ts);
 				return t;
 			});

--- a/src/Moq/NewMockSequence.cs
+++ b/src/Moq/NewMockSequence.cs
@@ -17,7 +17,7 @@ namespace Moq
 	/// <summary>
 	/// 
 	/// </summary>
-	public class SequenceException : Exception
+	public partial class SequenceException : Exception
 	{
 		internal SequenceException(Times times, int executedCount, ISetup setup) : base($"{setup} {times.GetExceptionMessage(executedCount)}") { }
 	}
@@ -133,7 +133,7 @@ namespace Moq
 				var trackedSetup = sequenceSetup.TrackedSetup;
 				if(lastTrackedSetup == trackedSetup)
 				{
-					throw new Exception("Consecutive setups are the same");
+					throw new SequenceException("Consecutive setups are the same");
 				}
 				lastTrackedSetup = trackedSetup;
 				verifiableSetup = new VerifiableSetup(sequenceSetup);

--- a/src/Moq/NewMockSequence.cs
+++ b/src/Moq/NewMockSequence.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Moq
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	public class SequenceVerificationException : Exception
+	{
+
+	}
+
+	/// <summary>
+	/// 
+	/// </summary>
+	public class SequenceException : Exception
+	{
+		internal SequenceException(Times times, int executedCount, ISetup setup) : base($"{setup} {times.GetExceptionMessage(executedCount)}") { }
+	}
+
+	/// <summary>
+	/// 
+	/// </summary>
+	public class VerifiableSetup
+	{
+		private readonly ITrackedSetup<Times> trackedSetup;
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="trackedSetup"></param>
+		public VerifiableSetup(ITrackedSetup<Times> trackedSetup)
+		{
+			this.trackedSetup = trackedSetup;
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="times"></param>
+		public void Verify(Times times)
+		{
+			var success = times.Validate(trackedSetup.ExecutionIndices.Count);
+			if (!success)
+			{
+				throw new SequenceVerificationException();
+			}
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		public void Verify()
+		{
+			if (trackedSetup.SequenceSetups.Count == 1)
+			{
+				Verify(trackedSetup.SequenceSetups[0].Context);
+			}
+			else
+			{
+				throw new Exception("not valid");
+			}
+		}
+	}
+
+	/// <summary>
+	/// 
+	/// </summary>
+	public sealed class NewMockSequence : MockSequenceBase<Times>
+	{
+		private int currentSequenceSetup;
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="strict"></param>
+		/// <param name="mocks"></param>
+		public NewMockSequence(bool strict, params Mock[] mocks) : base(strict, mocks) { }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="setup"></param>
+		/// <param name="times"></param>
+		/// <returns></returns>
+		public VerifiableSetup Setup(Action setup, Times? times = null)
+		{
+			Times t = times ?? Times.Once();
+			VerifiableSetup verifiableSetup = null;
+			base.InterceptSetup(setup, (ts, setupOrder) =>
+			{
+				verifiableSetup = new VerifiableSetup(ts);
+				return t;
+			});
+			return verifiableSetup;
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="trackedSetup"></param>
+		/// <param name="invocationIndex"></param>
+		/// <returns></returns>
+		protected override bool Condition(ITrackedSetup<Times> trackedSetup, int invocationIndex)
+		{
+			var sequenceSetup = SequenceSetups[currentSequenceSetup];
+
+			if (sequenceSetup.TrackedSetup == trackedSetup)
+			{
+				ConfirmSequenceSetup(sequenceSetup);
+			}
+			else
+			{
+				ConfirmPreviousSequenceSetup(sequenceSetup);
+
+				var nextSequenceSetup = currentSequenceSetup + 1;
+				if (nextSequenceSetup > SequenceSetups.Count)
+				{
+					//cyclical....
+				}
+				else
+				{
+					currentSequenceSetup++;
+					sequenceSetup = SequenceSetups[currentSequenceSetup];
+					ConfirmSequenceSetup(sequenceSetup);
+				}
+			}
+
+
+			return true;
+		}
+
+		private void ConfirmPreviousSequenceSetup(ISequenceSetup<Times> sequenceSetup)
+		{
+			var times = sequenceSetup.Context;
+			var kind = times.GetKind();
+			switch (kind)
+			{
+				case Times.Kind.Never:
+				case Times.Kind.AtMost:
+				case Times.Kind.AtMostOnce:
+					break;
+				case Times.Kind.Exactly:
+				case Times.Kind.Once:
+				case Times.Kind.BetweenExclusive:
+				case Times.Kind.BetweenInclusive:
+				case Times.Kind.AtLeast:
+				case Times.Kind.AtLeastOnce:
+					if (!times.Validate(sequenceSetup.ExecutionCount))
+					{
+						throw new SequenceException(times,sequenceSetup.ExecutionCount,sequenceSetup.TrackedSetup.Setup);
+					}
+					break;
+			}
+		}
+
+		private void ConfirmSequenceSetup(ISequenceSetup<Times> sequenceSetup)
+		{
+			var times = sequenceSetup.Context;
+			times.Deconstruct(out int _, out int to);
+			var kind = times.GetKind();
+			sequenceSetup.ExecutionCount++;
+			var shouldThrow = false;
+			switch (kind)
+			{
+				case Times.Kind.Never:
+					shouldThrow = true;
+					break;
+				case Times.Kind.Exactly:
+				case Times.Kind.Once:
+					if (times.Validate(sequenceSetup.ExecutionCount))
+					{
+						currentSequenceSetup++;
+					}
+					break;
+				case Times.Kind.AtLeast:
+				case Times.Kind.AtLeastOnce:
+					// we do not shift
+					break;
+				case Times.Kind.AtMost:
+				case Times.Kind.AtMostOnce:
+					shouldThrow = !times.Validate(sequenceSetup.ExecutionCount);
+					break;
+				case Times.Kind.BetweenExclusive:
+				case Times.Kind.BetweenInclusive:
+					if (sequenceSetup.ExecutionCount > to)
+					{
+						shouldThrow = true;
+					}
+					break;
+			}
+
+			if (shouldThrow)
+			{
+				throw new SequenceException(times, sequenceSetup.ExecutionCount, sequenceSetup.TrackedSetup.Setup);
+			}
+		}
+	
+		/// <summary>
+		/// 
+		/// </summary>
+		protected override void VerifyImpl()
+		{
+			for(var i = currentSequenceSetup; i < SequenceSetups.Count; i++)
+			{
+				ConfirmPreviousSequenceSetup(SequenceSetups[i]);
+			}
+		}
+	}
+
+}

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -135,6 +135,11 @@ namespace Moq
 			return null;
 		}
 
+		internal void Remove(Setup setup)
+		{
+			setups.Remove(setup);
+		}
+
 		public IEnumerable<Setup> GetInnerMockSetups()
 		{
 			return this.ToArray(setup => !setup.IsOverridden && !setup.IsConditional && setup.InnerMock != null);

--- a/src/Moq/Times.cs
+++ b/src/Moq/Times.cs
@@ -18,6 +18,10 @@ namespace Moq
 		private readonly int from;
 		private readonly int to;
 		private readonly Kind kind;
+		internal Kind GetKind()
+		{
+			return kind;
+		}
 
 		private Times(Kind kind, int from, int to)
 		{
@@ -297,7 +301,7 @@ namespace Moq
 			return from <= count && count <= to;
 		}
 
-		private enum Kind
+		internal enum Kind
 		{
 			AtLeastOnce,
 			AtLeast,

--- a/tests/Moq.Tests/MockSequenceFixture.cs
+++ b/tests/Moq.Tests/MockSequenceFixture.cs
@@ -691,7 +691,7 @@ namespace Moq.Tests
 			}
 
 			Setup();
-			var exception = Assert.Throws<Exception>(Setup);
+			var exception = Assert.Throws<SequenceException>(Setup);
 			Assert.Equal("Consecutive setups are the same", exception.Message);
 		}
 

--- a/tests/Moq.Tests/MockSequenceFixture.cs
+++ b/tests/Moq.Tests/MockSequenceFixture.cs
@@ -529,6 +529,41 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public void MockSequenceWillNotThrowWhenSkipOptionalTimesSetups()
+		{
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)), NewMockSequence.OptionalTimes());
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(2)), NewMockSequence.OptionalTimes());
+				mockSequence.Setup(() => mock.Setup(m => m.Do(2)));
+			}, (mocked, protectedMocked) =>
+			{
+				mocked.Do(1);
+				mocked.Do(2);
+			});
+		}
+
+		[Fact]
+		public void MockSequenceWillThrowWhenSkipNonOptionalTimesSetups()
+		{
+			Assert.Throws<SequenceException>(() =>
+			{
+				LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+				{
+					mockSequence.Setup(() => mock.Setup(m => m.Do(1)));
+					mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)), NewMockSequence.OptionalTimes());
+					mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(2)), Times.Once());
+					mockSequence.Setup(() => mock.Setup(m => m.Do(2)));
+				}, (mocked, protectedMocked) =>
+				{
+					mocked.Do(1);
+					mocked.Do(2);
+				});
+			});
+		}
+
+		[Fact]
 		public void MockSequenceCanUseVerifiableSetupToVerify()
 		{
 			VerifiableSetup verifiableSetup1 = null;

--- a/tests/Moq.Tests/MockSequenceFixture.cs
+++ b/tests/Moq.Tests/MockSequenceFixture.cs
@@ -658,6 +658,22 @@ namespace Moq.Tests
 			mockSequence.Verify();
 		}
 
+		[Fact]
+		public void MockSequenceShouldThrowWithConsecutiveSameSetups()
+		{
+			var mock = new Mock<IFoo>();
+			var mockSequence = new NewMockSequence(false, mock);
+			
+			void Setup()
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)));
+			}
+
+			Setup();
+			var exception = Assert.Throws<Exception>(Setup);
+			Assert.Equal("Consecutive setups are the same", exception.Message);
+		}
+
 		internal class AMockSequence : MockSequenceBase<int>
 		{
 			public bool StrictFailure { get; set; }

--- a/tests/Moq.Tests/MockSequenceFixture.cs
+++ b/tests/Moq.Tests/MockSequenceFixture.cs
@@ -1,6 +1,9 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using Moq.Protected;
+using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Moq.Tests
@@ -115,9 +118,590 @@ namespace Moq.Tests
 			Assert.Throws<MockException>(() => a.Object.Do(200));
 		}
 
+		[Fact]
+		public void MockSequenceBaseFindsSetupsFromActions()
+		{
+			var contextCounter = 0;
+			var mock = new Mock<IFoo>();
+			var nestedMock = new Mock<IHaveNested>();
+			var aMockSequence = new AMockSequence(false,mock, nestedMock);
+			ITrackedSetup<int> trackedSetup = null;
+			int order = -1;
+			Func<ITrackedSetup<int>, int,int> callback = (ts, o) =>
+			 {
+				 trackedSetup = ts;
+				 order = o;
+				 return contextCounter++;
+			 };
+			aMockSequence.Setup(() => mock.Setup(f => f.Do(1)), callback);
+			Assert.Equal(0, order);
+			Assert.Equal("MockSequenceFixture.IFoo f => f.Do(1)", trackedSetup.Setup.ToString());
+			var sequenceSetups = trackedSetup.SequenceSetups;
+			var sequenceSetup = sequenceSetups[0];
+			Assert.Single(sequenceSetups);
+			Assert.Equal(contextCounter - 1, sequenceSetup.Context);
+			Assert.Equal(order, sequenceSetup.SetupIndex);
+			var repeatedSetup = trackedSetup;
+			var allTrackedSetups = aMockSequence.GetAllTrackedSetups();
+			var trackedSetups = aMockSequence.GetTrackedSetups();
+			Assert.Single(allTrackedSetups);
+			Assert.Single(trackedSetups);
+			Assert.Same(trackedSetup, allTrackedSetups[0]);
+			Assert.Same(trackedSetup, trackedSetups[0]);
+
+			aMockSequence.Setup(() =>
+			{
+				nestedMock.Setup(n => n.ReturnNested(1).DoNested(1));
+			}, callback);
+			Assert.Equal(1, order);
+			Assert.Equal("MockSequenceFixture.INested ... => ....DoNested(1)", trackedSetup.Setup.ToString());
+			Assert.Equal(3, allTrackedSetups.Count);
+			Assert.Equal(2, trackedSetups.Count);
+			Assert.Contains(trackedSetup, allTrackedSetups);
+			Assert.Same(trackedSetup, trackedSetups[1]);
+
+			// repeatedSetup
+			aMockSequence.Setup(() => mock.Setup(f => f.Do(1)), callback);
+			Assert.Equal(2, order);
+			Assert.Equal(3, allTrackedSetups.Count);
+			Assert.Equal(2, trackedSetups.Count);
+			Assert.Same(repeatedSetup, trackedSetup);
+			sequenceSetups = trackedSetup.SequenceSetups;
+			Assert.Equal(2, sequenceSetups.Count);
+			Assert.Same(sequenceSetup, sequenceSetups[0]);
+			sequenceSetup = sequenceSetups[1];
+			Assert.Equal(contextCounter - 1, sequenceSetup.Context);
+			Assert.Equal(order, sequenceSetup.SetupIndex);
+			
+		}
+
+		[Fact]
+		public void MockSequenceBaseInvokesConditionWithTrackedSetupAndExecutionIndex()
+		{
+			var mock = new Mock<IFoo>();
+			var aMockSequence = new AMockSequence(false,mock);
+			aMockSequence.Setup(() => mock.Setup(f => f.Do(1)), (ts, order) => order);
+			mock.Object.Do(1);
+			Assert.Single(aMockSequence.ConditionCalls);
+			var conditionCall = aMockSequence.ConditionCalls[0];
+			Assert.Equal(0,conditionCall.executionOrder);
+			var trackedSetup = conditionCall.trackedSetup;
+			Assert.Equal("MockSequenceFixture.IFoo f => f.Do(1)", trackedSetup.Setup.ToString());
+			var sequenceSetup = trackedSetup.SequenceSetups[0];
+			Assert.Equal(0, sequenceSetup.SetupIndex);
+			Assert.Equal(0, sequenceSetup.Context);
+		}
+
+		[Fact]
+		public void MockSequenceBaseShouldCaptureInvocations()
+		{
+			var mock = new Mock<IFoo>();
+			var nestedMock = new Mock<IHaveNested>();
+			// listening from non sequence setups works if done before hand.... 
+			// but it does not update after....
+			nestedMock.Setup(n => n.ReturnNested(1).DoNested(2)).Returns(1);
+			var aMockSequence = new AMockSequence(false, mock, nestedMock);
+
+			mock.Object.Do(1);
+			Assert.Single(aMockSequence.sequenceInvocations);
+
+			nestedMock.Object.ReturnNested(1).DoNested(1);
+			Assert.Equal(3, aMockSequence.sequenceInvocations.Count);
+
+		}
+
+		[Fact]
+		public void MockSequenceBaseTracksExecutionIndices()
+		{
+			var mock = new Mock<IFoo>();
+			var mocked = mock.Object;
+			var aMockSequence = new AMockSequence(false, mock);
+			IReadOnlyList<int> executionIndices1 = null;
+			aMockSequence.Setup(() => mock.Setup(m => m.Do(1)), (ts, setupOrder) =>
+			 {
+				 executionIndices1 = ts.ExecutionIndices;
+				 return 1;
+			 });
+			IReadOnlyList<int> executionIndices2 = null;
+			aMockSequence.Setup(() => mock.Setup(m => m.Do(2)), (ts, setupOrder) =>
+			{
+				executionIndices2 = ts.ExecutionIndices;
+				return 2;
+			});
+			
+			Assert.Empty(executionIndices1);
+			Assert.Empty(executionIndices2);
+
+			mocked.Do(3);
+			Assert.Empty(executionIndices1);
+			Assert.Empty(executionIndices2);
+
+			mocked.Do(1);
+			Assert.Single(executionIndices1);
+			Assert.Equal(0, executionIndices1[0]);
+			Assert.Empty(executionIndices2);
+
+			mocked.Do(2);
+			mocked.Do(1);
+			Assert.Equal(2, executionIndices1.Count);
+			Assert.Equal(2, executionIndices1[1]);
+			Assert.Single(executionIndices2);
+			Assert.Equal(1, executionIndices2[0]);
+
+
+		}
+
+		[Fact]
+		public void MockSequenceBaseCanCheckInvocationsAgainstSequenceSetups()
+		{
+			var mock = new Mock<IFoo>();
+			var aMockSequence = new AMockSequence(false,mock);
+			mock.Setup(m => m.Do(1));
+			mock.Object.Do(1);
+			Assert.Single(aMockSequence.sequenceInvocations);
+			Assert.False(aMockSequence.InvocationsHaveMatchingSetups());
+
+			aMockSequence = new AMockSequence(false, mock);
+			aMockSequence.Setup(() => mock.Setup(m => m.Do(2)), (ts, order) => order);
+			mock.Object.Do(2);
+			Assert.Single(aMockSequence.sequenceInvocations);
+			Assert.True(aMockSequence.InvocationsHaveMatchingSetups());
+
+		}
+
+		[Fact]
+		public void MockSequenceBaseStrictInvokesStrictnessFailureForUnmatchedInvocations()
+		{
+			var mock = new Mock<IFoo>();
+			var aMockSequence = new AMockSequence(true, mock);
+			aMockSequence.Setup(() => mock.Setup(m => m.Do(2)), (ts, order) => order);
+			
+			mock.Object.Do(1);
+			Assert.False(aMockSequence.StrictFailure);
+
+			// strictness test occurs when condition returns true
+			mock.Object.Do(2);
+			Assert.True(aMockSequence.StrictFailure);
+		}
+
+		[Fact]
+		public void MockSequenceBaseStrictThrowsStrictSequenceExceptionForUnmatchedInvocations()
+		{
+			var mock = new Mock<IFoo>();
+			var aMockSequence = new AMockSequence(true, mock);
+			aMockSequence.CallBaseForStrictFailure = true;
+			aMockSequence.Setup(() => mock.Setup(m => m.Do(2)), (ts, order) => order);
+			mock.Object.Do(1);
+
+			// strictness test occurs when condition returns true
+			Assert.Throws<StrictSequenceException>(() => mock.Object.Do(2));
+		}
+
+		private void LooseNewMockSequenceTestBase(Action<Mock<IFoo>,IProtectedAsMock<Protected,ProtectedLike>, NewMockSequence> setupSequence,Action<IFoo,Protected> act)
+		{
+			var mock = new Mock<IFoo>();
+			var mocked = mock.Object;
+			var protectedMock = new Mock<Protected>();
+			var protectedAsMock = protectedMock.Protected().As<ProtectedLike>();
+
+			var protectedMocked = protectedMock.Object;
+			var mockSequence = new NewMockSequence(false, mock, protectedMock);
+			setupSequence(mock, protectedAsMock, mockSequence);
+			act(mocked, protectedMocked);
+		}
+
+		[Fact]
+		public void MockSequenceShouldNotThrowIfNotCalled()
+		{
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+			}, (mocked, protectedMocked) =>
+			 {
+				 
+			 });
+		}
+
+		[Fact]
+		public void MockSequenceShouldNotThrowIfCalledInOrder_OneTime()
+		{
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+			}, (mocked, protectedMocked) =>
+			{
+				mocked.Do(1);
+				protectedMocked.InvokeProtectedDo(1);
+			});
+		}
+
+		[Fact]
+		public void MockSequenceShouldThrowIfNotCalledInOrder_OneTime()
+		{
+			Assert.Throws<SequenceException>(() => 
+				LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+				{
+					mockSequence.Setup(() => mock.Setup(m => m.Do(1)));
+					mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				}, (mocked, protectedMocked) =>
+				{
+					protectedMocked.InvokeProtectedDo(1);
+					mocked.Do(1);
+				})
+			);
+		}
+
+		[Fact]
+		public void MockSequenceShouldNotThrowIfCalledCorrectExactTimes()
+		{
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.Exactly(2));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+			}, (mocked, protectedMocked) =>
+			{
+				mocked.Do(1);
+				mocked.Do(1);
+				protectedMocked.InvokeProtectedDo(1);
+			});
+		}
+
+		[Fact]
+		public void MockSequenceShouldThrowIfNotCalledCorrectExactTimes()
+		{
+			Assert.Throws<SequenceException>(() =>
+				LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+				{
+					mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.Exactly(2));
+					mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				}, (mocked, protectedMocked) =>
+				{
+					mocked.Do(1);
+					protectedMocked.InvokeProtectedDo(1);
+				})
+			);
+		}
+
+		[Fact]
+		public void MockSequenceShouldNotThrowIfAtLeastTimesIsMet()
+		{
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.AtLeast(2));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+			}, (mocked, protectedMocked) =>
+			{
+				mocked.Do(1);
+				mocked.Do(1);
+				protectedMocked.InvokeProtectedDo(1);
+			});
+		}
+
+		[Fact]
+		public void MockSequenceShouldNotThrowIfAtLeastTimesIsMetMoreThan()
+		{
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.AtLeast(2));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+			}, (mocked, protectedMocked) =>
+			{
+				mocked.Do(1);
+				mocked.Do(1);
+				mocked.Do(1);
+				protectedMocked.InvokeProtectedDo(1);
+			});
+		}
+
+		[Fact]
+		public void MockSequenceShouldThrowIfAtLeastTimesIsNotMet()
+		{
+			Assert.Throws<SequenceException>(() =>
+				LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+				{
+					mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.AtLeast(2));
+					mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				}, (mocked, protectedMocked) =>
+				{
+					mocked.Do(1);
+					protectedMocked.InvokeProtectedDo(1);
+				})
+			);
+		}
+
+		[Fact]
+		public void MockSequenceShouldThrowImmediatelyIfNeverCalled()
+		{
+			Assert.Throws<SequenceException>(() =>
+				LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+				{
+					mockSequence.Setup(() => mock.Setup(m => m.Do(1)));
+					mockSequence.Setup(() => mock.Setup(m => m.Do(2)),Times.Never());
+					mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				}, (mocked, protectedMocked) =>
+				{
+					mocked.Do(1);
+					mocked.Do(2);
+				})
+			);
+		}
+
+		[Fact]
+		public void MockSequenceShouldNotThrowIfAtMostMet()
+		{
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.AtMost(2));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+			}, (mocked, protectedMocked) =>
+			{
+				mocked.Do(1);
+				mocked.Do(1);
+				protectedMocked.InvokeProtectedDo(1);
+			});
+		}
+
+		[Fact]
+		public void MockSequenceShouldThrowImmediatelyIfInvokedMoreThanAtMost()
+		{
+			Assert.Throws<SequenceException>(() =>
+				LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+				{
+					mockSequence.Setup(() => mock.Setup(m => m.Do(1)),Times.AtMost(2));
+					mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				}, (mocked, protectedMocked) =>
+				{
+					mocked.Do(1);
+					mocked.Do(1);
+					mocked.Do(1);
+				})
+			);
+		}
+
+		[Fact]
+		public void MockSequenceShouldNotThrowIfBetweenInclusiveMet()
+		{
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.Between(0, 2, Range.Inclusive));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+			}, (mocked, protectedMocked) =>
+			{
+				mocked.Do(1);
+				mocked.Do(1);
+				protectedMocked.InvokeProtectedDo(1);
+			});
+		}
+
+		[Fact]
+		public void MockSequenceShouldThrowImmediatelyIfBetweenInclusiveTooManyInvocations()
+		{
+			Assert.Throws<SequenceException>(() =>
+				LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+				{
+					mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.Between(0,2,Range.Inclusive));
+					mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				}, (mocked, protectedMocked) =>
+				{
+					mocked.Do(1);
+					mocked.Do(1);
+					mocked.Do(1);
+				})
+			);
+		}
+
+		[Fact]
+		public void MockSequenceShouldThrowIfBetweenInclusiveTooFewInvocations()
+		{
+			Assert.Throws<SequenceException>(() =>
+				LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+				{
+					mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.Between(1, 2, Range.Inclusive));
+					mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				}, (mocked, protectedMocked) =>
+				{
+					
+					protectedMocked.InvokeProtectedDo(1);
+				})
+			);
+		}
+
+		[Fact]
+		public void MockSequenceCanUseVerifiableSetupToVerify()
+		{
+			VerifiableSetup verifiableSetup1 = null;
+			VerifiableSetup verifiableSetup2 = null;
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				verifiableSetup1 = mockSequence.Setup(() => mock.Setup(m => m.Do(1)));
+				verifiableSetup2 = mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+			}, (mocked, protectedMocked) =>
+			{
+				mocked.Do(1);
+			});
+
+			verifiableSetup1.Verify();
+			Assert.Throws<SequenceVerificationException>(() => verifiableSetup2.Verify(Times.Once()));
+		}
+		
+		[Fact]
+		public void MockSequenceVerifyVerifiesThatAllSetupsHaveBeenMet()
+		{
+			NewMockSequence sequence = null;
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.Exactly(2));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				sequence = mockSequence;
+			}, (mocked, protectedMocked) =>
+			{
+				mocked.Do(1);
+			});
+			Assert.Throws<SequenceException>(() => sequence.Verify());
+
+			NewMockSequence sequence2 = null;
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.Exactly(2));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				sequence2 = mockSequence;
+			}, (mocked, protectedMocked) =>
+			{
+				mocked.Do(1);
+				mocked.Do(1);
+			});
+			Assert.Throws<SequenceException>(() => sequence2.Verify());
+
+			NewMockSequence sequence3 = null;
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.Exactly(2));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				sequence3 = mockSequence;
+			}, (mocked, protectedMocked) =>
+			{
+				mocked.Do(1);
+				mocked.Do(1);
+				protectedMocked.InvokeProtectedDo(1);
+			});
+			sequence3.Verify();
+		}
+
+		[Fact]
+		public void MockSequenceVerifyStrictVerifiesNoInvocationsWithoutSequenceSetup()
+		{
+			var mock = new Mock<IFoo>();
+			var mocked = mock.Object;
+			var protectedMock = new Mock<Protected>();
+			var protectedAsMock = protectedMock.Protected().As<ProtectedLike>();
+
+			var protectedMocked = protectedMock.Object;
+			var mockSequence = new NewMockSequence(true, mock, protectedMock);
+			mockSequence.Setup(() => mock.Setup(m => m.Do(1)));
+			mocked.Do(1);
+			mocked.Do(2);
+
+			Assert.Throws<StrictSequenceException>(mockSequence.Verify);
+		}
+
+		[Fact]
+		public void MockSequenceVerifyLooseDoesNotVerifyInvocationsWithoutSequenceSetup()
+		{
+			var mock = new Mock<IFoo>();
+			var mocked = mock.Object;
+			var protectedMock = new Mock<Protected>();
+			var protectedAsMock = protectedMock.Protected().As<ProtectedLike>();
+
+			var protectedMocked = protectedMock.Object;
+			var mockSequence = new NewMockSequence(false, mock, protectedMock);
+			mockSequence.Setup(() => mock.Setup(m => m.Do(1)));
+			mocked.Do(1);
+			mocked.Do(2);
+
+			mockSequence.Verify();
+		}
+
+		internal class AMockSequence : MockSequenceBase<int>
+		{
+			public bool StrictFailure { get; set; }
+			public bool CallBaseForStrictFailure { get; set; }
+			public AMockSequence(bool strict, params Mock[] mocks) : base(strict, mocks) { }
+			public void Setup(Action setup,Func<ITrackedSetup<int>,int,int> setupCallback)
+			{
+				base.InterceptSetup(setup,setupCallback);
+			}
+
+			public List<(ITrackedSetup<int> trackedSetup, int executionOrder)> ConditionCalls = new List<(ITrackedSetup<int>, int)>();
+
+			protected override bool Condition(ITrackedSetup<int> trackedSetup, int invocationIndex)
+			{
+				ConditionCalls.Add((trackedSetup, invocationIndex));
+				return true;
+			}
+
+			internal List<TrackedSetup<int>> GetAllTrackedSetups()
+			{
+				return allTrackedSetups;
+			}
+
+			internal IReadOnlyList<ITrackedSetup<int>> GetTrackedSetups()
+			{
+				return TrackedSetups;
+			}
+			internal IReadOnlyList<ISequenceSetup<int>> GetSequenceSetups()
+			{
+				return SequenceSetups;
+			}
+
+			public bool InvocationsHaveMatchingSetups()
+			{
+				return base.InvocationsHaveMatchingSequenceSetup();
+			}
+
+			protected override void StrictnessFailure(IEnumerable<SequenceInvocation> unmatchedInvocations)
+			{
+				StrictFailure = true;
+				if (CallBaseForStrictFailure)
+				{
+					base.StrictnessFailure(unmatchedInvocations);
+				}
+			}
+
+			protected override void VerifyImpl()
+			{
+				throw new NotImplementedException();
+			}
+		}
+
+		public interface IHaveNested
+		{
+			INested ReturnNested(int arg);
+		}
+
+		public interface INested
+		{
+			int DoNested(int arg);
+		}
+
 		public interface IFoo
 		{
 			int Do(int arg);
+		}
+	
+		public abstract class Protected
+		{
+			protected abstract int ProtectedDo(int arg);
+			public int InvokeProtectedDo(int arg)
+			{
+				return ProtectedDo(arg);
+			}
+		}
+
+		public interface ProtectedLike
+		{
+			int ProtectedDo(int arg);
 		}
 	}
 }

--- a/tests/Moq.Tests/MockSequenceFixture.cs
+++ b/tests/Moq.Tests/MockSequenceFixture.cs
@@ -119,6 +119,22 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public void MockSequenceBaseShouldThrowIfNoMocksInConstructor()
+		{
+			var exception = Assert.Throws<ArgumentException>(() => new AMockSequence(false));
+			Assert.StartsWith("No mocks", exception.Message);
+		}
+
+		[Fact]
+		public void MockSequenceBaseShouldThrowIfSetupDoesNotSetup()
+		{
+			var mock = new Mock<IFoo>();
+			var sequence = new AMockSequence(false, mock);
+			var exception = Assert.Throws<ArgumentException>(() => sequence.Setup(() => { },_ => 1));
+			Assert.StartsWith("No setup performed", exception.Message);
+		}
+
+		[Fact]
 		public void MockSequenceBaseFindsSetupsFromActions()
 		{
 			var contextCounter = 0;
@@ -578,7 +594,7 @@ namespace Moq.Tests
 			});
 
 			verifiableSetup1.Verify();
-			Assert.Throws<SequenceVerificationException>(() => verifiableSetup2.Verify(Times.Once()));
+			Assert.Throws<SequenceException>(() => verifiableSetup2.Verify(Times.Once()));
 		}
 
 		[Fact]
@@ -599,7 +615,7 @@ namespace Moq.Tests
 			});
 
 			verifiableSetup1.VerifyAll(Times.Once());
-			Assert.Throws<SequenceVerificationException>(() => verifiableSetup2.VerifyAll());
+			Assert.Throws<SequenceException>(() => verifiableSetup2.VerifyAll());
 		}
 
 		[Fact]
@@ -691,8 +707,8 @@ namespace Moq.Tests
 			}
 
 			Setup();
-			var exception = Assert.Throws<SequenceException>(Setup);
-			Assert.Equal("Consecutive setups are the same", exception.Message);
+			var exception = Assert.Throws<ArgumentException>(Setup);
+			Assert.StartsWith("Consecutive setups are the same", exception.Message);
 		}
 
 		internal class AMockSequence : MockSequenceBase<int>


### PR DESCRIPTION
A base class that provides functionality for the concept of a mock sequence 

A new mock sequence type with the following behaviour

Captures invocations performed on the registered mocks to facilitate the concept of strict vs loose sequences.
Setups are performed on the mocks and not the sequence and you can now specify how many Times these "sequence setups" can have matching invocations.


Note that this implementation does not have the concept of Cyclic - lets discuss further.
When the invocations do not match the sequence an exception is thrown immediately and is not dependent on the MockBehavior of the mock with the matching setup. - let's discuss further.

Usage

```
var mock = new Mock<IFoo>();
var mocked = mock.Object;

var protectedMock = new Mock<Protected>();
var protectedAsMock = protectedMock.Protected().As<ProtectedLike>();
var protectedMocked = protectedMock.Object;

// loose sequence
var mockSequence = new NewMockSequence(false, mock, protectedMock);

// VerifiableSetup can be Verified - this will be worked on and may change and may be deemed unnecessary.
var verifiableSetup = mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times..AtLeast(1));
mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1))); // defaults to Times.Once()

//act - may throw exception

mockSequence.Verify()
```

How it works

Listens for changes to setups ( so no special code for protected mocks ) - adding a condition ( internal code change ) so that the sequence can be notified when setups are matched.
To faciliate using the same setup multiple times internal code changed so that "overridden" setups can be removed.

Listens for invocations on the registered mocks ( internal code change to register for additions - tbd behaviour change when invocations cleared )

Some internal information on Times has been surfaced internally to allow using Times in the context of a sequence.




