### PR TITLE
new mock sequence - for discussion

### DIFF
--- a/src/Moq/AsInterface.cs
+++ b/src/Moq/AsInterface.cs
@@ -25,6 +25,11 @@ namespace Moq
 
 		internal override InvocationCollection MutableInvocations => this.owner.MutableInvocations;
 
+		internal override void AddInvocationListener(Action<Invocation> listener)
+		{
+			owner.AddInvocationListener(listener);
+		}
+
 		internal override bool IsObjectInitialized => this.owner.IsObjectInitialized;
 
 		internal override Type MockedType => this.owner.MockedType;

--- a/src/Moq/InvocationCollection.cs
+++ b/src/Moq/InvocationCollection.cs
@@ -65,6 +65,7 @@ namespace Moq
 
 				this.invocations[this.count] = invocation;
 				this.count++;
+				owner.AddedInvocation(invocation);
 			}
 		}
 

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -45,6 +45,11 @@ namespace Moq
 			get => this.failMessage;
 		}
 
+		internal void SetCondition(Condition condition)
+		{
+			this.condition = condition;
+		}
+
 		public override Condition Condition => this.condition;
 
 		private static string GetUserCodeCallSite()

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -192,6 +192,21 @@ namespace Moq
 
 		internal abstract InvocationCollection MutableInvocations { get; }
 
+		private readonly List<Action<Invocation>> invocationListeners = new List<Action<Invocation>>();
+
+		internal virtual void AddInvocationListener(Action<Invocation> listener)
+		{
+			invocationListeners.Add(listener);
+		}
+
+		internal virtual void AddedInvocation(Invocation invocation)
+		{
+			foreach(var listener in invocationListeners)
+			{
+				listener(invocation);
+			}
+		}
+
 		/// <summary>
 		///   Returns the mocked object value.
 		/// </summary>

--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -123,12 +123,7 @@
 
 	<Target Name="Test" />
 
-	<Target Name="UpdatePackageMetadata"
-          BeforeTargets="PrepareForBuild;GetAssemblyVersion;GenerateNuspec;Pack"
-          DependsOnTargets="InitializeSourceControlInformation"
-          Condition="'$(SourceControlInformationFeatureSupported)' And
-                     '$(RepositoryUrl)' != '' And 
-                     '$(SourceRevisionId)' != ''">
+	<Target Name="UpdatePackageMetadata" BeforeTargets="PrepareForBuild;GetAssemblyVersion;GenerateNuspec;Pack" DependsOnTargets="InitializeSourceControlInformation" Condition="'$(SourceControlInformationFeatureSupported)' And&#xD;&#xA;                     '$(RepositoryUrl)' != '' And &#xD;&#xA;                     '$(SourceRevisionId)' != ''">
 		<PropertyGroup>
 			<Description>$(Description)
 

--- a/src/Moq/NewMockSequence/Base/ISequenceInvocation.cs
+++ b/src/Moq/NewMockSequence/Base/ISequenceInvocation.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+namespace Moq
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	public interface ISequenceInvocation
+	{
+		/// <summary>
+		/// 
+		/// </summary>
+		IInvocation Invocation { get; }
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		Mock Mock { get; }
+	}
+}

--- a/src/Moq/NewMockSequence/Base/InvocationShapeSetupsBase.cs
+++ b/src/Moq/NewMockSequence/Base/InvocationShapeSetupsBase.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.Collections.Generic;
+
+namespace Moq
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	/// <typeparam name="TSequenceSetup"></typeparam>
+	public abstract class InvocationShapeSetupsBase<TSequenceSetup> where TSequenceSetup : SequenceSetupBase
+	{
+		private readonly List<TSequenceSetup> sequenceSetupsInternal = new List<TSequenceSetup>();
+
+		/// <summary>
+		/// 
+		/// </summary>
+		protected IReadOnlyList<TSequenceSetup> SequenceSetups => sequenceSetupsInternal;
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="sequenceSetup"></param>
+		public InvocationShapeSetupsBase(TSequenceSetup sequenceSetup)
+		{
+			sequenceSetupsInternal.Add(sequenceSetup);
+			InvocationShape = sequenceSetup.SetupInternal.Expectation;
+			sequenceSetup.InvocationShapeSetupsObject = this;
+		}
+		
+		internal void AddSequenceSetup(TSequenceSetup sequenceSetup)
+		{
+			sequenceSetupsInternal.Add(sequenceSetup);
+			sequenceSetup.InvocationShapeSetupsObject = this;
+		}
+		internal InvocationShape InvocationShape { get; }
+	}
+
+}

