### PR TITLE
Add AnyValueAttribute and usage tests #1199

### DIFF
--- a/src/Moq/AnyValueAttribute.cs
+++ b/src/Moq/AnyValueAttribute.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+
+namespace Moq
+{
+	/// <summary>
+	/// A class member with this attribute will be treated automatically like <see cref="It.IsAny{TValue}"/>.
+	/// Supports https://github.com/moq/moq4/issues/1199
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Property, Inherited = true)]   //TODO consider and test `| AttributeTargets.Method | AttributeTargets.Field`
+	public class AnyValueAttribute : Attribute
+	{
+		
+	}
+}

--- a/tests/Moq.Tests/MatchExpressionFixture.cs
+++ b/tests/Moq.Tests/MatchExpressionFixture.cs
@@ -95,7 +95,7 @@ namespace Moq.Tests
 			var expression = GetExpression();
 			var matchExpression = FindMatchExpression(expression);
 			Debug.Assert(matchExpression != null);
-			var (matcher, _) = MatcherFactory.CreateMatcher(matchExpression);
+			var (matcher, _) = MatcherFactory.CreateMatcher2(matchExpression);
 			Assert.IsType<Match<int>>(matcher);
 		}
 

--- a/tests/Moq.Tests/Matchers/AnyMatcherFixture.cs
+++ b/tests/Moq.Tests/Matchers/AnyMatcherFixture.cs
@@ -15,7 +15,7 @@ namespace Moq.Tests.Matchers
 		{
 			var expr = ToExpression<object>(() => It.IsAny<object>()).Body;
 
-			var (matcher, _) = MatcherFactory.CreateMatcher(expr);
+			var (matcher, _) = MatcherFactory.CreateMatcher2(expr);
 
 			Assert.True(matcher.Matches(null, typeof(object)));
 		}
@@ -25,7 +25,7 @@ namespace Moq.Tests.Matchers
 		{
 			var expr = ToExpression<object>(() => It.IsAny<object>()).Body;
 
-			var (matcher, _) = MatcherFactory.CreateMatcher(expr);
+			var (matcher, _) = MatcherFactory.CreateMatcher2(expr);
 
 			Assert.True(matcher.Matches("foo", typeof(object)));
 		}
@@ -35,7 +35,7 @@ namespace Moq.Tests.Matchers
 		{
 			var expr = ToExpression<IDisposable>(() => It.IsAny<IDisposable>()).Body;
 
-			var (matcher, _) = MatcherFactory.CreateMatcher(expr);
+			var (matcher, _) = MatcherFactory.CreateMatcher2(expr);
 
 			Assert.True(matcher.Matches(new Disposable(), typeof(IDisposable)));
 		}
@@ -45,7 +45,7 @@ namespace Moq.Tests.Matchers
 		{
 			var expr = ToExpression<IFormatProvider>(() => It.IsAny<IFormatProvider>()).Body;
 
-			var (matcher, _) = MatcherFactory.CreateMatcher(expr);
+			var (matcher, _) = MatcherFactory.CreateMatcher2(expr);
 
 			Assert.False(matcher.Matches("foo", typeof(IFormatProvider)));
 		}

