### PR TITLE
Disallow use of type matchers in `.Callback` and `.Returns`

### DIFF
--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -172,9 +172,16 @@ namespace Moq
 							callback.GetMethodInfo().GetParameterTypeList()));
 				}
 
-				if (callback.GetMethodInfo().ReturnType != typeof(void))
+				var callbackMethod = callback.GetMethodInfo();
+
+				if (callbackMethod.ReturnType != typeof(void))
 				{
 					throw new ArgumentException(Resources.InvalidCallbackNotADelegateWithReturnTypeVoid, nameof(callback));
+				}
+
+				if (callbackMethod.GetParameterTypes().Any(Extensions.IsOrContainsTypeMatcher))
+				{
+					throw new ArgumentException(Resources.TypeMatchersMayNotBeUsedWithCallbacks);
 				}
 
 				behavior = new Callback(invocation => callback.InvokePreserveStack(invocation.Arguments));
@@ -283,6 +290,11 @@ namespace Moq
 				ValidateNumberOfCallbackParameters(callback, callbackMethod);
 
 				ValidateCallbackReturnType(callbackMethod, expectedReturnType);
+
+				if (callbackMethod.GetParameterTypes().Any(Extensions.IsOrContainsTypeMatcher))
+				{
+					throw new ArgumentException(Resources.TypeMatchersMayNotBeUsedWithCallbacks);
+				}
 			}
 		}
 		

--- a/src/Moq/Properties/Resources.Designer.cs
+++ b/src/Moq/Properties/Resources.Designer.cs
@@ -554,6 +554,15 @@ namespace Moq.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Type matchers may not be used as the type for &apos;Callback&apos; or &apos;Returns&apos; parameters, because no argument will never have that precise type. Consider using type &apos;object&apos; instead..
+        /// </summary>
+        internal static string TypeMatchersMayNotBeUsedWithCallbacks {
+            get {
+                return ResourceManager.GetString("TypeMatchersMayNotBeUsedWithCallbacks", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Type {0} does not implement required interface {1}.
         /// </summary>
         internal static string TypeNotImplementInterface {

--- a/src/Moq/Properties/Resources.resx
+++ b/src/Moq/Properties/Resources.resx
@@ -351,4 +351,7 @@ This could be caused by an unrecognized type conversion, coercion, narrowing, or
   <data name="UseItIsOtherOverload" xml:space="preserve">
     <value>It is impossible to call the provided strongly-typed predicate due to the use of a type matcher. Provide a weakly-typed predicate with two parameters (object, Type) instead.</value>
   </data>
+  <data name="TypeMatchersMayNotBeUsedWithCallbacks" xml:space="preserve">
+    <value>Type matchers may not be used as the type for 'Callback' or 'Returns' parameters, because no argument will never have that precise type. Consider using type 'object' instead.</value>
+  </data>
 </root>

--- a/tests/Moq.Tests/ItIsAnyTypeFixture.cs
+++ b/tests/Moq.Tests/ItIsAnyTypeFixture.cs
@@ -202,6 +202,38 @@ namespace Moq.Tests
 		}
 
 		[Fact]
+		public void Type_matcher_should_be_disallowed_in_Callback()
+		{
+			var mock = new Mock<IY>();
+			var setup = mock.Setup(m => m.Method(It.IsAny<It.IsAnyType>()));
+
+			Assert.Throws<ArgumentException>(() => setup.Callback<It.IsAnyType>(arg => { }));
+			//                                                                  ^^^
+			// Similar to the above test, no actual argument will ever have type `It.IsAnyType`;
+			// Moq should mark this as illegal use, and one should be using `object` instead.
+
+			_ = mock.Object.Method(true);
+			//                     ^^^^
+			// this would cause an `ArgumentException`: "... cannot be converted to type 'It.IsAnyType'"
+		}
+
+		[Fact]
+		public void Type_matcher_should_be_disallowed_in_Returns()
+		{
+			var mock = new Mock<IY>();
+			var setup = mock.Setup(m => m.Method(It.IsAny<It.IsAnyType>()));
+
+			Assert.Throws<ArgumentException>(() => setup.Returns<It.IsAnyType>(arg => arg));
+			//                                                                 ^^^
+			// Similar to the above test, no actual argument will ever have type `It.IsAnyType`;
+			// Moq should mark this as illegal use, and one should be using `object` instead.
+
+			_ = mock.Object.Method(true);
+			//                     ^^^^
+			// this would cause an `ArgumentException`: "... cannot be converted to type 'It.IsAnyType'"
+		}
+
+		[Fact]
 		public void Setup_with_It_Ref_It_IsAnyType_IsAny()
 		{
 			object received = null;


### PR DESCRIPTION
Resolves #1205.