### PR TITLE
Enable multi-method setups

### DIFF
--- a/src/Moq/Behaviors/ReturnBaseOrDefaultValue.cs
+++ b/src/Moq/Behaviors/ReturnBaseOrDefaultValue.cs
@@ -106,7 +106,7 @@ namespace Moq.Behaviors
 				var returnValue = this.mock.GetDefaultValue(method, out var innerMock);
 				if (innerMock != null && invocation.MatchingSetup == null)
 				{
-					var setup = new InnerMockSetup(originalExpression: null, this.mock, expectation: InvocationShape.CreateFrom(invocation), returnValue);
+					var setup = new InnerMockSetup(originalExpression: null, this.mock, expectation: MethodExpectation.CreateFrom(invocation), returnValue);
 					this.mock.MutableSetups.Add(setup);
 					setup.Execute(invocation);
 				}

--- a/src/Moq/Expectation.cs
+++ b/src/Moq/Expectation.cs
@@ -1,0 +1,45 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System;
+using System.Linq.Expressions;
+
+using Moq.Async;
+
+namespace Moq
+{
+	/// <summary>
+	///   Represents a set (or the "shape") of invocations
+	///   against which concrete <see cref="Invocation"/>s can be matched.
+	/// </summary>
+	internal abstract class Expectation : IEquatable<Expectation>
+	{
+		public abstract LambdaExpression Expression { get; }
+
+		public virtual bool HasResultExpression(out IAwaitableFactory awaitableFactory)
+		{
+			awaitableFactory = null;
+			return false;
+		}
+
+		public override bool Equals(object obj)
+		{
+			return obj is Expectation other && this.Equals(other);
+		}
+
+		public abstract bool Equals(Expectation other);
+
+		public abstract override int GetHashCode();
+
+		public abstract bool IsMatch(Invocation invocation);
+
+		public virtual void SetupEvaluatedSuccessfully(Invocation invocation)
+		{
+		}
+
+		public override string ToString()
+		{
+			return this.Expression.ToStringFixed();
+		}
+	}
+}

--- a/src/Moq/ExpressionExtensions.cs
+++ b/src/Moq/ExpressionExtensions.cs
@@ -137,11 +137,11 @@ namespace Moq
 		/// <exception cref="ArgumentException">
 		///   It was not possible to completely split up the expression.
 		/// </exception>
-		internal static Stack<InvocationShape> Split(this LambdaExpression expression, bool allowNonOverridableLastProperty = false)
+		internal static Stack<MethodExpectation> Split(this LambdaExpression expression, bool allowNonOverridableLastProperty = false)
 		{
 			Debug.Assert(expression != null);
 
-			var parts = new Stack<InvocationShape>();
+			var parts = new Stack<MethodExpectation>();
 
 			Expression remainder = expression.Body;
 			while (CanSplit(remainder))
@@ -163,7 +163,7 @@ namespace Moq
 						remainder.ToStringFixed()));
 			}
 
-			void Split(Expression e, out Expression r /* remainder */, out InvocationShape p /* part */, bool assignment = false, bool allowNonOverridableLastProperty = false)
+			void Split(Expression e, out Expression r /* remainder */, out MethodExpectation p /* part */, bool assignment = false, bool allowNonOverridableLastProperty = false)
 			{
 				const string ParameterName = "...";
 
@@ -182,7 +182,7 @@ namespace Moq
 							arguments[ai] = lhs.Arguments[ai];
 						}
 						arguments[arguments.Length - 1] = assignmentExpression.Right;