--- a/tests/Moq.Tests/Matchers/AnyValueAttributeTests1.cs
+++ b/tests/Moq.Tests/Matchers/AnyValueAttributeTests1.cs
@@ -1,0 +1,135 @@
+﻿using Xunit;
+using System;
+using Moq.Tests.Matchers.AnyAttribute1.SomeOtherLib;
+
+/// <summary>
+/// This example allows using `_` for any type including interfaces, but it has the downside of requiring some
+/// extra user maintennance when refactoring the interfaces. This is overcome in <see cref="Moq.Tests.Matchers.AnyAttribute2.AnyValueAttributeTests2"/>.
+/// Tests for https://github.com/moq/moq4/issues/1199
+/// </summary>
+
+namespace Moq.Tests.Matchers.AnyAttribute1.SomeOtherLib
+{
+	/// <summary>
+	/// Helper class probably provided by user/3rd party lib and not Moq
+	/// </summary>
+	public class AnyValueHelper<T> where T : AnyValueBase, new()
+	{
+		[AnyValue] //new Attribute that allows this to work
+		public static T _ => default;
+		[AnyValue]
+		public static T any => default;
+	}
+
+	/// <summary>
+	/// Helper class probably provided by user/3rd party lib and not Moq
+	/// </summary>
+	public class AnyValueBase
+	{
+		public static implicit operator int(AnyValueBase _) => default;
+		public static implicit operator byte(AnyValueBase _) => default;
+		//TODO all the built-in value types
+	}
+}
+
+
+namespace Moq.Tests.Matchers.AnyAttribute1
+{
+	using static AnyValueHelper<AdamsAnyHelper>;   // note using static to simplify syntax
+
+	/// <summary>
+	/// Helper class probably provided by user (Adam) for any types not handled by <see cref="AnyValueBase"/>.
+	/// </summary>
+	public class AdamsAnyHelper : AnyValueBase, ICar
+	{
+		#region boilerplate
+
+		int ICar.Calc(int a, int b, int c, int d)
+		{
+			throw new NotImplementedException();
+		}
+
+		int ICar.DoSomething(ICar a, GearId b, int c)
+		{
+			throw new NotImplementedException();
+		}
+
+		int ICar.Echo(int a)
+		{
+			throw new NotImplementedException();
+		}
+
+		int ICar.Race(ICar a)
+		{
+			throw new NotImplementedException();
+		}
+
+		public static implicit operator GearId(AdamsAnyHelper _) => default;
+
+		#endregion
+	}
+
+	/// <summary>
+	/// Example enum
+	/// </summary>
+	public enum GearId
+	{
+		Reverse,
+		Neutral,
+		Gear1,
+	}
+
+	/// <summary>
+	/// Example interface
+	/// </summary>
+	public interface ICar
+	{
+		int Echo(int a);
+		int Calc(int a, int b, int c, int d);
+		int Race(ICar a);
+		int DoSomething(ICar a, GearId b, int c);
+	}
+
+	public class AnyValueAttributeTests2
+	{
+		[Fact]
+		public void Echo_1Primitive()
+		{
+			var mockCar = new Mock<ICar>();
+			var car = mockCar.Object;
+
+			mockCar.Setup(car => car.Echo(_)).Returns(0x68);
+			Assert.Equal(0x68, car.Echo(default));
+		}
+
+		[Fact]
+		public void Calc_4Primitives()
+		{
+			var mockCar = new Mock<ICar>();
+			var car = mockCar.Object;
+
+			mockCar.Setup(car => car.Calc(_, _, _, _)).Returns(123456);
+			Assert.Equal(123456, car.Calc(default, default, default, default));
+		}
+
+		[Fact]
+		public void Race_1Interface()
+		{
+			var mockCar = new Mock<ICar>();
+			var car = mockCar.Object;
+
+			mockCar.Setup(car => car.Race(_)).Returns(0x68);
+			Assert.Equal(0x68, car.Race(default));
+		}
+
+		[Fact]
+		public void DoSomething_MixedTypes()
+		{
+			var mockCar = new Mock<ICar>();
+			var car = mockCar.Object;
+
+			mockCar.Setup(car => car.DoSomething(_, _, _)).Returns(0x68);
+			Assert.Equal(0x68, car.DoSomething(default, default, default));
+		}
+	}
+}

--- a/tests/Moq.Tests/Matchers/AnyValueAttributeTests2.cs
+++ b/tests/Moq.Tests/Matchers/AnyValueAttributeTests2.cs
@@ -1,13 +1,15 @@
 ﻿using Xunit;
-using Moq.Tests.Matchers.AnyAttribute2.SomeOtherLib;
+using Moq.Tests.Matchers.AnyValueAttribute2.SomeOtherLib;
 
 /// <summary>
+/// This example usage is OK, but not ideal. See <see cref="Moq.Tests.Matchers.AnyValueAttribute3.AutoIsAny"/> example instead.
+/// 
 /// This example allows using `Any` for any non-interface type and `AnyI` otherwise.
 /// This avoids extra user maintennance when the interfaces are refactored.
 /// Tests for https://github.com/moq/moq4/issues/1199
 /// </summary>
 
-namespace Moq.Tests.Matchers.AnyAttribute2.SomeOtherLib
+namespace Moq.Tests.Matchers.AnyValueAttribute2.SomeOtherLib
 {
 	/// <summary>
 	/// Helper class probably provided by user/3rd party lib and not Moq
@@ -39,7 +41,7 @@ namespace Moq.Tests.Matchers.AnyAttribute2.SomeOtherLib
 }
 
 