--- a/src/Moq/NewMockSequence/Base/MockSequenceBase.cs
+++ b/src/Moq/NewMockSequence/Base/MockSequenceBase.cs
@@ -1,0 +1,204 @@
+﻿// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Moq
+{
+
+	/// <summary>
+	/// 
+	/// </summary>     
+	public abstract class MockSequenceBase<TSequenceSetup, TInvocationShapeSetups> 
+		where TSequenceSetup : SequenceSetupBase 
+		where  TInvocationShapeSetups : InvocationShapeSetupsBase<TSequenceSetup>
+	{
+		private int setupCount = -1;
+		private readonly Mock[] mocks;
+		private readonly SequenceInvocationListener sequenceInvocationListener;
+		private readonly List<Setup> allSetups = new List<Setup>();
+		private readonly List< TInvocationShapeSetups> allInvocationShapeSetups = new List< TInvocationShapeSetups>();
+		private readonly List<TSequenceSetup> sequenceSetups = new List<TSequenceSetup>();
+		/// <summary>
+		/// 
+		/// </summary>
+		protected readonly bool strict;
+		/// <summary>
+		/// 
+		/// </summary>
+		protected IReadOnlyList<TSequenceSetup> SequenceSetups => sequenceSetups;
+
+		internal List<SequenceInvocation> SequenceInvocations => sequenceInvocationListener.SequenceInvocations;
+		internal IReadOnlyList<ISetup> AllSetups => allSetups;
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="strict"></param>
+		/// <param name="mocks"></param>
+		public MockSequenceBase(bool strict,params Mock[] mocks)
+		{
+			if(mocks.Length == 0)
+			{
+				throw new ArgumentException("No mocks", nameof(mocks));
+			}
+			this.mocks = mocks;
+			this.strict = strict;
+			sequenceInvocationListener = new SequenceInvocationListener(mocks);
+			sequenceInvocationListener.NewInvocationEvent += SequenceInvocationListener_NewInvocationEvent;
+			sequenceInvocationListener.ListenForInvocations();
+		}
+
+		// todo - for MockAs get duplicate events
+		private void SequenceInvocationListener_NewInvocationEvent(object sender, SequenceInvocation sequenceInvocation)
+		{
+			var invocation = sequenceInvocation.InvocationInternal;
+
+			var noMatch = !allSetups.Any(setup =>
+				{
+					var isMatch = false;
+					// second condition for mock.As
+					if (setup.Mock == sequenceInvocation.Mock || setup.Mock.MutableSetups == sequenceInvocation.Mock.MutableSetups)
+					{
+						isMatch = setup.Expectation.IsMatch(invocation);
+					}
+					return isMatch;
+				});
+			if (noMatch)
+			{
+				if (strict)
+				{
+					StrictnessFailure(sequenceInvocation);
+				}
+				
+			}
+			
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="setup"></param>
+		/// <param name="sequenceSetupCallback"></param>
+		protected void InterceptSetup(Action setup, Action<TSequenceSetup> sequenceSetupCallback)
+		{
+			setupCount++;
+			List<List<SetupWithDepth>> allSetupsBefore = mocks.Select(m => SetupFinder.GetAllSetups(m)).ToList();
+			setup();
+			List<List<SetupWithDepth>> allSetupsAfter = mocks.Select(m => SetupFinder.GetAllSetups(m)).ToList();
+			for(var i = 0; i < allSetupsBefore.Count; i++)
+			{
+				var result = allSetupsBefore[i].NewSetups(allSetupsAfter[i]);
+				if (!result.NoChange)
+				{
+					allSetups.AddRange(result.NewSetups.Select(sd => sd.Setup));
+					sequenceInvocationListener.ListenForInvocations(result.NewSetups.Select(s => s.Setup.Mock));
+					var terminalSetup = result.TerminalSetup.Setup;
+
+					var sequenceSetup = CreateSequenceSetup(terminalSetup);
+					InitializeSequenceSetup(sequenceSetup);
+					sequenceSetupCallback(sequenceSetup);
+
+					return;
+				}
+
+			}
+
+			throw new ArgumentException("No setup performed",nameof(setup));
+		}
+		
+		private void InitializeSequenceSetup(TSequenceSetup sequenceSetup)
+		{
+			sequenceSetups.Add(sequenceSetup);
+			ApplyInvocationShapeSetups(sequenceSetup);
+			SetCondition(sequenceSetup, sequenceSetup.SetupInternal);
+
+		}
+		
+		private TSequenceSetup CreateSequenceSetup(Setup setup)
+		{
+			var sequenceSetup = (TSequenceSetup)Activator.CreateInstance(typeof(TSequenceSetup));
+			sequenceSetup.SetupIndex = setupCount;
+			sequenceSetup.SetupInternal = setup;
+			
+			return sequenceSetup;
+		}
+
+		private void ApplyInvocationShapeSetups(TSequenceSetup newSequenceSetup)
+		{
+			var invocationShape = newSequenceSetup.SetupInternal.Expectation;
+			var invocationShapeSetups = allInvocationShapeSetups.SingleOrDefault(ts => ts.InvocationShape.Equals(invocationShape));
+			if (invocationShapeSetups == null)
+			{
+				invocationShapeSetups = (TInvocationShapeSetups) Activator.CreateInstance(typeof( TInvocationShapeSetups),newSequenceSetup);
+				allInvocationShapeSetups.Add(invocationShapeSetups);
+			}
+			else
+			{
+				invocationShapeSetups.AddSequenceSetup(newSequenceSetup);
+			}
+
+		}
+
+		private void SetCondition(TSequenceSetup sequenceSetup,ISetup setup)
+		{
+			if (setup is MethodCall methodCall)
+			{
+				methodCall.SetCondition(
+					new Condition(() =>
+					{
+						return Condition(sequenceSetup);
+					},
+					() =>
+					{
+						SetupExecuted(sequenceSetup);
+					})
+				);
+			}
+			else
+			{
+				throw new Exception("todo");//todo
+			}
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="unmatchedInvocation"></param>
+		protected virtual void StrictnessFailure(ISequenceInvocation unmatchedInvocation)
+		{
+			throw new StrictSequenceException($"Invocation without sequence setup. {unmatchedInvocation.Invocation}") { UnmatchedInvocation = unmatchedInvocation };
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="sequenceSetup"></param>
+		/// <returns></returns>
+		protected abstract bool Condition(TSequenceSetup sequenceSetup);
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="sequenceSetup"></param>
+		protected virtual void SetupExecuted(TSequenceSetup sequenceSetup)
+		{
+
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		public void VerifyNoOtherCalls()
+		{
+			var invocationsWithoutSequenceSetup = SequenceInvocations.Where(si => si.Invocation.MatchingSetup == null).ToList();
+			if (invocationsWithoutSequenceSetup.Count > 0)
+			{
+				throw new SequenceException($"Expected no invocations without sequence setup but found {invocationsWithoutSequenceSetup.Count}");
+			}
+		}
+	}
+
+}

--- a/src/Moq/NewMockSequence/Base/NewSetupsExtensions.cs
+++ b/src/Moq/NewMockSequence/Base/NewSetupsExtensions.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Moq
+{
+	internal static class NewSetupsExtensions
+	{
+		public class NewSetupsResult
+		{
+			public bool NoChange { get; set; }
+			public List<SetupWithDepth> NewSetups { get; set; }
+			public SetupWithDepth TerminalSetup { get; set; }
+		}
+
+		public static NewSetupsResult NewSetups(this List<SetupWithDepth> before, List<SetupWithDepth> after)
+		{
+			if (after.Count == before.Count)
+			{
+				return new NewSetupsResult { NoChange = true };
+			}
+
+			var difference = after.Except(before, EqualityComparer<SetupWithDepth>.Default);
+			var orderedByDepth = difference.OrderBy(sd => sd.Depth).ToList();
+			var terminalSetup = orderedByDepth.Last();
+			return new NewSetupsResult
+			{
+				NewSetups = orderedByDepth,
+				TerminalSetup = terminalSetup
+			};
+		}
+	}
+
+}

--- a/src/Moq/NewMockSequence/Base/SequenceException.cs
+++ b/src/Moq/NewMockSequence/Base/SequenceException.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+
+namespace Moq
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	public partial class SequenceException : Exception
+	{
+		internal SequenceException() { }
+		internal SequenceException(string message) : base(message) { }
+	}
+
+}

--- a/src/Moq/NewMockSequence/Base/SequenceInvocation.cs
+++ b/src/Moq/NewMockSequence/Base/SequenceInvocation.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+namespace Moq
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	internal class SequenceInvocation : ISequenceInvocation
+	{
+		public SequenceInvocation(Mock mock, Invocation invocation)
+		{
+			Mock = mock;
+			InvocationInternal = invocation;
+
+		}
+		/// <summary>
+		/// 
+		/// </summary>
+		public Mock Mock { get; }
+		/// <summary>
+		/// 
+		/// </summary>
+		public IInvocation Invocation => InvocationInternal;
+
+		public Invocation InvocationInternal { get; }
+	}
+
+}

--- a/src/Moq/NewMockSequence/Base/SequenceInvocationListener.cs
+++ b/src/Moq/NewMockSequence/Base/SequenceInvocationListener.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Moq
+{
+	internal class SequenceInvocationListener
+	{
+		public event EventHandler<SequenceInvocation> NewInvocationEvent;
+		private readonly List<Mock> listenedToMocks = new List<Mock>();
+		private readonly Mock[] mocks;
+		internal List<SequenceInvocation> SequenceInvocations { get; } = new List<SequenceInvocation>();
+
+		public SequenceInvocationListener(Mock[] mocks)
+		{
+			this.mocks = mocks;
+		}
+
+		internal void ListenForInvocations()
+		{
+			ListenForInvocations(mocks);
+		}
+
+		internal void ListenForInvocations(IEnumerable<Mock> mocks)
+		{
+			foreach (var mock in mocks)
+			{
+				ListenForInvocation(mock);
+			}
+		}
+
+		private void ListenForInvocation(Mock mock)
+		{
+			ListenForInvocations(mock.MutableSetups.Where(s => s.InnerMock != null).Select(s => s.InnerMock));
+			if (!listenedToMocks.Contains(mock))
+			{
+				mock.AddInvocationListener(invocation => NewInvocation(new SequenceInvocation(mock, invocation)));
+				listenedToMocks.Add(mock);
+			}
+		}
+
+		private void NewInvocation(SequenceInvocation sequenceInvocation)
+		{
+			SequenceInvocations.Add(sequenceInvocation);
+			NewInvocationEvent?.Invoke(this, sequenceInvocation);
+
+		}
+
+	}
+
+}

--- a/src/Moq/NewMockSequence/Base/SequenceSetupBase.cs
+++ b/src/Moq/NewMockSequence/Base/SequenceSetupBase.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+namespace Moq
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	public abstract class SequenceSetupBase
+	{
+		/// <summary>
+		/// 
+		/// </summary>
+		protected internal object InvocationShapeSetupsObject { get; set; }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		public int SetupIndex { get; set; }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		public ISetup Setup => SetupInternal;
+		internal Setup SetupInternal { get; set; }
+
+	}
+
+}

--- a/src/Moq/NewMockSequence/Base/SetupFinder.cs
+++ b/src/Moq/NewMockSequence/Base/SetupFinder.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Moq
+{
+	internal class SetupWithDepth : IEquatable<SetupWithDepth>
+	{
+		public int Depth { get; set; }
+		public Setup Setup { get; set; }
+		public SetupCollection ContainingMutableSetups { get; set; }
+
+		public bool Equals(SetupWithDepth other)
+		{
+			return Setup == other.Setup;
+		}
+
+		public override int GetHashCode()
+		{
+			return Setup.GetHashCode();
+		}
+
+	}
+
+	internal static class SetupFinder
+	{
+		private static void GetAllSetups(SetupCollection setups, List<SetupWithDepth> setupsWithDepth, int depth)
+		{
+			setupsWithDepth.AddRange(setups.ToArray().Select(s => new SetupWithDepth { Depth = depth, Setup = s, ContainingMutableSetups = setups }));
+			foreach (var setup in setups)
+			{
+				if (setup.InnerMock != null)
+				{
+					GetAllSetups(setup.InnerMock.MutableSetups, setupsWithDepth, depth + 1);
+				}
+			}
+		}
+		private static void GetAllSetups(SetupCollection setups, List<SetupWithDepth> setupsWithDepth)
+		{
+			GetAllSetups(setups, setupsWithDepth, 0);
+		}
+		public static List<SetupWithDepth> GetAllSetups(Mock mock)
+		{
+			var setupsWithDepth = new List<SetupWithDepth>();
+			GetAllSetups(mock.MutableSetups, setupsWithDepth);
+			return setupsWithDepth;
+		}
+	}
+
+}

--- a/src/Moq/NewMockSequence/Base/StrictSequenceException.cs
+++ b/src/Moq/NewMockSequence/Base/StrictSequenceException.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.Collections.Generic;
+
+namespace Moq
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	public class StrictSequenceException : SequenceException
+	{
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="message"></param>
+		public StrictSequenceException(string message) : base(message) { }
+		/// <summary>
+		/// 
+		/// </summary>
+		public ISequenceInvocation UnmatchedInvocation { get; set; }
+	}
+
+}

--- a/src/Moq/NewMockSequence/CyclicalInvocationShapeSetups.cs
+++ b/src/Moq/NewMockSequence/CyclicalInvocationShapeSetups.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Moq
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	public class CyclicalInvocationShapeSetups : InvocationShapeSetupsBase<CyclicalTimesSequenceSetup>
+	{
+		internal IEnumerable<CyclicalTimesSequenceSetup> MockSequenceSetups => SequenceSetups;
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="sequenceSetup"></param>
+		public CyclicalInvocationShapeSetups(CyclicalTimesSequenceSetup sequenceSetup) : base(sequenceSetup) { }
+		
+		internal CyclicalTimesSequenceSetup TryGetNextConsecutiveInvocationShapeSetup(int relativeTo,bool cyclic,int totalSetups)
+		{
+			var isLast = relativeTo == totalSetups - 1;
+			if (isLast)
+			{
+				if (cyclic)
+				{
+					return SequenceSetups.SingleOrDefault(s => s.SetupIndex == 0);
+				}
+				return null;
+			}
+
+			return SequenceSetups.SingleOrDefault(s => s.SetupIndex == relativeTo + 1);
+		}
+
+		internal int TotalExecutions()
+		{
+			return SequenceSetups.Sum(ss => ss.TotalExecutionCount);
+		}
+
+		// first that comes after or the first setup
+		internal int GetNextSequenceSetupIndex(int currentSetupIndex)
+		{
+			int firstSequenceSetupIndex = -1;
+			int nextSequenceSetupIndex = -1;
+			foreach (var sequenceSetup in SequenceSetups)
+			{
+				var sequenceSetupIndex = sequenceSetup.SetupIndex;
+				if (firstSequenceSetupIndex == -1)
+				{
+					firstSequenceSetupIndex = sequenceSetupIndex;
+				}
+				if (sequenceSetupIndex > currentSetupIndex)
+				{
+					nextSequenceSetupIndex = sequenceSetupIndex;
+					break;
+				}
+			}
+
+			if (nextSequenceSetupIndex != -1)
+			{
+				return nextSequenceSetupIndex;
+			}
+			return firstSequenceSetupIndex;
+		}
+	}
+
+}