-						p = new InvocationShape(
+						p = new MethodExpectation(
 							expression: Expression.Lambda(
 								Expression.MakeBinary(e.NodeType, lhs.Expression.Body, assignmentExpression.Right),
 								parameter),
@@ -216,7 +216,7 @@ namespace Moq
 							var parameter = Expression.Parameter(r.Type, r is ParameterExpression ope ? ope.Name : ParameterName);
 							var method = methodCallExpression.Method;
 							var arguments = methodCallExpression.Arguments;
-							p = new InvocationShape(
+							p = new MethodExpectation(
 										expression: Expression.Lambda(
 											Expression.Call(parameter, method, arguments),
 											parameter),
@@ -232,7 +232,7 @@ namespace Moq
 							var method = methodCallExpression.Method;
 							var arguments = methodCallExpression.Arguments.ToArray();
 							arguments[0] = parameter;
-							p = new InvocationShape(
+							p = new MethodExpectation(
 										expression: Expression.Lambda(
 											Expression.Call(method, arguments),
 											parameter),
@@ -264,7 +264,7 @@ namespace Moq
 						{
 							method = null;
 						}
-						p = new InvocationShape(
+						p = new MethodExpectation(
 									expression: Expression.Lambda(
 										Expression.MakeIndex(parameter, indexer, arguments),
 										parameter),
@@ -282,7 +282,7 @@ namespace Moq
 						r = invocationExpression.Expression;
 						var parameter = Expression.Parameter(r.Type, r is ParameterExpression ope ? ope.Name : ParameterName);
 						var arguments = invocationExpression.Arguments;
-						p = new InvocationShape(
+						p = new MethodExpectation(
 									expression: Expression.Lambda(
 										Expression.Invoke(parameter, arguments),
 										parameter),
@@ -323,7 +323,7 @@ namespace Moq
 						{
 							method = null;
 						}
-						p = new InvocationShape(
+						p = new MethodExpectation(
 									expression: Expression.Lambda(
 										Expression.MakeMemberAccess(parameter, property),
 										parameter),

--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -479,13 +479,13 @@ namespace Moq
 		public static IEnumerable<Mock> FindAllInnerMocks(this SetupCollection setups)
 		{
 			return setups.FindAll(setup => !setup.IsConditional)
-			             .Select(setup => setup.InnerMock)
+			             .SelectMany(setup => setup.InnerMocks)
 			             .Where(innerMock => innerMock != null);
 		}
 
 		public static Mock FindLastInnerMock(this SetupCollection setups, Func<Setup, bool> predicate)
 		{
-			return setups.FindLast(setup => !setup.IsConditional && predicate(setup))?.InnerMock;
+			return setups.FindLast(setup => !setup.IsConditional && predicate(setup))?.InnerMocks.SingleOrDefault();
 		}
 	}
 }

--- a/src/Moq/ISetup.cs
+++ b/src/Moq/ISetup.cs
@@ -2,6 +2,8 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq.Expressions;
 
 namespace Moq
@@ -16,6 +18,18 @@ namespace Moq
 		///   The setup expression.
 		/// </summary>
 		LambdaExpression Expression { get; }
+
+		// NOTE regarding the `InnerMock` and `InnerMocks` properties below:
+		//
+		// Moq has support for multi-method setups, but does not yet make actual use of them.
+		// Once that changes, some setups may have more than one inner mock. This possibility
+		// has already been accounted for in Moq's internals, but not in this interface:
+		// The `InnerMock` property should really be replaced with an `InnerMocks` one.
+		//
+		// Before making this change, let's wait a little longer to see whether it can be avoided.
+		// This is a distinct possibility since fixing Moq's recursive verification algorithm
+		// may do away with the need to expose the "inner mock" concept altogether. It would be
+		// a pity to add `InnerMocks`, only to have both properties become obsolete soon after.
 
 		/// <summary>
 		///   Gets the inner mock of this setup (if present and known).
@@ -32,7 +46,27 @@ namespace Moq
 		///     since calling a user-provided function could have effects beyond Moq's understanding and control.
 		///   </para>
 		/// </summary>
+		// /// <exception cref="InvalidOperationException">The setup has more than one inner mock.</exception>
+		// [Obsolete("Use 'InnerMocks' instead.")]
+		// [EditorBrowsable(EditorBrowsableState.Never)]
 		Mock InnerMock { get; }
+
+		// /// <summary>
+		// ///   Gets the inner mocks of this setup (if present and known).
+		// ///   <para>
+		// ///     An "inner mock" is the <see cref="Moq.Mock"/> instance associated with a setup's return value,
+		// ///     if that setup is configured to return a mock object.
+		// ///   </para>
+		// ///   <para>
+		// ///     This property will return an empty sequence if a setup either does not return any mock objects,
+		// ///     or if Moq cannot safely determine its return value(s) without risking any side effects. For instance,
+		// ///     Moq is able to inspect the return value if it is a constant (e.g. <c>`.Returns(value)`</c>);
+		// ///     if, on the other hand, it gets computed by a factory function (e.g. <c>`.Returns(() => value)`</c>),
+		// ///     Moq will not attempt to retrieve that value just to find the inner mock,
+		// ///     since calling a user-provided function could have effects beyond Moq's understanding and control.
+		// ///   </para>
+		// /// </summary>
+		// IEnumerable<Mock> InnerMocks { get; }
 
 		/// <summary>
 		///   Gets whether this setup is conditional.

--- a/src/Moq/InnerMockSetup.cs
+++ b/src/Moq/InnerMockSetup.cs
@@ -12,7 +12,7 @@ namespace Moq
 	{
 		private readonly object returnValue;
 
-		public InnerMockSetup(Expression originalExpression, Mock mock, InvocationShape expectation, object returnValue)
+		public InnerMockSetup(Expression originalExpression, Mock mock, MethodExpectation expectation, object returnValue)
 			: base(originalExpression, mock, expectation)
 		{
 			Debug.Assert(Awaitable.TryGetResultRecursive(returnValue) is IMocked);

--- a/src/Moq/InnerMockSetup.cs
+++ b/src/Moq/InnerMockSetup.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq.Expressions;
 
@@ -22,7 +23,15 @@ namespace Moq
 			this.MarkAsVerifiable();
 		}
 
-		public override Mock InnerMock => TryGetInnerMockFrom(this.returnValue);
+		public override IEnumerable<Mock> InnerMocks
+		{
+			get
+			{
+				var innerMock = TryGetInnerMockFrom(this.returnValue);
+				Debug.Assert(innerMock != null);
+				yield return innerMock;
+			}
+		}
 
 		protected override void ExecuteCore(Invocation invocation)
 		{
@@ -31,7 +40,10 @@ namespace Moq
 
 		protected override void ResetCore()
 		{
-			this.InnerMock.MutableSetups.Reset();
+			foreach (var innerMock in this.InnerMocks)
+			{
+				innerMock.MutableSetups.Reset();
+			}
 		}
 
 		protected override void VerifySelf()

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -29,7 +29,7 @@ namespace Moq
 
 		private string declarationSite;
 
-		public MethodCall(Expression originalExpression, Mock mock, Condition condition, InvocationShape expectation)
+		public MethodCall(Expression originalExpression, Mock mock, Condition condition, MethodExpectation expectation)
 			: base(originalExpression, mock, expectation)
 		{
 			this.condition = condition;

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -2,6 +2,7 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -47,7 +48,17 @@ namespace Moq
 
 		public override Condition Condition => this.condition;
 
-		public override Mock InnerMock => TryGetInnerMockFrom((this.returnOrThrow as ReturnValue)?.Value);
+		public override IEnumerable<Mock> InnerMocks
+		{
+			get
+			{
+				var innerMock = TryGetInnerMockFrom((this.returnOrThrow as ReturnValue)?.Value);
+				if (innerMock != null)
+				{
+					yield return innerMock;
+				}
+			}
+		}
 
 		private static string GetUserCodeCallSite()
 		{

--- a/src/Moq/MethodExpectation.cs
+++ b/src/Moq/MethodExpectation.cs
@@ -18,15 +18,15 @@ namespace Moq
 	/// <summary>
 	///   Describes the "shape" of an invocation against which concrete <see cref="Invocation"/>s can be matched.
 	///   <para>
-	///     This shape is described by <see cref="InvocationShape.Expression"/> which has the general form
+	///     This shape is described by <see cref="MethodExpectation.Expression"/> which has the general form
 	///     `mock => mock.Method(...arguments)`. Because the method and arguments are frequently needed,
-	///     they are cached in <see cref="InvocationShape.Method"/> and <see cref="InvocationShape.Arguments"/>
+	///     they are cached in <see cref="MethodExpectation.Method"/> and <see cref="MethodExpectation.Arguments"/>
 	///     for faster access.
 	///   </para>
 	/// </summary>
-	internal sealed class InvocationShape : IEquatable<InvocationShape>
+	internal sealed class MethodExpectation : IEquatable<MethodExpectation>
 	{
-		public static InvocationShape CreateFrom(Invocation invocation)
+		public static MethodExpectation CreateFrom(Invocation invocation)
 		{
 			var method = invocation.Method;
 
@@ -55,7 +55,7 @@ namespace Moq
 				Debug.Assert(property.CanRead(out var getter) && method == getter);
 			}
 
-			return new InvocationShape(expression, method, arguments, exactGenericTypeArguments: true);
+			return new MethodExpectation(expression, method, arguments, exactGenericTypeArguments: true);
 		}
 
 		private static readonly Expression[] noArguments = new Expression[0];
@@ -74,7 +74,7 @@ namespace Moq
 #endif
 		private readonly bool exactGenericTypeArguments;
 
-		public InvocationShape(LambdaExpression expression, MethodInfo method, IReadOnlyList<Expression> arguments = null, bool exactGenericTypeArguments = false, bool skipMatcherInitialization = false, bool allowNonOverridable = false)
+		public MethodExpectation(LambdaExpression expression, MethodInfo method, IReadOnlyList<Expression> arguments = null, bool exactGenericTypeArguments = false, bool skipMatcherInitialization = false, bool allowNonOverridable = false)
 		{
 			Debug.Assert(expression != null);
 			Debug.Assert(method != null);
@@ -194,7 +194,7 @@ namespace Moq
 			return true;
 		}
 
-		public bool Equals(InvocationShape other)
+		public bool Equals(MethodExpectation other)
 		{
 			if (this.Method != other.Method)
 			{
@@ -273,7 +273,7 @@ namespace Moq
 
 		public override bool Equals(object obj)
 		{
-			return obj is InvocationShape other && this.Equals(other);
+			return obj is MethodExpectation other && this.Equals(other);
 		}
 
 		public override int GetHashCode()

--- a/src/Moq/MethodExpectation.cs
+++ b/src/Moq/MethodExpectation.cs
@@ -16,15 +16,15 @@ using E = System.Linq.Expressions.Expression;
 namespace Moq
 {
 	/// <summary>
-	///   Describes the "shape" of an invocation against which concrete <see cref="Invocation"/>s can be matched.
+	///   An <see cref="Expectation"/> that is bound to a single, specific method.
 	///   <para>
-	///     This shape is described by <see cref="MethodExpectation.Expression"/> which has the general form
-	///     `mock => mock.Method(...arguments)`. Because the method and arguments are frequently needed,
+	///     <see cref="MethodExpectation.Expression"/> has the general form
+	///     <c>`mock => mock.Method(...arguments)`</c>. Because the method and arguments are frequently needed,
 	///     they are cached in <see cref="MethodExpectation.Method"/> and <see cref="MethodExpectation.Arguments"/>
 	///     for faster access.
 	///   </para>
 	/// </summary>
-	internal sealed class MethodExpectation : IEquatable<MethodExpectation>
+	internal sealed class MethodExpectation : Expectation
 	{
 		public static MethodExpectation CreateFrom(Invocation invocation)
 		{
@@ -61,7 +61,7 @@ namespace Moq
 		private static readonly Expression[] noArguments = new Expression[0];
 		private static readonly IMatcher[] noArgumentMatchers = new IMatcher[0];
 
-		public LambdaExpression Expression;
+		private LambdaExpression expression;
 		public readonly MethodInfo Method;
 		public readonly IReadOnlyList<Expression> Arguments;
 
@@ -85,7 +85,7 @@ namespace Moq
 				Guard.IsVisibleToProxyFactory(method);
 			}
 
-			this.Expression = expression;
+			this.expression = expression;
 			this.Method = method;
 			if (arguments != null && !skipMatcherInitialization)
 			{
@@ -100,13 +100,15 @@ namespace Moq
 			this.exactGenericTypeArguments = exactGenericTypeArguments;
 		}
 
+		public override LambdaExpression Expression => this.expression;
+
 		public void AddResultExpression(Func<E, E> add, IAwaitableFactory awaitableFactory)
 		{
-			this.Expression = E.Lambda(add(this.Expression.Body), this.Expression.Parameters);
+			this.expression = E.Lambda(add(this.Expression.Body), this.Expression.Parameters);
 			this.awaitableFactory = awaitableFactory;
 		}
 
-		public bool HasResultExpression(out IAwaitableFactory awaitableFactory)
+		public override bool HasResultExpression(out IAwaitableFactory awaitableFactory)
 		{
 			return (awaitableFactory = this.awaitableFactory) != null;
 		}
@@ -118,7 +120,7 @@ namespace Moq
 			arguments = this.Arguments;
 		}
 
-		public bool IsMatch(Invocation invocation)
+		public override bool IsMatch(Invocation invocation)
 		{
 			if (invocation.Method != this.Method && !this.IsOverride(invocation))
 			{
@@ -138,7 +140,7 @@ namespace Moq
 			return true;
 		}
 
-		public void SetupEvaluatedSuccessfully(Invocation invocation)
+		public override void SetupEvaluatedSuccessfully(Invocation invocation)
 		{
 			var arguments = invocation.Arguments;
 			var parameterTypes = invocation.Method.GetParameterTypes();
@@ -194,8 +196,10 @@ namespace Moq
 			return true;
 		}
 
-		public bool Equals(MethodExpectation other)
+		public override bool Equals(Expectation obj)
 		{
+			if (obj is not MethodExpectation other) return false;
+
 			if (this.Method != other.Method)
 			{
 				return false;
@@ -271,19 +275,9 @@ namespace Moq
 			return partiallyEvaluatedArguments;
 		}
 
-		public override bool Equals(object obj)
-		{
-			return obj is MethodExpectation other && this.Equals(other);
-		}
-
 		public override int GetHashCode()
 		{
 			return this.Method.GetHashCode();
-		}
-
-		public override string ToString()
-		{
-			return this.Expression.ToStringFixed();
 		}
 	}
 }

--- a/src/Moq/MethodSetup.cs
+++ b/src/Moq/MethodSetup.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Moq
+{
+	/// <summary>
+	///   Abstract base class for setups that target a single, specific method.
+	/// </summary>
+	internal abstract class MethodSetup : Setup
+	{
+		protected MethodSetup(Expression originalExpression, Mock mock, InvocationShape expectation)
+			: base(originalExpression, mock, expectation)
+		{
+		}
+
+		public MethodInfo Method => this.Expectation.Method;
+	}
+}

--- a/src/Moq/MethodSetup.cs
+++ b/src/Moq/MethodSetup.cs
@@ -16,6 +16,6 @@ namespace Moq
 		{
 		}
 
-		public MethodInfo Method => this.Expectation.Method;
+		public MethodInfo Method => ((MethodExpectation)this.Expectation).Method;
 	}
 }

--- a/src/Moq/MethodSetup.cs
+++ b/src/Moq/MethodSetup.cs
@@ -11,7 +11,7 @@ namespace Moq
 	/// </summary>
 	internal abstract class MethodSetup : Setup
 	{
-		protected MethodSetup(Expression originalExpression, Mock mock, InvocationShape expectation)
+		protected MethodSetup(Expression originalExpression, Mock mock, MethodExpectation expectation)
 			: base(originalExpression, mock, expectation)
 		{
 		}

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -430,24 +430,24 @@ namespace Moq
 		private static int GetMatchingInvocationCount(
 			Mock mock,
 			LambdaExpression expression,
-			out List<Pair<Invocation, InvocationShape>> invocationsToBeMarkedAsVerified)
+			out List<Pair<Invocation, MethodExpectation>> invocationsToBeMarkedAsVerified)
 		{
 			Debug.Assert(mock != null);
 			Debug.Assert(expression != null);
 
-			invocationsToBeMarkedAsVerified = new List<Pair<Invocation, InvocationShape>>();
+			invocationsToBeMarkedAsVerified = new List<Pair<Invocation, MethodExpectation>>();
 			return Mock.GetMatchingInvocationCount(
 				mock,
-				new ImmutablePopOnlyStack<InvocationShape>(expression.Split()),
+				new ImmutablePopOnlyStack<MethodExpectation>(expression.Split()),
 				new HashSet<Mock>(),
 				invocationsToBeMarkedAsVerified);
 		}
 
 		private static int GetMatchingInvocationCount(
 			Mock mock,
-			in ImmutablePopOnlyStack<InvocationShape> parts,
+			in ImmutablePopOnlyStack<MethodExpectation> parts,
 			HashSet<Mock> visitedInnerMocks,
-			List<Pair<Invocation, InvocationShape>> invocationsToBeMarkedAsVerified)
+			List<Pair<Invocation, MethodExpectation>> invocationsToBeMarkedAsVerified)
 		{
 			Debug.Assert(mock != null);
 			Debug.Assert(!parts.Empty);
@@ -466,7 +466,7 @@ namespace Moq
 			var count = 0;
 			foreach (var matchingInvocation in mock.MutableInvocations.ToArray().Where(part.IsMatch))
 			{
-				invocationsToBeMarkedAsVerified.Add(new Pair<Invocation, InvocationShape>(matchingInvocation, part));
+				invocationsToBeMarkedAsVerified.Add(new Pair<Invocation, MethodExpectation>(matchingInvocation, part));
 
 				if (remainingParts.Empty)
 				{
@@ -591,7 +591,7 @@ namespace Moq
 			});
 		}
 
-		private static TSetup SetupRecursive<TSetup>(Mock mock, LambdaExpression expression, Func<Mock, Expression, InvocationShape, TSetup> setupLast, bool allowNonOverridableLastProperty = false)
+		private static TSetup SetupRecursive<TSetup>(Mock mock, LambdaExpression expression, Func<Mock, Expression, MethodExpectation, TSetup> setupLast, bool allowNonOverridableLastProperty = false)
 			where TSetup : ISetup
 		{
 			Debug.Assert(mock != null);
@@ -602,7 +602,7 @@ namespace Moq
 			return Mock.SetupRecursive(mock, originalExpression: expression, parts, setupLast);
 		}
 
-		private static TSetup SetupRecursive<TSetup>(Mock mock, LambdaExpression originalExpression, Stack<InvocationShape> parts, Func<Mock, Expression, InvocationShape, TSetup> setupLast)
+		private static TSetup SetupRecursive<TSetup>(Mock mock, LambdaExpression originalExpression, Stack<MethodExpectation> parts, Func<Mock, Expression, MethodExpectation, TSetup> setupLast)
 			where TSetup : ISetup
 		{
 			var part = parts.Pop();
@@ -667,7 +667,7 @@ namespace Moq
 			Mock.RaiseEvent(mock, expression, parts, arguments);
 		}
 
-		internal static void RaiseEvent(Mock mock, LambdaExpression expression, Stack<InvocationShape> parts, object[] arguments)
+		internal static void RaiseEvent(Mock mock, LambdaExpression expression, Stack<MethodExpectation> parts, object[] arguments)
 		{
 			const BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly;
 

--- a/src/Moq/SequenceSetup.cs
+++ b/src/Moq/SequenceSetup.cs
@@ -15,7 +15,7 @@ namespace Moq
 		// contains the behaviors set up with the `CallBase`, `Pass`, `Returns`, and `Throws` verbs
 		private ConcurrentQueue<Behavior> behaviors;
 
-		public SequenceSetup(Expression originalExpression, Mock mock, InvocationShape expectation)
+		public SequenceSetup(Expression originalExpression, Mock mock, MethodExpectation expectation)
 			: base(originalExpression, mock, expectation)
 		{
 			this.behaviors = new ConcurrentQueue<Behavior>();

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
 
@@ -34,7 +35,9 @@ namespace Moq
 
 		public LambdaExpression Expression => this.expectation.Expression;
 
-		public virtual Mock InnerMock => null;
+		Mock ISetup.InnerMock => this.InnerMocks.SingleOrDefault();
+
+		public virtual IEnumerable<Mock> InnerMocks => Enumerable.Empty<Mock>();
 
 		public bool IsConditional => this.Condition != null;
 
@@ -148,7 +151,10 @@ namespace Moq
 			{
 				try
 				{
-					this.InnerMock?.Verify(predicate, verifiedMocks);
+					foreach (var innerMock in this.InnerMocks)
+					{
+						innerMock.Verify(predicate, verifiedMocks);
+					}
 				}
 				catch (MockException error) when (error.IsVerificationError)
 				{

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq.Expressions;
-using System.Reflection;
 using System.Text;
 
 using Moq.Async;
@@ -42,8 +41,6 @@ namespace Moq
 		public bool IsOverridden => (this.flags & Flags.Overridden) != 0;
 
 		public bool IsVerifiable => (this.flags & Flags.Verifiable) != 0;
-
-		public MethodInfo Method => this.expectation.Method;
 
 		public Mock Mock => this.mock;
 

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -13,12 +13,12 @@ namespace Moq
 {
 	internal abstract class Setup : ISetup
 	{
-		private readonly MethodExpectation expectation;
+		private readonly Expectation expectation;
 		private readonly Expression originalExpression;
 		private readonly Mock mock;
 		private Flags flags;
 
-		protected Setup(Expression originalExpression, Mock mock, MethodExpectation expectation)
+		protected Setup(Expression originalExpression, Mock mock, Expectation expectation)
 		{
 			Debug.Assert(mock != null);
 			Debug.Assert(expectation != null);
@@ -30,7 +30,7 @@ namespace Moq
 
 		public virtual Condition Condition => null;
 
-		public MethodExpectation Expectation => this.expectation;
+		public Expectation Expectation => this.expectation;
 
 		public LambdaExpression Expression => this.expectation.Expression;
 

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -13,12 +13,12 @@ namespace Moq
 {
 	internal abstract class Setup : ISetup
 	{
-		private readonly InvocationShape expectation;
+		private readonly MethodExpectation expectation;
 		private readonly Expression originalExpression;
 		private readonly Mock mock;
 		private Flags flags;
 
-		protected Setup(Expression originalExpression, Mock mock, InvocationShape expectation)
+		protected Setup(Expression originalExpression, Mock mock, MethodExpectation expectation)
 		{
 			Debug.Assert(mock != null);
 			Debug.Assert(expectation != null);
@@ -30,7 +30,7 @@ namespace Moq
 
 		public virtual Condition Condition => null;
 
-		public InvocationShape Expectation => this.expectation;
+		public MethodExpectation Expectation => this.expectation;
 
 		public LambdaExpression Expression => this.expectation.Expression;
 
@@ -101,7 +101,7 @@ namespace Moq
 			return this.expectation.IsMatch(invocation) && (this.Condition == null || this.Condition.IsTrue);
 		}
 
-		public bool Matches(InvocationShape expectation)
+		public bool Matches(MethodExpectation expectation)
 		{
 			return this.expectation.Equals(expectation);
 		}

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -11,12 +11,12 @@ namespace Moq
 	internal sealed class SetupCollection : ISetupList
 	{
 		private List<Setup> setups;
-		private HashSet<MethodExpectation> activeSetups;
+		private HashSet<Expectation> activeSetups;
 
 		public SetupCollection()
 		{
 			this.setups = new List<Setup>();
-			this.activeSetups = new HashSet<MethodExpectation>();
+			this.activeSetups = new HashSet<Expectation>();
 		}
 
 		public int Count
@@ -55,7 +55,7 @@ namespace Moq
 
 		private void MarkOverriddenSetups()
 		{
-			var visitedSetups = new HashSet<MethodExpectation>();
+			var visitedSetups = new HashSet<Expectation>();
 
 			// Iterating in reverse order because newer setups are more relevant than (i.e. override) older ones
 			for (int i = this.setups.Count - 1; i >= 0; --i)

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -82,7 +82,7 @@ namespace Moq
 
 			lock (this.setups)
 			{
-				this.setups.RemoveAll(x => x.Method.IsPropertyAccessor());
+				this.setups.RemoveAll(s => s is MethodSetup ms && ms.Method.IsPropertyAccessor());
 
 				// NOTE: In the general case, removing a setup means that some overridden setups might no longer
 				// be shadowed, and their `IsOverridden` flag should go back from `true` to `false`.

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -11,12 +11,12 @@ namespace Moq
 	internal sealed class SetupCollection : ISetupList
 	{
 		private List<Setup> setups;
-		private HashSet<InvocationShape> activeInvocationShapes;
+		private HashSet<MethodExpectation> activeSetups;
 
 		public SetupCollection()
 		{
 			this.setups = new List<Setup>();
-			this.activeInvocationShapes = new HashSet<InvocationShape>();
+			this.activeSetups = new HashSet<MethodExpectation>();
 		}
 
 		public int Count
@@ -46,7 +46,7 @@ namespace Moq
 			lock (this.setups)
 			{
 				this.setups.Add(setup);
-				if (!this.activeInvocationShapes.Add(setup.Expectation))
+				if (!this.activeSetups.Add(setup.Expectation))
 				{
 					this.MarkOverriddenSetups();
 				}
@@ -55,7 +55,7 @@ namespace Moq
 
 		private void MarkOverriddenSetups()
 		{
-			var visitedSetups = new HashSet<InvocationShape>();
+			var visitedSetups = new HashSet<MethodExpectation>();
 
 			// Iterating in reverse order because newer setups are more relevant than (i.e. override) older ones
 			for (int i = this.setups.Count - 1; i >= 0; --i)
@@ -97,7 +97,7 @@ namespace Moq
 			lock (this.setups)
 			{
 				this.setups.Clear();
-				this.activeInvocationShapes.Clear();
+				this.activeSetups.Clear();
 			}
 		}
 

--- a/src/Moq/SetupWithOutParameterSupport.cs
+++ b/src/Moq/SetupWithOutParameterSupport.cs
@@ -11,7 +11,7 @@ using Moq.Properties;
 
 namespace Moq
 {
-	internal abstract class SetupWithOutParameterSupport : Setup
+	internal abstract class SetupWithOutParameterSupport : MethodSetup
 	{
 		private readonly List<KeyValuePair<int, object>> outValues;
 

--- a/src/Moq/SetupWithOutParameterSupport.cs
+++ b/src/Moq/SetupWithOutParameterSupport.cs
@@ -15,7 +15,7 @@ namespace Moq
 	{
 		private readonly List<KeyValuePair<int, object>> outValues;
 
-		protected SetupWithOutParameterSupport(Expression originalExpression, Mock mock, InvocationShape expectation)
+		protected SetupWithOutParameterSupport(Expression originalExpression, Mock mock, MethodExpectation expectation)
 			: base(originalExpression, mock, expectation)
 		{
 			Debug.Assert(expectation != null);

--- a/src/Moq/StubbedPropertyGetterSetup.cs
+++ b/src/Moq/StubbedPropertyGetterSetup.cs
@@ -17,7 +17,7 @@ namespace Moq
 		private Func<object> getter;
 
 		public StubbedPropertyGetterSetup(Mock mock, LambdaExpression originalExpression, MethodInfo method, Func<object> getter)
-			: base(originalExpression: null, mock, new InvocationShape(originalExpression, method, noArguments))
+			: base(originalExpression: null, mock, new MethodExpectation(originalExpression, method, noArguments))
 		{
 			this.getter = getter;
 

--- a/src/Moq/StubbedPropertyGetterSetup.cs
+++ b/src/Moq/StubbedPropertyGetterSetup.cs
@@ -10,7 +10,7 @@ namespace Moq
 	/// <summary>
 	///   Setup used by <see cref="Mock.SetupAllProperties(Mock)"/> for property getters.
 	/// </summary>
-	internal sealed class StubbedPropertyGetterSetup : Setup
+	internal sealed class StubbedPropertyGetterSetup : MethodSetup
 	{
 		private static Expression[] noArguments = new Expression[0];
 

--- a/src/Moq/StubbedPropertyGetterSetup.cs
+++ b/src/Moq/StubbedPropertyGetterSetup.cs
@@ -2,6 +2,7 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -24,7 +25,17 @@ namespace Moq
 			this.MarkAsVerifiable();
 		}
 
-		public override Mock InnerMock => TryGetInnerMockFrom(this.getter.Invoke());
+		public override IEnumerable<Mock> InnerMocks
+		{
+			get
+			{
+				var innerMock = TryGetInnerMockFrom(this.getter.Invoke());
+				if (innerMock != null)
+				{
+					yield return innerMock;
+				}
+			}
+		}
 
 		protected override void ExecuteCore(Invocation invocation)
 		{

--- a/src/Moq/StubbedPropertySetterSetup.cs
+++ b/src/Moq/StubbedPropertySetterSetup.cs
@@ -16,7 +16,7 @@ namespace Moq
 		private Action<object> setter;
 
 		public StubbedPropertySetterSetup(Mock mock, LambdaExpression originalExpression, MethodInfo method, Action<object> setter)
-			: base(originalExpression: null, mock, new InvocationShape(originalExpression, method, new Expression[] { It.IsAny(method.GetParameterTypes().Last()) }))
+			: base(originalExpression: null, mock, new MethodExpectation(originalExpression, method, new Expression[] { It.IsAny(method.GetParameterTypes().Last()) }))
 		{
 			this.setter = setter;
 

--- a/src/Moq/StubbedPropertySetterSetup.cs
+++ b/src/Moq/StubbedPropertySetterSetup.cs
@@ -11,7 +11,7 @@ namespace Moq
 	/// <summary>
 	///   Setup used by <see cref="Mock.SetupAllProperties(Mock)"/> for property setters.
 	/// </summary>
-	internal sealed class StubbedPropertySetterSetup : Setup
+	internal sealed class StubbedPropertySetterSetup : MethodSetup
 	{
 		private Action<object> setter;
 

--- a/tests/Moq.Tests/MethodExpectationFixture.cs
+++ b/tests/Moq.Tests/MethodExpectationFixture.cs
@@ -10,14 +10,14 @@ using Xunit;
 
 namespace Moq.Tests
 {
-	public class InvocationShapeFixture
+	public class MethodExpectationFixture
 	{
 		// This test is unspectacular but sets the stage for the one following it. See comment below.
 		[Fact]
 		public void Regular_parameters_are_compared_using_equality()
 		{
-			var fst = ToInvocationShape<A>(a => a.Method(1, 2, 3));
-			var snd = ToInvocationShape<A>(a => a.Method(1, 2, 3));
+			var fst = ToMethodExpectation<A>(a => a.Method(1, 2, 3));
+			var snd = ToMethodExpectation<A>(a => a.Method(1, 2, 3));
 
 			Assert.NotSame(fst, snd);
 			Assert.Equal(fst, snd);
@@ -30,8 +30,8 @@ namespace Moq.Tests
 		[Fact]
 		public void Param_array_args_are_compared_using_structural_equality_not_reference_equality()
 		{
-			var fst = ToInvocationShape<B>(b => b.Method(1, 2, 3));
-			var snd = ToInvocationShape<B>(b => b.Method(1, 2, 3));
+			var fst = ToMethodExpectation<B>(b => b.Method(1, 2, 3));
+			var snd = ToMethodExpectation<B>(b => b.Method(1, 2, 3));
 
 			Assert.NotSame(fst, snd);
 			Assert.Equal(fst, snd);
@@ -42,8 +42,8 @@ namespace Moq.Tests
 		{
 			int x = 1;
 
-			var fst = ToInvocationShape<B>(b => b.Method(1, 2, 3));
-			var snd = ToInvocationShape<B>(b => b.Method(x, 2, 3));
+			var fst = ToMethodExpectation<B>(b => b.Method(1, 2, 3));
+			var snd = ToMethodExpectation<B>(b => b.Method(x, 2, 3));
 			//                                           ^
 			// `x` will be captured and represented in the expression tree as a display class field access:
 			var xExpr = ((snd.Expression.Body as MethodCallExpression).Arguments.Last() as NewArrayExpression).Expressions.First();
@@ -53,13 +53,13 @@ namespace Moq.Tests
 			Assert.Equal(fst, snd);
 		}
 
-		private static InvocationShape ToInvocationShape<T>(Expression<Action<T>> expression)
+		private static MethodExpectation ToMethodExpectation<T>(Expression<Action<T>> expression)
 		{
 			Debug.Assert(expression != null);
 			Debug.Assert(expression.Body is MethodCallExpression);
 
 			var methodCall = (MethodCallExpression)expression.Body;
-			return new InvocationShape(expression, methodCall.Method, methodCall.Arguments);
+			return new MethodExpectation(expression, methodCall.Method, methodCall.Arguments);
 		}
 
 		public interface A


### PR DESCRIPTION
This refactoring enables setups that handle more than just a single method.

I'm have two use cases in mind:

 1. `StubbedPropertyGetterSetup` and `StubbedPropertySetterSetup` could be merged into a single setup type. This would be more efficient than what we have now, and also better capture the semantics of a call to `mock.SetupProperty()`.

 2. It would allow creation of a new setup type `StubbedPropertiesSetup` backing `mock.SetupAllProperties()`. This would be added on `mock.SetupAllProperties()` and keep track of any number of properties' values. Again, this would be more efficient than the current solution, allow us to get rid of some convoluted internal bits (such as [`SetupCollection.RemoveAllPropertyAccessorSetups`](https://github.com/moq/moq4/blob/eacd7571c063fb458072289dfd40f708a8a258bc/src/Moq/SetupCollection.cs#L75-L93)), and it may help solve #1066.