-namespace Moq.Tests.Matchers.AnyAttribute2
+namespace Moq.Tests.Matchers.AnyValueAttribute2
 {
 	using static AnyValueHelper<AdamsAnyHelper, IAdamsAnyInterfaceHelper>;   // note using static to simplify syntax
 
@@ -79,7 +81,7 @@ namespace Moq.Tests.Matchers.AnyAttribute2
 		int DoSomething(ICar a, GearId b, int c);
 	}
 
-	public class AnyValueAttributeTests2
+	public class Tests
 	{
 		[Fact]
 		public void Echo_1Primitive()

--- a/tests/Moq.Tests/Matchers/AnyValueAttributeTests2.cs
+++ b/tests/Moq.Tests/Matchers/AnyValueAttributeTests2.cs
@@ -1,0 +1,124 @@
+﻿using Xunit;
+using Moq.Tests.Matchers.AnyAttribute2.SomeOtherLib;
+
+/// <summary>
+/// This example allows using `Any` for any non-interface type and `AnyI` otherwise.
+/// This avoids extra user maintennance when the interfaces are refactored.
+/// Tests for https://github.com/moq/moq4/issues/1199
+/// </summary>
+
+namespace Moq.Tests.Matchers.AnyAttribute2.SomeOtherLib
+{
+	/// <summary>
+	/// Helper class probably provided by user/3rd party lib and not Moq
+	/// </summary>
+	public class AnyValueHelper<T, IType> where T : AnyValueBase
+	{
+		/// <summary>
+		/// Any non-interface type. Class or primitive type.
+		/// </summary>
+		[AnyValue] //new Attribute that allows this to work
+		public static T Any => default;
+
+		/// <summary>
+		/// Any Interface
+		/// </summary>
+		[AnyValue]
+		public static IType AnyI => default;
+	}
+
+	/// <summary>
+	/// Helper class probably provided by user/3rd party lib and not Moq
+	/// </summary>
+	public class AnyValueBase
+	{
+		public static implicit operator int(AnyValueBase _) => default;
+		public static implicit operator byte(AnyValueBase _) => default;
+		//TODO all the built-in value types
+	}
+}
+
+
+namespace Moq.Tests.Matchers.AnyAttribute2
+{
+	using static AnyValueHelper<AdamsAnyHelper, IAdamsAnyInterfaceHelper>;   // note using static to simplify syntax
+
+	/// <summary>
+	/// Helper class provided by user (Adam) for any types not handled by <see cref="AnyValueBase"/>.
+	/// </summary>
+	public class AdamsAnyHelper : AnyValueBase
+	{
+		public static implicit operator GearId(AdamsAnyHelper _) => default;
+	}
+
+	/// <summary>
+	/// Helper interface provided by user (Adam) for any interfaces
+	/// </summary>
+	public interface IAdamsAnyInterfaceHelper : ICar
+	{
+	}
+
+	/// <summary>
+	/// Example enum
+	/// </summary>
+	public enum GearId
+	{
+		Reverse,
+		Neutral,
+		Gear1,
+	}
+
+	/// <summary>
+	/// Example interface
+	/// </summary>
+	public interface ICar
+	{
+		int Echo(int a);
+		int Calc(int a, int b, int c, int d);
+		int Race(ICar a);
+		int DoSomething(ICar a, GearId b, int c);
+	}
+
+	public class AnyValueAttributeTests2
+	{
+		[Fact]
+		public void Echo_1Primitive()
+		{
+			var mockCar = new Mock<ICar>();
+			var car = mockCar.Object;
+
+			mockCar.Setup(car => car.Echo(Any)).Returns(0x68);
+			Assert.Equal(0x68, car.Echo(default));
+		}
+
+		[Fact]
+		public void Calc_4Primitives()
+		{
+			var mockCar = new Mock<ICar>();
+			var car = mockCar.Object;
+
+			mockCar.Setup(car => car.Calc(Any, Any, Any, Any)).Returns(123456);
+			Assert.Equal(123456, car.Calc(default, default, default, default));
+		}
+
+		[Fact]
+		public void Race_1Interface()
+		{
+			var mockCar = new Mock<ICar>();
+			var car = mockCar.Object;
+
+			mockCar.Setup(car => car.Race(AnyI)).Returns(0x68);
+			Assert.Equal(0x68, car.Race(default));
+		}
+
+		[Fact]
+		public void DoSomething_MixedTypes()
+		{
+			var mockCar = new Mock<ICar>();
+			var car = mockCar.Object;
+
+			mockCar.Setup(car => car.DoSomething(AnyI, Any, Any)).Returns(0x68);
+			Assert.Equal(0x68, car.DoSomething(default, default, default));
+		}
+	}
+}

--- a/tests/Moq.Tests/Matchers/AnyValueAttributeTests3.cs
+++ b/tests/Moq.Tests/Matchers/AnyValueAttributeTests3.cs
@@ -115,7 +115,7 @@ namespace Moq.Tests.Matchers.AnyValueAttribute3
 			var car = mockCar.Object;
 
 			mockCar.Setup(car => car.Echo(_)).Returns(0x68);
-			Assert.Equal(0x68, car.Echo(default));
+			Assert.Equal(0x68, car.Echo(1));
 		}
 
 		[Fact]