--- a/src/Moq/NewMockSequence/CyclicalTimesSequenceSetup.cs
+++ b/src/Moq/NewMockSequence/CyclicalTimesSequenceSetup.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+
+namespace Moq
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	public class CyclicalTimesSequenceSetup : SequenceSetupBase
+	{
+		private int executionCount;
+		private List<int> completedCyclicalExecutionCount = new List<int>();
+		internal int ExecutionCount
+		{
+			get
+			{
+				return executionCount;
+			}
+		}
+
+		
+		internal IReadOnlyList<int> CompletedCyclicalExecutionCount => completedCyclicalExecutionCount;
+
+		internal Times Times { get; set; }
+
+		internal int TotalExecutionCount { get; set; }
+
+		internal CyclicalInvocationShapeSetups InvocationShapeSetups { get => (CyclicalInvocationShapeSetups)InvocationShapeSetupsObject; }
+
+		internal void Executed()
+		{
+			executionCount++;
+			TotalExecutionCount++;
+		}
+
+		internal CyclicalTimesSequenceSetup TryGetNextConsecutiveInvocationShapeSetup(bool cyclic,int totalSetups)
+		{
+			return InvocationShapeSetups.TryGetNextConsecutiveInvocationShapeSetup(this.SetupIndex,cyclic,totalSetups);
+		}
+
+		internal int GetNextSequenceSetupIndex(int currentSetupIndex)
+		{
+			return this.InvocationShapeSetups.GetNextSequenceSetupIndex(currentSetupIndex);
+		}
+
+		internal void ResetForCyclical()
+		{
+			completedCyclicalExecutionCount.Add(executionCount);
+			executionCount = 0;
+		}
+	}
+
+}

--- a/src/Moq/NewMockSequence/NewMockSequence.cs
+++ b/src/Moq/NewMockSequence/NewMockSequence.cs
@@ -1,0 +1,275 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Moq
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	public sealed class NewMockSequence : MockSequenceBase<CyclicalTimesSequenceSetup, CyclicalInvocationShapeSetups>
+	{
+		private int currentSequenceSetupIndex;
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		public bool Cyclical { get; set; }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <returns></returns>
+		public static Times OptionalTimes()
+		{
+			return Times.Between(0, int.MaxValue, Range.Inclusive);
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="strict"></param>
+		/// <param name="mocks"></param>
+		public NewMockSequence(bool strict, params Mock[] mocks) : base(strict, mocks) { }
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="setup"></param>
+		/// <param name="times"></param>
+		/// <returns></returns>
+		public VerifiableSetup Setup(Action setup, Times? times = null)
+		{
+			Times t = times ?? Times.Once();
+			VerifiableSetup verifiableSetup = null;
+			base.InterceptSetup(setup, (sequenceSetup) =>
+			{
+				sequenceSetup.Times = t;
+				verifiableSetup = new VerifiableSetup(sequenceSetup);
+			});
+			return verifiableSetup;
+		}
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="sequenceSetup"></param>
+		/// <returns></returns>
+		protected override bool Condition(CyclicalTimesSequenceSetup sequenceSetup)
+		{
+			var condition = true;
+			var currentSequenceSetup = SequenceSetups[currentSequenceSetupIndex];
+
+			if (currentSequenceSetup.InvocationShapeSetups == sequenceSetup.InvocationShapeSetups)
+			{
+				if (currentSequenceSetup == sequenceSetup)
+				{
+					CurrentSequenceSetupInvoked();
+				}
+				else
+				{
+					return false; // the one we are interested in will come along soon
+				}
+			}
+			else
+			{
+				ConfirmSequenceSetupSatisfied(currentSequenceSetup);
+
+				// first ( of common ) that comes after or the first setup
+				var nextSequenceSetupIndex = sequenceSetup.GetNextSequenceSetupIndex(currentSequenceSetupIndex);
+				if (nextSequenceSetupIndex != sequenceSetup.SetupIndex)
+				{
+					return false; // there will be another along
+				}
+
+				if (nextSequenceSetupIndex > currentSequenceSetupIndex)
+				{
+					ConfirmSequenceSetupsOptionalFromCurrentToExclusive(nextSequenceSetupIndex);
+					currentSequenceSetupIndex = nextSequenceSetupIndex;
+					CurrentSequenceSetupInvoked();
+				}
+				else
+				{
+					condition = SequenceSetupBeforeCurrentInvoked(sequenceSetup);
+				}
+			}
+
+			return condition;
+		}
+
+		private void CurrentSequenceSetupInvoked()
+		{
+			var currentSequenceSetup = SequenceSetups[currentSequenceSetupIndex];
+			currentSequenceSetup.Executed();
+
+			var times = currentSequenceSetup.Times;
+			times.Deconstruct(out int from, out int to);
+			var kind = times.GetKind();
+
+			ThrowForBadTimes(times, from, to, currentSequenceSetup);
+			TryMoveToConsecutiveForApplicableTimes(kind, from, to, currentSequenceSetup);
+		}
+
+		private void ThrowForBadTimes(Times times, int from, int to, CyclicalTimesSequenceSetup currentSequenceSetup)
+		{
+			var shouldThrow = false;
+			var kind = times.GetKind();
+			switch (kind)
+			{
+				case Times.Kind.Never:
+					shouldThrow = true;
+					break;
+				case Times.Kind.Exactly:
+				case Times.Kind.Once:
+					shouldThrow = currentSequenceSetup.ExecutionCount > from;
+					break;
+				case Times.Kind.AtLeast:
+				case Times.Kind.AtLeastOnce:
+					break;
+				case Times.Kind.AtMost:
+				case Times.Kind.AtMostOnce:
+					shouldThrow = !currentSequenceSetup.Times.Validate(currentSequenceSetup.ExecutionCount);
+					break;
+				case Times.Kind.BetweenExclusive:
+				case Times.Kind.BetweenInclusive:
+					if (currentSequenceSetup.ExecutionCount > to)
+					{
+						shouldThrow = true;
+					}
+					break;
+			}
+
+			if (shouldThrow)
+			{
+				throw new SequenceException(times, currentSequenceSetup.ExecutionCount, currentSequenceSetup.Setup);
+			}
+		}
+
+		private void TryMoveToConsecutiveForApplicableTimes(Times.Kind kind, int from, int to, CyclicalTimesSequenceSetup sequenceSetup)
+		{
+			var shouldTryMoveToConsecutive = false;
+			var executionCount = sequenceSetup.ExecutionCount;
+			switch (kind)
+			{
+				case Times.Kind.Exactly:
+				case Times.Kind.Once:
+				case Times.Kind.AtLeast:
+				case Times.Kind.AtLeastOnce:
+					shouldTryMoveToConsecutive = from == executionCount;
+					break;
+				case Times.Kind.AtMost:
+				case Times.Kind.AtMostOnce:
+					shouldTryMoveToConsecutive = to == executionCount;
+					break;
+			}
+
+			if (shouldTryMoveToConsecutive)
+			{
+				TryMoveToConsecutive(sequenceSetup);
+			}
+		}
+
+		private bool TryMoveToConsecutive(CyclicalTimesSequenceSetup sequenceSetup)
+		{
+			var nextConsecutiveInvocationShapeSetup = sequenceSetup.TryGetNextConsecutiveInvocationShapeSetup(Cyclical, SequenceSetups.Count);
+			if (nextConsecutiveInvocationShapeSetup != null)
+			{
+				currentSequenceSetupIndex = nextConsecutiveInvocationShapeSetup.SetupIndex;
+				if (currentSequenceSetupIndex == 0)
+				{
+					ResetForCyclical();
+				}
+				return true;
+			}
+			return false;
+		}
+
+		private void ConfirmSequenceSetupSatisfied(CyclicalTimesSequenceSetup sequenceSetup)
+		{
+			var times = sequenceSetup.Times;
+			var kind = times.GetKind();
+			switch (kind)
+			{
+				case Times.Kind.Never:
+				case Times.Kind.AtMost:
+				case Times.Kind.AtMostOnce:
+					break;
+				case Times.Kind.Exactly:
+				case Times.Kind.Once:
+				case Times.Kind.BetweenExclusive:
+				case Times.Kind.BetweenInclusive:
+				case Times.Kind.AtLeast:
+				case Times.Kind.AtLeastOnce:
+					if (!times.Validate(sequenceSetup.ExecutionCount))
+					{
+						throw new SequenceException(times,sequenceSetup.ExecutionCount,sequenceSetup.Setup);
+					}
+					break;
+			}
+		}
+
+		private void ConfirmSequenceSetupsOptionalFromCurrentToExclusive(int upToIndex)
+		{
+			for (var i = currentSequenceSetupIndex + 1; i < upToIndex; i++)
+			{
+				ConfirmSequenceSetupSatisfied(SequenceSetups[i]);
+			}
+		}
+
+		private bool SequenceSetupBeforeCurrentInvoked(CyclicalTimesSequenceSetup newSequenceSetup)
+		{
+			if (Cyclical)
+			{
+				ConfirmRemainingSequenceSetupsOptional();
+				ResetForCyclical();
+				ConfirmPreviousSequenceSetupsOptional(newSequenceSetup.SetupIndex);
+				currentSequenceSetupIndex = newSequenceSetup.SetupIndex;
+				CurrentSequenceSetupInvoked();
+			}
+			else
+			{
+				if (strict) // to be determined
+				{
+					var unmatchedInvocation = SequenceInvocations.Last();
+					throw new StrictSequenceException($"Cyclical invocation but not cyclic. {newSequenceSetup.Setup}") { UnmatchedInvocation = unmatchedInvocation };
+				}
+			}
+
+			return true;
+		}
+
+		private void ConfirmRemainingSequenceSetupsOptional()
+		{
+			ConfirmSequenceSetupsOptionalFromCurrentToExclusive(SequenceSetups.Count);
+		}
+
+		private void ConfirmPreviousSequenceSetupsOptional(int upToIndex)
+		{
+			for (var i = 0; i < upToIndex; i++)
+			{
+				ConfirmSequenceSetupSatisfied(SequenceSetups[i]);
+			}
+		}
+		
+		private void ResetForCyclical()
+		{
+			foreach (var sequenceSetup in SequenceSetups)
+			{
+				sequenceSetup.ResetForCyclical();
+			}
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		public void Verify()
+		{
+			for (var i = currentSequenceSetupIndex; i < SequenceSetups.Count; i++)
+			{
+				ConfirmSequenceSetupSatisfied(SequenceSetups[i]);
+			}
+		}
+	}
+}

--- a/src/Moq/NewMockSequence/SequenceException.cs
+++ b/src/Moq/NewMockSequence/SequenceException.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Moq
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	public partial class SequenceException : Exception
+	{
+		internal SequenceException(Times times, int executedCount, ISetup setup) : 
+			base($"{times.GetExceptionMessage(executedCount)}{(setup == null ? "" : $"{setup}")}") { }
+	}
+
+}