@@ -125,7 +125,7 @@ namespace Moq.Tests.Matchers.AnyValueAttribute3
 			var car = mockCar.Object;
 
 			mockCar.Setup(car => car.Calc(_, _, _, _)).Returns(123456);
-			Assert.Equal(123456, car.Calc(default, default, default, default));
+			Assert.Equal(123456, car.Calc(1, 2, 3, 4));
 		}
 
 		[Fact]
@@ -136,7 +136,7 @@ namespace Moq.Tests.Matchers.AnyValueAttribute3
 
 
 			mockCar.Setup(car => car.Race(_)).Returns(0x68);
-			Assert.Equal(0x68, car.Race(default));
+			Assert.Equal(0x68, car.Race(null));
 
 			var realCar = new Car();
 			Assert.Equal(0x68, car.Race(realCar));
@@ -150,7 +150,7 @@ namespace Moq.Tests.Matchers.AnyValueAttribute3
 
 
 			mockCar.Setup(car => car.Race(It.IsAny<ICar>())).Returns(0x68);
-			Assert.Equal(0x68, car.Race(default));
+			Assert.Equal(0x68, car.Race(null));
 
 			var realCar = new Car();
 			Assert.Equal(0x68, car.Race(realCar));
@@ -163,7 +163,7 @@ namespace Moq.Tests.Matchers.AnyValueAttribute3
 			var car = mockCar.Object;
 
 			mockCar.Setup(car => car.DoSomething(_, _, _)).Returns(0x68);
-			Assert.Equal(0x68, car.DoSomething(default, default, default));
+			Assert.Equal(0x68, car.DoSomething(null, GearId.Neutral, 1));
 		}
 	}
 }

--- a/tests/Moq.Tests/Matchers/AnyValueAttributeTests3.cs
+++ b/tests/Moq.Tests/Matchers/AnyValueAttributeTests3.cs
@@ -82,6 +82,29 @@ namespace Moq.Tests.Matchers.AnyValueAttribute3
 		int DoSomething(ICar a, GearId b, int c);
 	}
 
+	public class Car : ICar
+	{
+		public int Calc(int a, int b, int c, int d)
+		{
+			throw new NotImplementedException();
+		}
+
+		public int DoSomething(ICar a, GearId b, int c)
+		{
+			throw new NotImplementedException();
+		}
+
+		public int Echo(int a)
+		{
+			throw new NotImplementedException();
+		}
+
+		public int Race(ICar a)
+		{
+			throw new NotImplementedException();
+		}
+	}
+
 
 	public class Tests
 	{
@@ -111,8 +134,26 @@ namespace Moq.Tests.Matchers.AnyValueAttribute3
 			var mockCar = new Mock<ICar>();
 			var car = mockCar.Object;
 
+
 			mockCar.Setup(car => car.Race(_)).Returns(0x68);
 			Assert.Equal(0x68, car.Race(default));
+
+			var realCar = new Car();
+			Assert.Equal(0x68, car.Race(realCar));
+		}
+
+		[Fact]
+		public void OldRace_1Interface()
+		{
+			var mockCar = new Mock<ICar>();
+			var car = mockCar.Object;
+
+
+			mockCar.Setup(car => car.Race(It.IsAny<ICar>())).Returns(0x68);
+			Assert.Equal(0x68, car.Race(default));
+
+			var realCar = new Car();
+			Assert.Equal(0x68, car.Race(realCar));
 		}
 
 		[Fact]