--- a/src/Moq/NewMockSequence/VerifiableSetup.cs
+++ b/src/Moq/NewMockSequence/VerifiableSetup.cs
@@ -1,0 +1,145 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Moq
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	public class VerifiableSetup
+	{
+		private CyclicalTimesSequenceSetup sequenceSetup;
+
+		/// <summary>
+		/// 
+		/// </summary>
+		internal IReadOnlyList<int> CyclicalExecutionCount
+		{
+			get
+			{
+				var cyclicalExecutionCount = new List<int>(sequenceSetup.CompletedCyclicalExecutionCount);
+				cyclicalExecutionCount.Add(sequenceSetup.ExecutionCount);
+				return cyclicalExecutionCount;
+			}
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="sequenceSetup"></param>
+		internal VerifiableSetup(CyclicalTimesSequenceSetup sequenceSetup)
+		{
+			this.sequenceSetup = sequenceSetup;
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		public void Verify()
+		{
+			VerifySequenceSetup(sequenceSetup);
+		}
+
+		private void VerifySequenceSetup(CyclicalTimesSequenceSetup sequenceSetup)
+		{
+			Verify(sequenceSetup.Times, sequenceSetup.ExecutionCount, sequenceSetup.Setup);
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="times"></param>
+		public void Verify(Times times)
+		{
+			Verify(times, sequenceSetup.TotalExecutionCount, sequenceSetup.Setup);
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="times"></param>
+		public void Verify(int times)
+		{
+			Verify(Times.Exactly(times));
+		}
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		public void VerifyAll()
+		{
+			foreach (var sequenceSetup in sequenceSetup.InvocationShapeSetups.MockSequenceSetups)
+			{
+				VerifySequenceSetup(sequenceSetup);
+			}
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="times"></param>
+		public void VerifyAll(Times times)
+		{
+			Verify(times, sequenceSetup.InvocationShapeSetups.TotalExecutions());
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="times"></param>
+		public void VerifyAll(int times)
+		{
+			VerifyAll(Times.Exactly(times));
+		}
+
+		private void Verify(Times times, int executionCount, ISetup setup = null)
+		{
+			var success = times.Validate(executionCount);
+			if (!success)
+			{
+				throw new SequenceException(times, executionCount, setup);
+			}
+		}
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="cyclicalTimes"></param>
+		public void VerifyCyclical(IEnumerable<int> cyclicalTimes)
+		{
+			VerifyCyclical(cyclicalTimes.Select(i => Times.Exactly(i)));
+		}
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="cyclicalTimes"></param>
+		public void VerifyCyclical(IEnumerable<Times> cyclicalTimes)
+		{
+			var count = 0;
+			List<Times> cyclicalTimesList = cyclicalTimes.ToList();
+			var expectedCycles = cyclicalTimesList.Count;
+			var actualCycles = CyclicalExecutionCount.Count;
+			AssertNumberOfCycles(actualCycles, expectedCycles);
+			
+			foreach (var cyclicalTime in cyclicalTimes)
+			{
+				var actual = CyclicalExecutionCount[count];
+				if (!cyclicalTime.Validate(actual))
+				{
+					throw new SequenceException($"On cycle {count}. {cyclicalTime.GetExceptionMessage(actual)}");
+				}
+				count++;
+			}
+		}
+
+		private void AssertNumberOfCycles(int actualCycles, int expectedCycles)
+		{
+			if (actualCycles != expectedCycles)
+			{
+				throw new SequenceException($"Expected cycles {expectedCycles} but was {actualCycles}");
+			}
+		}
+	}
+
+}

--- a/src/Moq/Times.cs
+++ b/src/Moq/Times.cs
@@ -18,6 +18,10 @@ namespace Moq
 		private readonly int from;
 		private readonly int to;
 		private readonly Kind kind;
+		internal Kind GetKind()
+		{
+			return kind;
+		}
 
 		private Times(Kind kind, int from, int to)
 		{
@@ -297,7 +301,7 @@ namespace Moq
 			return from <= count && count <= to;
 		}
 
-		private enum Kind
+		internal enum Kind
 		{
 			AtLeastOnce,
 			AtLeast,

--- a/tests/Moq.Tests/NewMockSequenceFixture.cs
+++ b/tests/Moq.Tests/NewMockSequenceFixture.cs
@@ -1,0 +1,1104 @@
+﻿// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using Moq.Protected;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Moq.Tests
+{
+	public class NewMockSequenceFixture
+	{
+		[Fact]
+		public void MockSequenceBaseShouldThrowIfNoMocksInConstructor()
+		{
+			var exception = Assert.Throws<ArgumentException>(() => new AMockSequence(false));
+			Assert.StartsWith("No mocks", exception.Message);
+		}
+
+		[Fact]
+		public void MockSequenceBaseShouldThrowIfSetupDoesNotSetup()
+		{
+			var mock = new Mock<IFoo>();
+			var sequence = new AMockSequence(false, mock);
+			var exception = Assert.Throws<ArgumentException>(() => sequence.Setup(() => { }));
+			Assert.StartsWith("No setup performed", exception.Message);
+		}
+
+		[Fact]
+		public void MockSequenceBaseFindsSetupsFromActions()
+		{
+			var mock = new Mock<IFoo>();
+			var nestedMock = new Mock<IHaveNested>();
+			var aMockSequence = new AMockSequence(false, mock, nestedMock);
+			DefaultInvocationShapeSetups invocationShapeSetups = null;
+			DefaultSequenceSetup sequenceSetupFromAction = null;
+			int setupIndex = -1;
+			Action<DefaultSequenceSetup> callback = (sequenceSetup) =>
+			{
+				sequenceSetupFromAction = sequenceSetup;
+				invocationShapeSetups = sequenceSetup.InvocationShapeSetups;
+				setupIndex = sequenceSetup.SetupIndex;
+			};
+			aMockSequence.Setup(() => mock.Setup(f => f.Do(1)), callback);
+			Assert.Equal(0, setupIndex);
+			Assert.Equal("NewMockSequenceFixture.IFoo f => f.Do(1)", sequenceSetupFromAction.Setup.ToString());
+			var commonSequenceSetups = invocationShapeSetups.GetSequenceSetups();
+			Assert.Single(commonSequenceSetups);
+			Assert.Same(sequenceSetupFromAction, commonSequenceSetups[0]);
+
+
+			var repeatedInvocationShapeSetups = invocationShapeSetups;
+
+			// callback for terminal setups
+			aMockSequence.Setup(() =>
+			{
+				nestedMock.Setup(n => n.ReturnNested(1).DoNested(1));
+			}, callback);
+			Assert.Equal(1, setupIndex);
+			Assert.Equal("NewMockSequenceFixture.INested ... => ....DoNested(1)", sequenceSetupFromAction.Setup.ToString());
+			// captures all setups
+			Assert.Equal(3, aMockSequence.AllSetups.Count);
+			var sequenceSetups = aMockSequence.GetSequenceSetups();
+			Assert.Equal(2, sequenceSetups.Count);
+			Assert.Same(sequenceSetupFromAction, sequenceSetups[1]);
+			Assert.NotSame(repeatedInvocationShapeSetups, invocationShapeSetups);
+
+			//repeatedSetup
+			aMockSequence.Setup(() => mock.Setup(f => f.Do(1)), callback);
+			Assert.Equal(2, setupIndex);
+			Assert.Same(repeatedInvocationShapeSetups, invocationShapeSetups);
+			Assert.Same(sequenceSetupFromAction, invocationShapeSetups.GetSequenceSetups()[1]);
+
+		}
+
+		[Fact]
+		public void MockSequenceBaseFindsProtectedAsMockSetups()
+		{
+			var mock = new Mock<Protected>();
+			var protectedAsMock = mock.Protected().As<ProtectedLike>();
+			var aMockSequence = new AMockSequence(false, mock);
+			DefaultSequenceSetup sequenceSetup = null;
+			aMockSequence.Setup(() => protectedAsMock.Setup(m => m.ProtectedDo(1)), s => sequenceSetup = s);
+			Assert.Equal("NewMockSequenceFixture.Protected m => m.ProtectedDo(1)", sequenceSetup.Setup.ToString());
+		}
+
+		[Fact]
+		public void MockSequenceBaseInvokesConditionWithSequenceSetupDerivation()
+		{
+			var mock = new Mock<IFoo>();
+			var aMockSequence = new AMockSequence(false, mock);
+			aMockSequence.Setup(() => mock.Setup(f => f.Do(1)));
+			mock.Object.Do(1);
+			Assert.Single(aMockSequence.ConditionSequenceSetups);
+			var conditionSequenceSetup = aMockSequence.ConditionSequenceSetups[0];
+			Assert.IsType<DefaultSequenceSetup>(conditionSequenceSetup);
+			Assert.Equal("NewMockSequenceFixture.IFoo f => f.Do(1)", conditionSequenceSetup.Setup.ToString());
+
+			Assert.Equal(0, conditionSequenceSetup.SetupIndex);
+			var defaultInvocationShapesSetups = conditionSequenceSetup.InvocationShapeSetupsObject as DefaultInvocationShapeSetups;
+			var sequenceSetups = defaultInvocationShapesSetups.GetSequenceSetups();
+			Assert.Single(sequenceSetups);
+			Assert.Same(conditionSequenceSetup, sequenceSetups[0]);
+		}
+
+		[Fact]
+		public void MockSequenceBaseShouldReturnTheConditionReturnValueForTheActualCondition()
+		{
+			var mock = new Mock<IFoo>();
+			var mockSequence = new AMockSequence(false, mock);
+			DefaultSequenceSetup setup = null;
+			mockSequence.Setup(() => mock.Setup(m => m.Do(1)), _setup => setup = _setup);
+			var methodCall = setup.SetupInternal as MethodCall;
+
+			Assert.True(methodCall.Condition.IsTrue);
+			Assert.Same(setup, mockSequence.ConditionSequenceSetups[0]);
+
+			mockSequence.ConditionReturn = false;
+			Assert.False(methodCall.Condition.IsTrue);
+			Assert.Same(setup, mockSequence.ConditionSequenceSetups[1]);
+		}
+
+		[Fact]
+		public void MockSequenceBaseShouldCaptureInvocations()
+		{
+			var mock = new Mock<IFoo>();
+			var nestedMock = new Mock<IHaveNested>();
+			// listening from non sequence setups works if done before hand.... 
+			// but it does not update after....
+			nestedMock.Setup(n => n.ReturnNested(1).DoNested(2)).Returns(1);
+			var aMockSequence = new AMockSequence(false, mock, nestedMock);
+
+			mock.Object.Do(1);
+			Assert.Single(aMockSequence.SequenceInvocations);
+
+			nestedMock.Object.ReturnNested(1).DoNested(1);
+			Assert.Equal(3, aMockSequence.SequenceInvocations.Count);
+
+		}
+
+		[Fact]
+		public void MockSequenceBaseStrictInvokesStrictnessFailureForUnmatchedInvocations()
+		{
+			var mock = new Mock<IFoo>();
+			var aMockSequence = new AMockSequence(true, mock);
+			aMockSequence.CallBaseForStrictFailure = false;
+			aMockSequence.Setup(() => mock.Setup(m => m.Do(2)));
+
+			mock.Object.Do(1);
+			Assert.True(aMockSequence.StrictFailure);
+		}
+
+		[Fact]
+		public void MockSequenceBaseStrictThrowsStrictSequenceExceptionForInvocationsWithoutSequenceSetup()
+		{
+			var mock = new Mock<IFoo>();
+			var aMockSequence = new AMockSequence(true, mock);
+			aMockSequence.Setup(() => mock.Setup(m => m.Do(2)));
+
+			var exception = Assert.Throws<StrictSequenceException>(() => mock.Object.Do(1));
+			Assert.Equal("Invocation without sequence setup. NewMockSequenceFixture.IFoo.Do(1)", exception.Message);
+		}
+
+		[Fact]
+		public void MockSequenceBaseStrictThrowsStrictSequenceExceptionForInvocationsWithoutSequenceSetupNested()
+		{
+			var mock = new Mock<IHaveNested>();
+			var aMockSequence = new AMockSequence(true, mock);
+			aMockSequence.Setup(() => mock.Setup(m => m.ReturnNested(1).DoNested(1)).Returns(1));
+
+			Assert.Equal(1, mock.Object.ReturnNested(1).DoNested(1));
+
+			var exception = Assert.Throws<StrictSequenceException>(() => mock.Object.ReturnNested(1).DoNested(2));
+			Assert.Equal("Invocation without sequence setup. NewMockSequenceFixture.INested.DoNested(2)", exception.Message);
+		}
+
+		[Fact]
+		public void MockSequenceBaseLooseDoesNotThrowsStrictSequenceExceptionForInvocationsWithoutSequenceSetup()
+		{
+			var mock = new Mock<IFoo>();
+			var aMockSequence = new AMockSequence(false, mock);
+			aMockSequence.Setup(() => mock.Setup(m => m.Do(2)));
+
+			mock.Object.Do(1);
+		}
+
+		[Fact]
+		public void MockSequenceBaseLooseVerifyNoOtherCallsShouldThrowIfInvocationsWithoutSequenceSetups()
+		{
+			var mock = new Mock<IFoo>();
+			var mockSequence = new AMockSequence(false, mock);
+			mockSequence.Setup(() => mock.Setup(m => m.Do(2)));
+			
+			mockSequence.VerifyNoOtherCalls();
+			
+			mock.Object.Do(1);
+
+			var exception = Assert.Throws<SequenceException>(() => mockSequence.VerifyNoOtherCalls());
+			Assert.Equal("Expected no invocations without sequence setup but found 1", exception.Message);
+		}
+
+		[Fact]
+		public void MockSequenceBaseWorksWithMockAs()
+		{
+			var mock = new Mock<IFoo>();
+			var mockBar = mock.As<IBar>();
+			// works without mockBar too
+			var mockSequence = new AMockSequence(true, mock, mockBar);
+			
+			mockSequence.Setup(() => mockBar.Setup(m => m.DoBar(1)).Returns(1));
+			mockSequence.Setup(() => mockBar.Setup(m => m.DoBar(2)).Returns(2));
+
+			Assert.Equal(1, mockBar.Object.DoBar(1));
+			Assert.Equal(2, mockBar.Object.DoBar(2));
+
+			var exception = Assert.Throws<StrictSequenceException>(() => mockBar.Object.DoBar(0));
+			Assert.Equal("Invocation without sequence setup. NewMockSequenceFixture.IBar.DoBar(0)", exception.Message);
+
+		}
+
+		private void LooseNewMockSequenceTestBase(Action<Mock<IFoo>, IProtectedAsMock<Protected, ProtectedLike>, NewMockSequence> setupSequence, Action<IFoo, Protected> act)
+		{
+			var mock = new Mock<IFoo>();
+			var mocked = mock.Object;
+			var protectedMock = new Mock<Protected>();
+			var protectedAsMock = protectedMock.Protected().As<ProtectedLike>();
+
+			var protectedMocked = protectedMock.Object;
+			var mockSequence = new NewMockSequence(false, mock, protectedMock);
+			setupSequence(mock, protectedAsMock, mockSequence);
+			act(mocked, protectedMocked);
+		}
+
+		[Fact]
+		public void MockSequenceShouldNotThrowIfNotCalled()
+		{
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+			}, (mocked, protectedMocked) =>
+			{
+
+			});
+		}
+
+		[Fact]
+		public void MockSequenceShouldNotThrowIfCalledInOrder_OneTime()
+		{
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)).Returns(1));
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(2));
+			}, (mocked, protectedMocked) =>
+			{
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(1, protectedMocked.InvokeProtectedDo(1));
+				Assert.Equal(2, mocked.Do(1));
+			});
+		}
+
+		[Fact]
+		public void MockSequenceShouldThrowIfNotCalledInOrder_OneTime()
+		{
+			var exception = Assert.Throws<SequenceException>(() =>
+				LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+				{
+					mockSequence.Setup(() => mock.Setup(m => m.Do(1)));
+					mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				}, (mocked, protectedMocked) =>
+				{
+					protectedMocked.InvokeProtectedDo(1);
+					mocked.Do(1);
+				})
+			);
+
+			Assert.Equal("Expected invocation on the mock once, but was 0 times: NewMockSequenceFixture.IFoo m => m.Do(1)", exception.Message);
+		}
+
+		[Fact]
+		public void MockSequenceShouldNotThrowIfCalledCorrectExactTimes()
+		{
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1), Times.Exactly(2));
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(2));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)).Returns(1));
+			}, (mocked, protectedMocked) =>
+			{
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(2, mocked.Do(1));
+				Assert.Equal(1, protectedMocked.InvokeProtectedDo(1));
+			});
+		}
+
+		[Fact]
+		public void MockSequenceShouldThrowIfCalledLessThanExactTimes()
+		{
+			var exception = Assert.Throws<SequenceException>(() =>
+				LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+				{
+					mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.Exactly(2));
+					mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				}, (mocked, protectedMocked) =>
+				{
+					mocked.Do(1);
+					protectedMocked.InvokeProtectedDo(1);
+				})
+			);
+
+			Assert.Equal("Expected invocation on the mock exactly 2 times, but was 1 times: NewMockSequenceFixture.IFoo m => m.Do(1)", exception.Message);
+		}
+
+		[Fact]
+		public void MockSequenceShouldThrowIfCalledMoreThanExactTimes()
+		{
+			var exception = Assert.Throws<SequenceException>(() =>
+				LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+				{
+					mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.Exactly(2));
+					mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				}, (mocked, protectedMocked) =>
+				{
+					mocked.Do(1);
+					mocked.Do(1);
+					mocked.Do(1);
+
+				})
+			);
+
+			Assert.Equal("Expected invocation on the mock exactly 2 times, but was 3 times: NewMockSequenceFixture.IFoo m => m.Do(1)", exception.Message);
+		}
+
+		[Fact]
+		public void MockSequenceShouldNotThrowIfAtLeastTimesIsMet()
+		{
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1), Times.AtLeast(2));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)).Returns(1));
+			}, (mocked, protectedMocked) =>
+			{
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(1, protectedMocked.InvokeProtectedDo(1));
+			});
+		}
+
+		[Fact]
+		public void MockSequenceShouldNotThrowIfAtLeastTimesIsMetMoreThan()
+		{
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1), Times.AtLeast(2));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)).Returns(1));
+			}, (mocked, protectedMocked) =>
+			{
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(1, protectedMocked.InvokeProtectedDo(1));
+			});
+		}
+
+		[Fact]
+		public void MockSequenceShouldThrowIfAtLeastTimesIsNotMet()
+		{
+			var exception = Assert.Throws<SequenceException>(() =>
+				LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+				{
+					mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.AtLeast(2));
+					mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				}, (mocked, protectedMocked) =>
+				{
+					mocked.Do(1);
+					protectedMocked.InvokeProtectedDo(1);
+				})
+			);
+
+			Assert.Equal("Expected invocation on the mock at least 2 times, but was 1 times: NewMockSequenceFixture.IFoo m => m.Do(1)", exception.Message);
+		}
+
+		[Fact]
+		public void MockSequenceShouldMoveToNextConsecutiveInvocationShapeSetupWhenAtLeastMet()
+		{
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				// effectively AtLeast(3) with different returns
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1), Times.AtLeast(2));
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(2), Times.AtLeast(1));
+				mockSequence.Setup(() => mock.Setup(m => m.Do(2)).Returns(9));
+			}, (mocked, protectedMocked) =>
+			{
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(2, mocked.Do(1));
+				Assert.Equal(9, mocked.Do(2));
+			});
+		}
+
+		[Fact]
+		public void MockSequenceShouldThrowImmediatelyIfNeverSetupCalled()
+		{
+			var exception = Assert.Throws<SequenceException>(() =>
+				LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+				{
+					mockSequence.Setup(() => mock.Setup(m => m.Do(1)));
+					mockSequence.Setup(() => mock.Setup(m => m.Do(2)), Times.Never());
+					mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				}, (mocked, protectedMocked) =>
+				{
+					mocked.Do(1);
+					mocked.Do(2);
+				})
+			);
+
+			Assert.Equal("Expected invocation on the mock should never have been performed, but was 1 times: NewMockSequenceFixture.IFoo m => m.Do(2)", exception.Message);
+		}
+
+		[Fact]
+		public void MockSequenceShouldNotThrowIfAtMostMet()
+		{
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1), Times.AtMost(2));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)).Returns(1));
+			}, (mocked, protectedMocked) =>
+			{
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(1, protectedMocked.InvokeProtectedDo(1));
+			});
+		}
+
+		[Fact]
+		public void MockSequenceShouldThrowImmediatelyIfInvokedMoreThanAtMost()
+		{
+			var exception = Assert.Throws<SequenceException>(() =>
+				LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+				{
+					mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.AtMost(2));
+					mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				}, (mocked, protectedMocked) =>
+				{
+					mocked.Do(1);
+					mocked.Do(1);
+					mocked.Do(1);
+				})
+			);
+
+			Assert.Equal("Expected invocation on the mock at most 2 times, but was 3 times: NewMockSequenceFixture.IFoo m => m.Do(1)", exception.Message);
+		}
+
+		[Fact]
+		public void MockSequenceShouldMoveToNextConsecutiveInvocationShapeSetupWhenAtMostMet()
+		{
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				// effectively AtMost(3) with different returns
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1), Times.AtMost(2));
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(2), Times.AtMost(1));
+			}, (mocked, protectedMocked) =>
+			{
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(2, mocked.Do(1));
+				Assert.Throws<SequenceException>(() => mocked.Do(1));
+			});
+		}
+
+		[Fact]
+		public void MockSequenceShouldNotThrowIfBetweenInclusiveMet()
+		{
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1), Times.Between(0, 2, Range.Inclusive));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)).Returns(1));
+			}, (mocked, protectedMocked) =>
+			{
+				Assert.Equal(1, protectedMocked.InvokeProtectedDo(1));
+			});
+
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1), Times.Between(0, 2, Range.Inclusive));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)).Returns(1));
+			}, (mocked, protectedMocked) =>
+			{
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(1, protectedMocked.InvokeProtectedDo(1));
+			});
+
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1), Times.Between(0, 2, Range.Inclusive));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)).Returns(1));
+			}, (mocked, protectedMocked) =>
+			{
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(1, protectedMocked.InvokeProtectedDo(1));
+			});
+		}
+
+		[Fact]
+		public void MockSequenceShouldThrowImmediatelyIfBetweenInclusiveTooManyInvocations()
+		{
+			var exception = Assert.Throws<SequenceException>(() =>
+				LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+				{
+					mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.Between(0, 2, Range.Inclusive));
+					mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				}, (mocked, protectedMocked) =>
+				{
+					mocked.Do(1);
+					mocked.Do(1);
+					mocked.Do(1);
+				})
+			);
+
+			Assert.Equal("Expected invocation on the mock between 0 and 2 times (Inclusive), but was 3 times: NewMockSequenceFixture.IFoo m => m.Do(1)", exception.Message);
+		}
+
+		[Fact]
+		public void MockSequenceShouldThrowIfBetweenInclusiveTooFewInvocations()
+		{
+			var exception = Assert.Throws<SequenceException>(() =>
+				LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+				{
+					mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.Between(1, 2, Range.Inclusive));
+					mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				}, (mocked, protectedMocked) =>
+				{
+					protectedMocked.InvokeProtectedDo(1);
+				})
+			);
+
+			Assert.Equal("Expected invocation on the mock between 1 and 2 times (Inclusive), but was 0 times: NewMockSequenceFixture.IFoo m => m.Do(1)", exception.Message);
+		}
+
+		[Fact]
+		public void MockSequenceConsecutiveBetweenInclusiveOrExclusiveCanBeSpecifiedWithAtLeastThenAtMost()
+		{
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				//equivalent of BetweenInclusive(2,5)
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1), Times.AtLeast(2));
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(2), Times.AtMost(3));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)).Returns(1));
+			}, (mocked, protectedMocked) =>
+			{
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(2, mocked.Do(1));
+				Assert.Equal(2, mocked.Do(1));
+				Assert.Equal(2, mocked.Do(1));
+				var exception = Assert.Throws<SequenceException>(() => mocked.Do(1));
+				Assert.Equal("Expected invocation on the mock at most 3 times, but was 4 times: NewMockSequenceFixture.IFoo m => m.Do(1)", exception.Message);
+
+				Assert.Equal(1, protectedMocked.InvokeProtectedDo(1));
+			});
+		}
+
+		[Fact]
+		public void MockSequenceShouldNotThrowIfBetweenExclusiveMet()
+		{
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1), Times.Between(1, 4, Range.Exclusive));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)).Returns(1));
+			}, (mocked, protectedMocked) =>
+			{
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(1, protectedMocked.InvokeProtectedDo(1));
+			});
+
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1), Times.Between(1, 4, Range.Exclusive));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)).Returns(1));
+			}, (mocked, protectedMocked) =>
+			{
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(1, protectedMocked.InvokeProtectedDo(1));
+			});
+		}
+
+		[Fact]
+		public void MockSequenceShouldThrowImmediatelyIfBetweenExclusiveTooManyInvocations()
+		{
+			var exception = Assert.Throws<SequenceException>(() =>
+				LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+				{
+					mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.Between(1, 3, Range.Exclusive));
+					mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				}, (mocked, protectedMocked) =>
+				{
+					mocked.Do(1);
+					mocked.Do(1);
+					mocked.Do(1);
+				})
+			);
+
+			Assert.Equal("Expected invocation on the mock between 1 and 3 times (Exclusive), but was 3 times: NewMockSequenceFixture.IFoo m => m.Do(1)", exception.Message);
+		}
+
+		[Fact]
+		public void MockSequenceShouldThrowIfBetweenExclusiveTooFewInvocations()
+		{
+			var exception = Assert.Throws<SequenceException>(() =>
+				LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+				{
+					mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.Between(1, 3, Range.Exclusive));
+					mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				}, (mocked, protectedMocked) =>
+				{
+					mocked.Do(1);
+					protectedMocked.InvokeProtectedDo(1);
+				})
+			);
+
+			Assert.Equal("Expected invocation on the mock between 1 and 3 times (Exclusive), but was 1 times: NewMockSequenceFixture.IFoo m => m.Do(1)", exception.Message);
+		}
+
+		[Fact]
+		public void MockSequenceWillNotThrowWhenSkipOptionalTimesSetups()
+		{
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)), NewMockSequence.OptionalTimes());
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(2)), NewMockSequence.OptionalTimes());
+				mockSequence.Setup(() => mock.Setup(m => m.Do(2)).Returns(2));
+			}, (mocked, protectedMocked) =>
+			{
+				Assert.Equal(1, mocked.Do(1));
+				Assert.Equal(2, mocked.Do(2));
+			});
+		}
+
+		[Fact]
+		public void MockSequenceWillThrowWhenSkipNonOptionalTimesSetups()
+		{
+			var exception = Assert.Throws<SequenceException>(() =>
+			{
+				LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+				{
+					mockSequence.Setup(() => mock.Setup(m => m.Do(1)));
+					mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)), NewMockSequence.OptionalTimes());
+					mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(2)), Times.Once());
+					mockSequence.Setup(() => mock.Setup(m => m.Do(2)));
+				}, (mocked, protectedMocked) =>
+				{
+					mocked.Do(1);
+					mocked.Do(2);
+				});
+			});
+
+			Assert.Equal("Expected invocation on the mock once, but was 0 times: NewMockSequenceFixture.Protected p => p.ProtectedDo(2)", exception.Message);
+		}
+
+		[Fact]
+		public void MockSequenceCanUseVerifiableSetupToVerifyASequenceSetup()
+		{
+			VerifiableSetup verifiableSetup1 = null;
+			VerifiableSetup verifiableSetup2 = null;
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				verifiableSetup1 = mockSequence.Setup(() => mock.Setup(m => m.Do(1)));
+				verifiableSetup2 = mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+			}, (mocked, protectedMocked) =>
+			{
+				mocked.Do(1);
+			});
+
+			verifiableSetup1.Verify();
+			Assert.Throws<SequenceException>(() => verifiableSetup2.Verify(Times.Once()));
+		}
+
+		[Fact]
+		public void MockSequenceCanUseVerifiableSetupToVerifyAllSameSequenceSetups()
+		{
+			VerifiableSetup verifiableSetup1 = null;
+			VerifiableSetup verifiableSetup2 = null;
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				verifiableSetup1 = mockSequence.Setup(() => mock.Setup(m => m.Do(1)));
+				verifiableSetup2 = mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+			}, (mocked, protectedMocked) =>
+			{
+				mocked.Do(1);
+				protectedMocked.InvokeProtectedDo(1);
+			});
+
+			verifiableSetup1.VerifyAll(Times.Once());
+			Assert.Throws<SequenceException>(() => verifiableSetup2.VerifyAll());
+		}
+
+		[Fact]
+		public void MockSequenceVerifyVerifiesThatAllSetupsHaveBeenMet()
+		{
+			NewMockSequence sequence = null;
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.Exactly(2));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				sequence = mockSequence;
+			}, (mocked, protectedMocked) =>
+			{
+				mocked.Do(1);
+			});
+			Assert.Throws<SequenceException>(() => sequence.Verify());
+
+			NewMockSequence sequence2 = null;
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.Exactly(2));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				sequence2 = mockSequence;
+			}, (mocked, protectedMocked) =>
+			{
+				mocked.Do(1);
+				mocked.Do(1);
+			});
+			Assert.Throws<SequenceException>(() => sequence2.Verify());
+
+			NewMockSequence sequence3 = null;
+			LooseNewMockSequenceTestBase((mock, protectedAs, mockSequence) =>
+			{
+				mockSequence.Setup(() => mock.Setup(m => m.Do(1)), Times.Exactly(2));
+				mockSequence.Setup(() => protectedAs.Setup(p => p.ProtectedDo(1)));
+				sequence3 = mockSequence;
+			}, (mocked, protectedMocked) =>
+			{
+				mocked.Do(1);
+				mocked.Do(1);
+				protectedMocked.InvokeProtectedDo(1);
+			});
+			sequence3.Verify();
+		}
+
+		[Fact]
+		public void MockSequenceStrictShouldThrowIfCyclicInvocationAndNotCyclic()
+		{
+			var mock = new Mock<IFoo>();
+			var mocked = mock.Object;
+			var sequence = new NewMockSequence(true, mock);
+			sequence.Setup(() => mock.Setup(m => m.Do(1)));
+			sequence.Setup(() => mock.Setup(m => m.Do(2)));
+			mocked.Do(1);
+			mocked.Do(2);
+			var exception = Assert.Throws<StrictSequenceException>(() => mocked.Do(1));
+			Assert.Equal("Cyclical invocation but not cyclic. NewMockSequenceFixture.IFoo m => m.Do(1)", exception.Message);
+		}
+
+		[Fact]
+		public void MockSequenceLooseShouldNotThrowIfCyclicInvocationAndNotCyclic()
+		{
+			var mock = new Mock<IFoo>();
+			var mocked = mock.Object;
+			var sequence = new NewMockSequence(false, mock);
+			sequence.Setup(() => mock.Setup(m => m.Do(1)));
+			sequence.Setup(() => mock.Setup(m => m.Do(2)));
+			mocked.Do(1);
+			mocked.Do(2);
+			mocked.Do(1);
+		}
+
+		[Fact]
+		public void MockSequenceWorksCyclical_OneTime()
+		{
+			var mock = new Mock<IFoo>();
+			var mocked = mock.Object;
+			var protectedMock = new Mock<Protected>();
+			var protectedAsMock = protectedMock.Protected().As<ProtectedLike>();
+			var protectedMocked = protectedMock.Object;
+			var sequence = new NewMockSequence(true, mock, protectedMock) { Cyclical = true };
+			sequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1));
+			sequence.Setup(() => protectedAsMock.Setup(m => m.ProtectedDo(2)).Returns(2));
+			Assert.Equal(1, mocked.Do(1));
+			Assert.Equal(2, protectedMocked.InvokeProtectedDo(2));
+			Assert.Equal(1, mocked.Do(1));
+			Assert.Equal(2, protectedMocked.InvokeProtectedDo(2));
+		}
+
+		[Fact]
+		public void MockSequenceWorksCyclicalWithSeparatedCommonSetups()
+		{
+			var mock = new Mock<IFoo>();
+			var mocked = mock.Object;
+			var protectedMock = new Mock<Protected>();
+			var protectedAsMock = protectedMock.Protected().As<ProtectedLike>();
+			var protectedMocked = protectedMock.Object;
+
+			var sequence = new NewMockSequence(true, mock, protectedMock) { Cyclical = true };
+			sequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1));
+			sequence.Setup(() => protectedAsMock.Setup(m => m.ProtectedDo(1)).Returns(1));
+			sequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(2));
+			sequence.Setup(() => protectedAsMock.Setup(m => m.ProtectedDo(2)).Returns(2));
+
+			Assert.Equal(1, mocked.Do(1));
+			Assert.Equal(1, protectedMocked.InvokeProtectedDo(1));
+			Assert.Equal(2, mocked.Do(1));
+			Assert.Equal(2, protectedMocked.InvokeProtectedDo(2));
+			Assert.Equal(1, mocked.Do(1));
+			Assert.Equal(1, protectedMocked.InvokeProtectedDo(1));
+			Assert.Equal(2, mocked.Do(1));
+			Assert.Equal(2, protectedMocked.InvokeProtectedDo(2));
+		}
+
+		[Fact]
+		public void MockSequenceWorksCyclicalWithAdjacentCommonSetups()
+		{
+			var mock = new Mock<IFoo>();
+			var mocked = mock.Object;
+			var protectedMock = new Mock<Protected>();
+			var protectedAsMock = protectedMock.Protected().As<ProtectedLike>();
+			var protectedMocked = protectedMock.Object;
+
+			var sequence = new NewMockSequence(true, mock, protectedMock) { Cyclical = true };
+			sequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1));
+			sequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(2));
+			sequence.Setup(() => protectedAsMock.Setup(m => m.ProtectedDo(1)).Returns(1));
+
+			Assert.Equal(1, mocked.Do(1));
+			Assert.Equal(2, mocked.Do(1));
+			Assert.Equal(1, protectedMocked.InvokeProtectedDo(1));
+			Assert.Equal(1, mocked.Do(1));
+			Assert.Equal(2, mocked.Do(1));
+			Assert.Equal(1, protectedMocked.InvokeProtectedDo(1));
+		}
+
+		[Fact]
+		public void MockSequenceWorksCyclicalWithAdjacentStartEnd()
+		{
+			var mock = new Mock<IFoo>();
+			var mocked = mock.Object;
+			var protectedMock = new Mock<Protected>();
+			var protectedAsMock = protectedMock.Protected().As<ProtectedLike>();
+			var protectedMocked = protectedMock.Object;
+
+			var sequence = new NewMockSequence(true, mock, protectedMock) { Cyclical = true };
+			sequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1));
+			sequence.Setup(() => protectedAsMock.Setup(m => m.ProtectedDo(1)).Returns(1));
+			sequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(2));
+
+			Assert.Equal(1, mocked.Do(1));
+			Assert.Equal(1, protectedMocked.InvokeProtectedDo(1));
+			Assert.Equal(2, mocked.Do(1));
+			Assert.Equal(1, mocked.Do(1));
+			Assert.Equal(1, protectedMocked.InvokeProtectedDo(1));
+			Assert.Equal(2, mocked.Do(1));
+		}
+
+		[Fact]
+		public void MockSequenceWorksCyclicalWithAdjacentStartEndExactTimesMoreThanOnce()
+		{
+			var mock = new Mock<IFoo>();
+			var mocked = mock.Object;
+			var protectedMock = new Mock<Protected>();
+			var protectedAsMock = protectedMock.Protected().As<ProtectedLike>();
+			var protectedMocked = protectedMock.Object;
+
+			var sequence = new NewMockSequence(true, mock, protectedMock) { Cyclical = true };
+			sequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1));
+			sequence.Setup(() => protectedAsMock.Setup(m => m.ProtectedDo(1)).Returns(1));
+			sequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(2), Times.Exactly(2));
+
+			Assert.Equal(1, mocked.Do(1));
+			Assert.Equal(1, protectedMocked.InvokeProtectedDo(1));
+			Assert.Equal(2, mocked.Do(1));
+			Assert.Equal(2, mocked.Do(1));
+			Assert.Equal(1, mocked.Do(1));
+			Assert.Equal(1, protectedMocked.InvokeProtectedDo(1));
+			Assert.Equal(2, mocked.Do(1));
+			Assert.Equal(2, mocked.Do(1));
+		}
+
+		[Fact]
+		public void MockSequenceCyclicalBeforeCurrentAfterBeginningShouldThrowIfNotOptional()
+		{
+			var mock = new Mock<IFoo>();
+			var mocked = mock.Object;
+
+			var sequence = new NewMockSequence(true, mock) { Cyclical = true };
+			sequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1));
+			sequence.Setup(() => mock.Setup(m => m.Do(2)).Returns(2));
+			sequence.Setup(() => mock.Setup(m => m.Do(3)).Returns(3));
+
+			Assert.Equal(1, mocked.Do(1));
+			Assert.Equal(2, mocked.Do(2));
+			Assert.Equal(3, mocked.Do(3));
+
+			var exception = Assert.Throws<SequenceException>(() => Assert.Equal(2, mocked.Do(2)));
+			Assert.Equal("Expected invocation on the mock once, but was 0 times: NewMockSequenceFixture.IFoo m => m.Do(1)", exception.Message);
+		}
+
+		[Fact]
+		public void VerifiableSetupHasCyclicalExecutionCount()
+		{
+			var mock = new Mock<IFoo>();
+			var mocked = mock.Object;
+
+			var sequence = new NewMockSequence(true, mock) { Cyclical = true };
+			var verifiableSequence1 = sequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1), Times.AtMost(2));
+			var verifiableSequence2 = sequence.Setup(() => mock.Setup(m => m.Do(2)).Returns(2));
+
+			Assert.Equal(1, mocked.Do(1));
+			Assert.Equal(1, mocked.Do(1));
+
+			Assert.Equal(new List<int> { 2 }, verifiableSequence1.CyclicalExecutionCount);
+			Assert.Equal(new List<int> { 0 }, verifiableSequence2.CyclicalExecutionCount);
+
+			Assert.Equal(2, mocked.Do(2));
+			Assert.Equal(1, mocked.Do(1));
+
+			Assert.Equal(new List<int> { 2, 1 }, verifiableSequence1.CyclicalExecutionCount);
+			Assert.Equal(new List<int> { 1, 0 }, verifiableSequence2.CyclicalExecutionCount);
+		}
+
+		[Fact]
+		public void VerifiableSetupVerifyCyclicalNumberWillThrowIfDifferentCycles()
+		{
+			var mock = new Mock<IFoo>();
+			var mocked = mock.Object;
+
+			var sequence = new NewMockSequence(true, mock) { Cyclical = true };
+			var verifiableSequence1 = sequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1), Times.AtMost(2));
+			var verifiableSequence2 = sequence.Setup(() => mock.Setup(m => m.Do(2)).Returns(2));
+
+			verifiableSequence1.VerifyCyclical(new List<int> { 0 });
+			var exception = Assert.Throws<SequenceException>(() => verifiableSequence1.VerifyCyclical(new List<int> { 0, 0 }));
+			Assert.Equal("Expected cycles 2 but was 1", exception.Message);
+		}
+
+
+		[Fact]
+		public void VerifiableSetupVerifyCyclicalTimesWillThrowIfDifferentCycles()
+		{
+			var mock = new Mock<IFoo>();
+			var mocked = mock.Object;
+
+			var sequence = new NewMockSequence(true, mock) { Cyclical = true };
+			var verifiableSequence1 = sequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1), Times.AtMost(2));
+			var verifiableSequence2 = sequence.Setup(() => mock.Setup(m => m.Do(2)).Returns(2));
+
+			var exception = Assert.Throws<SequenceException>(() => verifiableSequence1.VerifyCyclical(new List<Times> { Times.Once(), Times.Once(), Times.Once() }));
+			Assert.Equal("Expected cycles 3 but was 1", exception.Message);
+		}
+
+		[Fact]
+		public void VerifiableSetupVerifyCyclicalNumberWillThrowIfDiffers()
+		{
+			var mock = new Mock<IFoo>();
+			var mocked = mock.Object;
+
+			var sequence = new NewMockSequence(true, mock) { Cyclical = true };
+			var verifiableSequence1 = sequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1), Times.AtMost(2));
+			var verifiableSequence2 = sequence.Setup(() => mock.Setup(m => m.Do(2)).Returns(2));
+
+			mocked.Do(1);
+
+			var exception = Assert.Throws<SequenceException>(() => verifiableSequence1.VerifyCyclical(new List<int> { 2 }));
+			Assert.Equal("On cycle 0. Expected invocation on the mock exactly 2 times, but was 1 times: ", exception.Message);
+		}
+
+		[Fact]
+		public void VerifiableSetupVerifyCyclicalTimesWillThrowIfDiffers()
+		{
+			var mock = new Mock<IFoo>();
+			var mocked = mock.Object;
+
+			var sequence = new NewMockSequence(true, mock) { Cyclical = true };
+			var verifiableSequence1 = sequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1), Times.AtMost(2));
+			var verifiableSequence2 = sequence.Setup(() => mock.Setup(m => m.Do(2)).Returns(2));
+
+			mocked.Do(1);
+			mocked.Do(2);
+			mocked.Do(1);
+
+			var exception = Assert.Throws<SequenceException>(() => verifiableSequence1.VerifyCyclical(new List<Times> { Times.Once(), Times.Exactly(2) }));
+			Assert.Equal("On cycle 1. Expected invocation on the mock exactly 2 times, but was 1 times: ", exception.Message);
+		}
+
+		[Fact]
+		public void VerifySetupVerifyWithTimesNumberCanBeUsedForCyclical()
+		{
+			var mock = new Mock<IFoo>();
+			var mocked = mock.Object;
+
+			var sequence = new NewMockSequence(true, mock) { Cyclical = true };
+			var verifiableSequence1 = sequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1), Times.AtMost(2));
+			var verifiableSequence2 = sequence.Setup(() => mock.Setup(m => m.Do(2)).Returns(2));
+
+			mocked.Do(1);
+			verifiableSequence1.Verify(1);
+			mocked.Do(1);
+			verifiableSequence1.Verify(2);
+			mocked.Do(2);
+			mocked.Do(1);
+			verifiableSequence1.Verify(3);
+
+			var exception = Assert.Throws<SequenceException>(() => verifiableSequence1.Verify(4));
+			Assert.Equal("Expected invocation on the mock exactly 4 times, but was 3 times: NewMockSequenceFixture.IFoo m => m.Do(1)", exception.Message);
+		}
+
+		
+
+		internal class DefaultSequenceSetup : SequenceSetupBase
+		{
+			public DefaultInvocationShapeSetups InvocationShapeSetups => (DefaultInvocationShapeSetups)InvocationShapeSetupsObject;
+		}
+
+		internal class DefaultInvocationShapeSetups : InvocationShapeSetupsBase<DefaultSequenceSetup>
+		{
+			public DefaultInvocationShapeSetups(DefaultSequenceSetup sequenceSetup) : base(sequenceSetup) { }
+
+			public IReadOnlyList<DefaultSequenceSetup> GetSequenceSetups()
+			{
+				return SequenceSetups;
+			}
+		}
+
+		internal class AMockSequence : MockSequenceBase<DefaultSequenceSetup, DefaultInvocationShapeSetups>
+		{
+			public bool StrictFailure { get; set; }
+			public bool CallBaseForStrictFailure { get; set; } = true;
+			public bool ConditionReturn { get; set; } = true;
+			public AMockSequence(bool strict, params Mock[] mocks) : base(strict, mocks) { }
+			public void Setup(Action setup, Action<DefaultSequenceSetup> setupCallback = null)
+			{
+				if(setupCallback == null)
+				{
+					setupCallback = s => { };
+				}
+				base.InterceptSetup(setup, setupCallback);
+			}
+
+			public List<DefaultSequenceSetup> ConditionSequenceSetups = new List<DefaultSequenceSetup>();
+
+			protected override bool Condition(DefaultSequenceSetup sequenceSetup)
+			{
+				ConditionSequenceSetups.Add(sequenceSetup);
+				return ConditionReturn;
+			}
+
+			internal IReadOnlyList<DefaultSequenceSetup> GetSequenceSetups()
+			{
+				return SequenceSetups;
+			}
+
+			protected override void StrictnessFailure(ISequenceInvocation unmatchedInvocation)
+			{
+				StrictFailure = true;
+				if (CallBaseForStrictFailure)
+				{
+					base.StrictnessFailure(unmatchedInvocation);
+				}
+			}
+			
+		}
+
+		public interface IHaveNested
+		{
+			INested ReturnNested(int arg);
+		}
+
+		public interface INested
+		{
+			int DoNested(int arg);
+		}
+
+		public interface IFoo
+		{
+			int Do(int arg);
+		}
+
+		public interface IBar
+		{
+			int DoBar(int arg);
+		}
+
+		public abstract class Protected
+		{
+			protected abstract int ProtectedDo(int arg);
+			public int InvokeProtectedDo(int arg)
+			{
+				return ProtectedDo(arg);
+			}
+		}
+
+		public interface ProtectedLike
+		{
+			int ProtectedDo(int arg);
+		}
+	}
+}


### PR DESCRIPTION
A mock sequence that is 

Loose or strict
  It captures invocations on the registered mocks and when strict throws if no corresponding sequence setup.
  VerifyNoOtherCalls can be used if Loose.

Sequence setups are performed on the mock and captured.
So protected works with the same syntax.

```
			var mock = new Mock<IFoo>();
			var mocked = mock.Object;
			var protectedMock = new Mock<Protected>();
			var protectedAsMock = protectedMock.Protected().As<ProtectedLike>();
			var protectedMocked = protectedMock.Object;

			var sequence = new NewMockSequence(true, mock, protectedMock);
			sequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1));
			sequence.Setup(() => protectedAsMock.Setup(m => m.ProtectedDo(2)).Returns(2));
			Assert.Equal(1, mocked.Do(1));
			Assert.Equal(2, protectedMocked.InvokeProtectedDo(2));
			
```

  
When specifying the sequence you can use Times to adjust the expectation.  The default is `Times.Once()`

Can be cyclical

```
			var mock = new Mock<IFoo>();
			var mocked = mock.Object;
			var protectedMock = new Mock<Protected>();
			var protectedAsMock = protectedMock.Protected().As<ProtectedLike>();
			var protectedMocked = protectedMock.Object;
			var sequence = new NewMockSequence(true, mock, protectedMock) { Cyclical = true };
			sequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1));
			sequence.Setup(() => protectedAsMock.Setup(m => m.ProtectedDo(2)).Returns(2));
			Assert.Equal(1, mocked.Do(1));
			Assert.Equal(2, protectedMocked.InvokeProtectedDo(2));
			Assert.Equal(1, mocked.Do(1));
			Assert.Equal(2, protectedMocked.InvokeProtectedDo(2));
```

Although a sequence will throw if invocations do not occur as expected in most instances verification is needed.

For non cyclical - every set up has to pass the expectation - Times.
`mockSequence.Verify()`

For cyclical you would use the return value of a setup.

```
			var mock = new Mock<IFoo>();
			var mocked = mock.Object;

			var sequence = new NewMockSequence(true, mock) { Cyclical = true };
			var verifiableSequence1 = sequence.Setup(() => mock.Setup(m => m.Do(1)).Returns(1), Times.AtMost(2));
			var verifiableSequence2 = sequence.Setup(() => mock.Setup(m => m.Do(2)).Returns(2));

			mocked.Do(1);
			verifiableSequence1.Verify(1);
			mocked.Do(1);
			verifiableSequence1.Verify(2);
			mocked.Do(2);
			mocked.Do(1);
			verifiableSequence1.Verify(3);

			var exception = Assert.Throws<SequenceException>(() => verifiableSequence1.Verify(4));
			Assert.Equal("Expected invocation on the mock exactly 4 times, but was 3 times: NewMockSequenceFixture.IFoo m => m.Do(1)", exception.Message);
```

@stakx Please have a look when you get the opportunity.
 