--- a/tests/Moq.Tests/Matchers/AnyValueAttributeTests3.cs
+++ b/tests/Moq.Tests/Matchers/AnyValueAttributeTests3.cs
@@ -1,51 +1,40 @@
 ﻿using Xunit;
 using System;
-using Moq.Tests.Matchers.AnyValueAttribute1.SomeOtherLib;
 
 /// <summary>
-/// This example usage is OK, but not ideal. See <see cref="Moq.Tests.Matchers.AnyValueAttribute3.AutoIsAny"/> example instead.
+/// This is my favorite potential solution so far. Nothing that looks too weird to users. Fairly understandable.
 /// 
 /// This example allows using `_` for any type including interfaces, but it has the downside of requiring some
-/// extra user maintennance when an implemented interface is changed. This could be eased with a Roslyn analyzer/code fix.
+/// extra user maintennance when an implemented interface is changed. IDE based auto explicit interface implementation
+/// also makes this pretty easy.
+/// 
+/// This could be eased with a Roslyn analyzer/code fix.
+/// 
 /// Tests for https://github.com/moq/moq4/issues/1199
 /// </summary>
 
-namespace Moq.Tests.Matchers.AnyValueAttribute1.SomeOtherLib
+namespace Moq.Tests.Matchers.AnyValueAttribute3
 {
+	using static AutoIsAny;   // note using static to simplify syntax
+
 	/// <summary>
-	/// Helper class probably provided by user/3rd party lib and not Moq
+	/// Helper class provided by user
 	/// </summary>
-	public class AnyValueHelper<T> where T : AnyValueBase, new()
+	public abstract class AutoIsAny
 	{
 		[AnyValue] //new Attribute that allows this to work
-		public static T _ => default;
+		public static AnyValue _ => default;
 		[AnyValue]
-		public static T any => default;
+		public static AnyValue Any => default;	//alternative syntax to `_`
 	}
 
 	/// <summary>
-	/// Helper class probably provided by user/3rd party lib and not Moq
+	/// Helper class provided by user. Interfaces implemented via IDE auto explicit interface implementation
+	/// or Roslyn analyzer/code fix.
 	/// </summary>
-	public class AnyValueBase
-	{
-		public static implicit operator int(AnyValueBase _) => default;
-		public static implicit operator byte(AnyValueBase _) => default;
-		//TODO all the built-in value types
-	}
-}
-
-
-namespace Moq.Tests.Matchers.AnyValueAttribute1
-{
-	using static AnyValueHelper<AdamsAnyHelper>;   // note using static to simplify syntax
-
-	/// <summary>
-	/// Helper class probably provided by user (Adam) for any types not handled by <see cref="AnyValueBase"/>.
-	/// </summary>
-	public class AdamsAnyHelper : AnyValueBase, ICar
+	public abstract class AnyValue : ICar
 	{
 		#region boilerplate
-
 		int ICar.Calc(int a, int b, int c, int d)
 		{
 			throw new NotImplementedException();
@@ -66,8 +55,9 @@ namespace Moq.Tests.Matchers.AnyValueAttribute1
 			throw new NotImplementedException();
 		}
 
-		public static implicit operator GearId(AdamsAnyHelper _) => default;
-
+		public static implicit operator int(AnyValue _) => default;
+		public static implicit operator byte(AnyValue _) => default;
+		public static implicit operator GearId(AnyValue _) => default;
 		#endregion
 	}
 
@@ -91,6 +81,7 @@ namespace Moq.Tests.Matchers.AnyValueAttribute1
 		int Race(ICar a);
 		int DoSomething(ICar a, GearId b, int c);
 	}
+
 
 	public class Tests
 	{


### PR DESCRIPTION
This PR adds support for users/3rd party libraries that want to implement a more succinct wild card matcher like `_`. Original ticket: #1199

The change to moq itself is pretty small. Hopefully, this PR will allow exploring the potential and will help further discussion.