### PR TITLE
 Ability to specify proxy generator or invalidate it #925 

### DIFF
--- a/src/Moq/ActionObserver.cs
+++ b/src/Moq/ActionObserver.cs
@@ -107,7 +107,7 @@ namespace Moq
 				}
 			}
 
-			Expression[] GetArgumentExpressions(Invocation invocation, Match[] matches)
+			Expression[] GetArgumentExpressions(IInvocation invocation, Match[] matches)
 			{
 				// First, let's pretend that all arguments are constant values:
 				var parameterTypes = invocation.Method.GetParameterTypes();
@@ -239,7 +239,7 @@ namespace Moq
 		{
 			private readonly MatcherObserver matcherObserver;
 			private int creationTimestamp;
-			private Invocation invocation;
+			private IInvocation invocation;
 			private int invocationTimestamp;
 			private object returnValue;
 
@@ -251,7 +251,7 @@ namespace Moq
 				this.creationTimestamp = this.matcherObserver.GetNextTimestamp();
 			}
 
-			public Invocation Invocation => this.invocation;
+			public IInvocation Invocation => this.invocation;
 
 			public IEnumerable<Match> Matches
 			{
@@ -264,7 +264,7 @@ namespace Moq
 
 			public Recorder Next => (Awaitable.TryGetResultRecursive(this.returnValue) as IProxy)?.Interceptor as Recorder;
 
-			public void Intercept(Invocation invocation)
+			public void Intercept(IInvocation invocation)
 			{
 				var returnType = invocation.Method.ReturnType;
 

--- a/src/Moq/Async/IAwaitableFactory.cs
+++ b/src/Moq/Async/IAwaitableFactory.cs
@@ -7,18 +7,32 @@ using System.Linq.Expressions;
 
 namespace Moq.Async
 {
-	internal interface IAwaitableFactory
+	/// <summary>
+	/// </summary>
+	public interface IAwaitableFactory
 	{
+		/// <summary>
+		/// </summary>
 		Type ResultType { get; }
 
+		/// <summary>
+		/// </summary>
 		object CreateCompleted(object result = null);
 
+		/// <summary>
+		/// </summary>
 		object CreateFaulted(Exception exception);
 
+		/// <summary>
+		/// </summary>
 		object CreateFaulted(IEnumerable<Exception> exceptions);
 
+		/// <summary>
+		/// </summary>
 		Expression CreateResultExpression(Expression awaitableExpression);
 
+		/// <summary>
+		/// </summary>
 		bool TryGetResult(object awaitable, out object result);
 	}
 }

--- a/src/Moq/AutoImplementedPropertyGetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertyGetterSetup.cs
@@ -24,7 +24,7 @@ namespace Moq
 			this.MarkAsVerifiable();
 		}
 
-		protected override void ExecuteCore(Invocation invocation)
+		protected override void ExecuteCore(IInvocation invocation)
 		{
 			invocation.ReturnValue = this.getter.Invoke();
 		}

--- a/src/Moq/AutoImplementedPropertySetterSetup.cs
+++ b/src/Moq/AutoImplementedPropertySetterSetup.cs
@@ -23,7 +23,7 @@ namespace Moq
 			this.MarkAsVerifiable();
 		}
 
-		protected override void ExecuteCore(Invocation invocation)
+		protected override void ExecuteCore(IInvocation invocation)
 		{
 			this.setter.Invoke(invocation.Arguments[0]);
 		}

--- a/src/Moq/Behavior.cs
+++ b/src/Moq/Behavior.cs
@@ -9,6 +9,6 @@ namespace Moq
 		{
 		}
 
-		public abstract void Execute(Invocation invocation);
+		public abstract void Execute(IInvocation invocation);
 	}
 }

--- a/src/Moq/Behaviors/Callback.cs
+++ b/src/Moq/Behaviors/Callback.cs
@@ -17,7 +17,7 @@ namespace Moq.Behaviors
 			this.callback = callback;
 		}
 
-		public override void Execute(Invocation invocation)
+		public override void Execute(IInvocation invocation)
 		{
 			this.callback.Invoke(invocation);
 		}

--- a/src/Moq/Behaviors/LimitInvocationCount.cs
+++ b/src/Moq/Behaviors/LimitInvocationCount.cs
@@ -21,7 +21,7 @@ namespace Moq.Behaviors
 			this.count = 0;
 		}
 
-		public override void Execute(Invocation invocation)
+		public override void Execute(IInvocation invocation)
 		{
 			++this.count;
 

--- a/src/Moq/Behaviors/NoOp.cs
+++ b/src/Moq/Behaviors/NoOp.cs
@@ -11,7 +11,7 @@ namespace Moq.Behaviors
 		{
 		}
 
-		public override void Execute(Invocation invocation)
+		public override void Execute(IInvocation invocation)
 		{
 		}
 	}

--- a/src/Moq/Behaviors/RaiseEvent.cs
+++ b/src/Moq/Behaviors/RaiseEvent.cs
@@ -26,7 +26,7 @@ namespace Moq.Behaviors
 			this.eventArgsParams = eventArgsParams;
 		}
 
-		public override void Execute(Invocation invocation)
+		public override void Execute(IInvocation invocation)
 		{
 			object[] args;
 

--- a/src/Moq/Behaviors/ReturnBase.cs
+++ b/src/Moq/Behaviors/ReturnBase.cs
@@ -11,7 +11,7 @@ namespace Moq.Behaviors
 		{
 		}
 
-		public override void Execute(Invocation invocation)
+		public override void Execute(IInvocation invocation)
 		{
 			invocation.ReturnValue = invocation.CallBase();
 		}

--- a/src/Moq/Behaviors/ReturnBaseOrDefaultValue.cs
+++ b/src/Moq/Behaviors/ReturnBaseOrDefaultValue.cs
@@ -17,7 +17,7 @@ namespace Moq.Behaviors
 			this.mock = mock;
 		}
 
-		public override void Execute(Invocation invocation)
+		public override void Execute(IInvocation invocation)
 		{
 			Debug.Assert(invocation.Method != null);
 			Debug.Assert(invocation.Method.ReturnType != null);

--- a/src/Moq/Behaviors/ReturnComputedValue.cs
+++ b/src/Moq/Behaviors/ReturnComputedValue.cs
@@ -17,7 +17,7 @@ namespace Moq.Behaviors
 			this.valueFactory = valueFactory;
 		}
 
-		public override void Execute(Invocation invocation)
+		public override void Execute(IInvocation invocation)
 		{
 			invocation.ReturnValue = this.valueFactory.Invoke(invocation);
 		}

--- a/src/Moq/Behaviors/ReturnValue.cs
+++ b/src/Moq/Behaviors/ReturnValue.cs
@@ -14,7 +14,7 @@ namespace Moq.Behaviors
 
 		public object Value => this.value;
 
-		public override void Execute(Invocation invocation)
+		public override void Execute(IInvocation invocation)
 		{
 			invocation.ReturnValue = this.value;
 		}

--- a/src/Moq/Behaviors/ThrowException.cs
+++ b/src/Moq/Behaviors/ThrowException.cs
@@ -17,7 +17,7 @@ namespace Moq.Behaviors
 			this.exception = exception;
 		}
 
-		public override void Execute(Invocation invocation)
+		public override void Execute(IInvocation invocation)
 		{
 			throw this.exception;
 		}

--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -481,7 +481,7 @@ namespace Moq
 			return setups.FirstOrDefault(setup => setup.Expectation.Equals(expectation));
 		}
 
-		public static Setup TryFind(this IEnumerable<Setup> setups, Invocation invocation)
+		public static Setup TryFind(this IEnumerable<Setup> setups, IInvocation invocation)
 		{
 			return setups.FirstOrDefault(setup => setup.Matches(invocation));
 		}

--- a/src/Moq/IInvocation.cs
+++ b/src/Moq/IInvocation.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Moq.Async;
 
 namespace Moq
 {
@@ -18,14 +19,22 @@ namespace Moq
 		MethodInfo Method { get; }
 
 		/// <summary>
+		/// </summary>
+		MethodInfo MethodImplementation { get; }
+
+		/// <summary>
 		/// Gets the arguments of the invocation.
 		/// </summary>
-		IReadOnlyList<object> Arguments { get; }
+		object[] Arguments { get; }
 
 		/// <summary>
 		///   Gets the setup that matched this invocation (or <see langword="null"/> if there was no matching setup).
 		/// </summary>
 		ISetup MatchingSetup { get; }
+
+		/// <summary>
+		/// </summary>
+		Type ProxyType { get; }
 
 		/// <summary>
 		///   Gets whether this invocation was successfully verified by any of the various <c>`Verify`</c> methods.
@@ -35,11 +44,23 @@ namespace Moq
 		/// <summary>
 		/// The value being returned for a non-void method if no exception was thrown.
 		/// </summary>
-		object ReturnValue { get; }
+		object ReturnValue { get; set; }
 
 		/// <summary>
 		/// Optional exception if the method invocation results in an exception being thrown.
 		/// </summary>
-		Exception Exception { get; }
+		Exception Exception { get; set; }
+
+		/// <summary>
+		/// </summary>
+		void MarkAsMatchedBy(ISetup setup);
+
+		/// <summary>
+		/// </summary>
+		void ConvertResultToAwaitable(IAwaitableFactory awaitableFactory);
+
+		/// <summary>
+		/// </summary>
+		object CallBase();
 	}
 }

--- a/src/Moq/InnerMockSetup.cs
+++ b/src/Moq/InnerMockSetup.cs
@@ -22,7 +22,7 @@ namespace Moq
 			this.MarkAsVerifiable();
 		}
 
-		protected override void ExecuteCore(Invocation invocation)
+		protected override void ExecuteCore(IInvocation invocation)
 		{
 			invocation.ReturnValue = this.returnValue;
 		}

--- a/src/Moq/Interception/IInterceptor.cs
+++ b/src/Moq/Interception/IInterceptor.cs
@@ -7,8 +7,10 @@ namespace Moq
 	/// This role interface represents a <see cref="Mock"/>'s ability to intercept method invocations for its <see cref="Mock.Object"/>.
 	/// It is meant for use by <see cref="ProxyFactory"/>.
 	/// </summary>
-	internal interface IInterceptor
+	public interface IInterceptor
 	{
-		void Intercept(Invocation invocation);
+		/// <summary>
+		/// </summary>
+		void Intercept(IInvocation invocation);
 	}
 }

--- a/src/Moq/Interception/InterceptionAspects.cs
+++ b/src/Moq/Interception/InterceptionAspects.cs
@@ -13,7 +13,7 @@ namespace Moq
 {
 	internal static class HandleWellKnownMethods
 	{
-		private static Dictionary<string, Func<Invocation, Mock, bool>> specialMethods = new Dictionary<string, Func<Invocation, Mock, bool>>()
+		private static Dictionary<string, Func<IInvocation, Mock, bool>> specialMethods = new Dictionary<string, Func<IInvocation, Mock, bool>>()
 		{
 			["Equals"] = HandleEquals,
 			["Finalize"] = HandleFinalize,
@@ -22,13 +22,13 @@ namespace Moq
 			["ToString"] = HandleToString,
 		};
 
-		public static bool Handle(Invocation invocation, Mock mock)
+		public static bool Handle(IInvocation invocation, Mock mock)
 		{
 			return specialMethods.TryGetValue(invocation.Method.Name, out var handler)
 				&& handler.Invoke(invocation, mock);
 		}
 
-		private static bool HandleEquals(Invocation invocation, Mock mock)
+		private static bool HandleEquals(IInvocation invocation, Mock mock)
 		{
 			if (IsObjectMethod(invocation.Method) && !mock.MutableSetups.Any(c => IsObjectMethod(c.Method, "Equals")))
 			{
@@ -41,12 +41,12 @@ namespace Moq
 			}
 		}
 
-		private static bool HandleFinalize(Invocation invocation, Mock mock)
+		private static bool HandleFinalize(IInvocation invocation, Mock mock)
 		{
 			return IsFinalizer(invocation.Method);
 		}
 
-		private static bool HandleGetHashCode(Invocation invocation, Mock mock)
+		private static bool HandleGetHashCode(IInvocation invocation, Mock mock)
 		{
 			// Only if there is no corresponding setup for `GetHashCode()`
 			if (IsObjectMethod(invocation.Method) && !mock.MutableSetups.Any(c => IsObjectMethod(c.Method, "GetHashCode")))
@@ -60,7 +60,7 @@ namespace Moq
 			}
 		}
 
-		private static bool HandleToString(Invocation invocation, Mock mock)
+		private static bool HandleToString(IInvocation invocation, Mock mock)
 		{
 			// Only if there is no corresponding setup for `ToString()`
 			if (IsObjectMethod(invocation.Method) && !mock.MutableSetups.Any(c => IsObjectMethod(c.Method, "ToString")))
@@ -74,7 +74,7 @@ namespace Moq
 			}
 		}
 
-		private static bool HandleMockGetter(Invocation invocation, Mock mock)
+		private static bool HandleMockGetter(IInvocation invocation, Mock mock)
 		{
 			if (typeof(IMocked).IsAssignableFrom(invocation.Method.DeclaringType))
 			{
@@ -99,7 +99,7 @@ namespace Moq
 
 	internal static class FindAndExecuteMatchingSetup
 	{
-		public static bool Handle(Invocation invocation, Mock mock)
+		public static bool Handle(IInvocation invocation, Mock mock)
 		{
 			var matchingSetup = mock.MutableSetups.FindMatchFor(invocation);
 			if (matchingSetup != null)
@@ -116,7 +116,7 @@ namespace Moq
 
 	internal static class HandleEventSubscription
 	{
-		public static bool Handle(Invocation invocation, Mock mock)
+		public static bool Handle(IInvocation invocation, Mock mock)
 		{
 			const BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly;
 
@@ -170,7 +170,7 @@ namespace Moq
 
 	internal static class RecordInvocation
 	{
-		public static void Handle(Invocation invocation, Mock mock)
+		public static void Handle(IInvocation invocation, Mock mock)
 		{
 			// Save to support Verify[expression] pattern.
 			mock.MutableInvocations.Add(invocation);
@@ -179,7 +179,7 @@ namespace Moq
 
 	internal static class Return
 	{
-		public static void Handle(Invocation invocation, Mock mock)
+		public static void Handle(IInvocation invocation, Mock mock)
 		{
 			new ReturnBaseOrDefaultValue(mock).Execute(invocation);
 		}
@@ -189,7 +189,7 @@ namespace Moq
 	{
 		private static readonly int AccessorPrefixLength = "?et_".Length; // get_ or set_
 
-		public static bool Handle(Invocation invocation, Mock mock)
+		public static bool Handle(IInvocation invocation, Mock mock)
 		{
 			if (mock.AutoSetupPropertiesDefaultValueProvider == null)
 			{
@@ -278,7 +278,7 @@ namespace Moq
 
 	internal static class FailForStrictMock
 	{
-		public static void Handle(Invocation invocation, Mock mock)
+		public static void Handle(IInvocation invocation, Mock mock)
 		{
 			if (mock.Behavior == MockBehavior.Strict)
 			{

--- a/src/Moq/Interception/Mock.cs
+++ b/src/Moq/Interception/Mock.cs
@@ -5,7 +5,7 @@ namespace Moq
 {
 	partial class Mock : IInterceptor
 	{
-		void IInterceptor.Intercept(Invocation invocation)
+		void IInterceptor.Intercept(IInvocation invocation)
 		{
 			if (HandleWellKnownMethods.Handle(invocation, this))
 			{

--- a/src/Moq/Invocation.cs
+++ b/src/Moq/Invocation.cs
@@ -18,7 +18,7 @@ namespace Moq
 		private MethodInfo methodImplementation;
 		private readonly Type proxyType;
 		private object result;
-		private Setup matchingSetup;
+		private ISetup matchingSetup;
 		private bool verified;
 
 		/// <summary>
@@ -65,8 +65,6 @@ namespace Moq
 		/// </remarks>
 		public object[] Arguments => this.arguments;
 
-		IReadOnlyList<object> IInvocation.Arguments => this.arguments;
-
 		public ISetup MatchingSetup => this.matchingSetup;
 
 		public Type ProxyType => this.proxyType;
@@ -109,9 +107,9 @@ namespace Moq
 		///   Calls the <see langword="base"/> method implementation
 		///   and returns its return value (or <see langword="null"/> for <see langword="void"/> methods).
 		/// </summary>
-		protected internal abstract object CallBase();
+		public abstract object CallBase();
 
-		internal void MarkAsMatchedBy(Setup setup)
+		public void MarkAsMatchedBy(ISetup setup)
 		{
 			Debug.Assert(this.matchingSetup == null);
 
@@ -120,7 +118,7 @@ namespace Moq
 
 		internal void MarkAsVerified() => this.verified = true;
 
-		internal void MarkAsVerifiedIfMatchedBy(Func<Setup, bool> predicate)
+		internal void MarkAsVerifiedIfMatchedBy(Func<ISetup, bool> predicate)
 		{
 			if (this.matchingSetup != null && predicate(this.matchingSetup))
 			{

--- a/src/Moq/InvocationCollection.cs
+++ b/src/Moq/InvocationCollection.cs
@@ -10,7 +10,7 @@ namespace Moq
 {
 	internal sealed class InvocationCollection : IInvocationList
 	{
-		private Invocation[] invocations;
+		private IInvocation[] invocations;
 
 		private int capacity = 0;
 		private int count = 0;
@@ -52,7 +52,7 @@ namespace Moq
 			}
 		}
 
-		public void Add(Invocation invocation)
+		public void Add(IInvocation invocation)
 		{
 			lock (this.invocationsLock)
 			{
@@ -99,7 +99,7 @@ namespace Moq
 			}
 		}
 
-		public Invocation[] ToArray(Func<Invocation, bool> predicate)
+		public IInvocation[] ToArray(Func<IInvocation, bool> predicate)
 		{
 			lock (this.invocationsLock)
 			{
@@ -108,7 +108,7 @@ namespace Moq
 					return new Invocation[0];
 				}
 				
-				var result = new List<Invocation>(this.count);
+				var result = new List<IInvocation>(this.count);
 
 				for (var i = 0; i < this.count; i++)
 				{
@@ -126,7 +126,7 @@ namespace Moq
 		public IEnumerator<IInvocation> GetEnumerator()
 		{
 			// Take local copies of collection and count so they are isolated from changes by other threads.
-			Invocation[] collection;
+			IInvocation[] collection;
 			int count;
 
 			lock (this.invocationsLock)

--- a/src/Moq/InvocationShape.cs
+++ b/src/Moq/InvocationShape.cs
@@ -26,7 +26,7 @@ namespace Moq
 	/// </summary>
 	internal sealed class InvocationShape : IEquatable<InvocationShape>
 	{
-		public static InvocationShape CreateFrom(Invocation invocation)
+		public static InvocationShape CreateFrom(IInvocation invocation)
 		{
 			var method = invocation.Method;
 
@@ -118,7 +118,7 @@ namespace Moq
 			arguments = this.Arguments;
 		}
 
-		public bool IsMatch(Invocation invocation)
+		public bool IsMatch(IInvocation invocation)
 		{
 			if (invocation.Method != this.Method && !this.IsOverride(invocation))
 			{
@@ -138,7 +138,7 @@ namespace Moq
 			return true;
 		}
 
-		public void SetupEvaluatedSuccessfully(Invocation invocation)
+		public void SetupEvaluatedSuccessfully(IInvocation invocation)
 		{
 			var arguments = invocation.Arguments;
 			var parameterTypes = invocation.Method.GetParameterTypes();
@@ -148,7 +148,7 @@ namespace Moq
 			}
 		}
 
-		private bool IsOverride(Invocation invocation)
+		private bool IsOverride(IInvocation invocation)
 		{
 			Debug.Assert(invocation.Method != this.Method);
 

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -82,7 +82,7 @@ namespace Moq
 			return null;
 		}
 
-		protected override void ExecuteCore(Invocation invocation)
+		protected override void ExecuteCore(IInvocation invocation)
 		{
 			this.limitInvocationCount?.Execute(invocation);
 

--- a/src/Moq/MockException.cs
+++ b/src/Moq/MockException.cs
@@ -130,7 +130,7 @@ namespace Moq
 		/// <summary>
 		///   Returns the exception to be thrown when a strict mock has no setup corresponding to the specified invocation.
 		/// </summary>
-		internal static MockException NoSetup(Invocation invocation)
+		internal static MockException NoSetup(IInvocation invocation)
 		{
 			return new MockException(
 				MockExceptionReasons.NoSetup,
@@ -145,7 +145,7 @@ namespace Moq
 		/// <summary>
 		///   Returns the exception to be thrown when a strict mock has no setup that provides a return value for the specified invocation.
 		/// </summary>
-		internal static MockException ReturnValueRequired(Invocation invocation)
+		internal static MockException ReturnValueRequired(IInvocation invocation)
 		{
 			return new MockException(
 				MockExceptionReasons.ReturnValueRequired,
@@ -214,7 +214,7 @@ namespace Moq
 		/// <summary>
 		///   Returns the exception to be thrown when <see cref="Mock.VerifyNoOtherCalls(Mock)"/> finds invocations that have not been verified.
 		/// </summary>
-		internal static MockException UnverifiedInvocations(Mock mock, IEnumerable<Invocation> invocations)
+		internal static MockException UnverifiedInvocations(Mock mock, IEnumerable<IInvocation> invocations)
 		{
 			var message = new StringBuilder();
 

--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -6,7 +6,7 @@
 	<Import Project="$(BuildDirectory)SourceLink.props" />
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net45;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
 		<AssemblyName>Moq</AssemblyName>
 		<DebugSymbols>True</DebugSymbols>
 		<DebugType>embedded</DebugType>

--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -6,7 +6,7 @@
 	<Import Project="$(BuildDirectory)SourceLink.props" />
 
 	<PropertyGroup>
-		<TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net6.0;net45;netstandard2.0</TargetFrameworks>
 		<AssemblyName>Moq</AssemblyName>
 		<DebugSymbols>True</DebugSymbols>
 		<DebugType>embedded</DebugType>

--- a/src/Moq/ProxyFactories/CastleProxyFactory.cs
+++ b/src/Moq/ProxyFactories/CastleProxyFactory.cs
@@ -16,6 +16,27 @@ using Moq.Properties;
 namespace Moq
 {
 	/// <summary>
+	/// An implementation of <see cref="ProxyFactory"/> that is based on Cecil.
+	/// </summary>
+	internal sealed class CecilProxyFactory : ProxyFactory
+	{
+		public override object CreateProxy(Type mockType, IInterceptor interceptor, Type[] interfaces, object[] arguments)
+		{
+			throw new NotImplementedException();
+		}
+
+		public override bool IsMethodVisible(MethodInfo method, out string messageIfNotVisible)
+		{
+			throw new NotImplementedException();
+		}
+
+		public override bool IsTypeVisible(Type type)
+		{
+			throw new NotImplementedException();
+		}
+	}
+
+	/// <summary>
 	/// An implementation of <see cref="ProxyFactory"/> that is based on Castle DynamicProxy.
 	/// </summary>
 	internal sealed class CastleProxyFactory : ProxyFactory
@@ -122,7 +143,7 @@ namespace Moq
 				this.underlying = underlying;
 			}
 
-			protected internal override object CallBase()
+			public override object CallBase()
 			{
 				Debug.Assert(this.underlying != null);
 

--- a/src/Moq/ProxyFactories/CastleProxyFactory.cs
+++ b/src/Moq/ProxyFactories/CastleProxyFactory.cs
@@ -16,27 +16,6 @@ using Moq.Properties;
 namespace Moq
 {
 	/// <summary>
-	/// An implementation of <see cref="ProxyFactory"/> that is based on Cecil.
-	/// </summary>
-	internal sealed class CecilProxyFactory : ProxyFactory
-	{
-		public override object CreateProxy(Type mockType, IInterceptor interceptor, Type[] interfaces, object[] arguments)
-		{
-			throw new NotImplementedException();
-		}
-
-		public override bool IsMethodVisible(MethodInfo method, out string messageIfNotVisible)
-		{
-			throw new NotImplementedException();
-		}
-
-		public override bool IsTypeVisible(Type type)
-		{
-			throw new NotImplementedException();
-		}
-	}
-
-	/// <summary>
 	/// An implementation of <see cref="ProxyFactory"/> that is based on Castle DynamicProxy.
 	/// </summary>
 	internal sealed class CastleProxyFactory : ProxyFactory

--- a/src/Moq/ProxyFactories/InterfaceProxy.cs
+++ b/src/Moq/ProxyFactories/InterfaceProxy.cs
@@ -68,7 +68,7 @@ namespace Moq.Internals
 			{
 			}
 
-			protected internal override object CallBase()
+			public override object CallBase()
 			{
 				throw new NotSupportedException();
 			}

--- a/src/Moq/ProxyFactories/ProxyFactory.cs
+++ b/src/Moq/ProxyFactories/ProxyFactory.cs
@@ -6,17 +6,25 @@ using System.Reflection;
 
 namespace Moq
 {
-	internal abstract class ProxyFactory
+	/// <summary>
+	/// </summary>
+	public abstract class ProxyFactory
 	{
 		/// <summary>
 		/// Gets the global <see cref="ProxyFactory"/> instance used by Moq.
 		/// </summary>
-		public static ProxyFactory Instance { get; } = new CastleProxyFactory();
+		public static ProxyFactory Instance { get; set; } = new CastleProxyFactory();
 
+		/// <summary>
+		/// </summary>
 		public abstract object CreateProxy(Type mockType, IInterceptor interceptor, Type[] interfaces, object[] arguments);
 
+		/// <summary>
+		/// </summary>
 		public abstract bool IsMethodVisible(MethodInfo method, out string messageIfNotVisible);
 
+		/// <summary>
+		/// </summary>
 		public abstract bool IsTypeVisible(Type type);
 	}
 }

--- a/src/Moq/SequenceSetup.cs
+++ b/src/Moq/SequenceSetup.cs
@@ -28,7 +28,7 @@ namespace Moq
 			this.behaviors.Enqueue(behavior);
 		}
 
-		protected override void ExecuteCore(Invocation invocation)
+		protected override void ExecuteCore(IInvocation invocation)
 		{
 			if (this.behaviors.TryDequeue(out var behavior))
 			{

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -52,7 +52,7 @@ namespace Moq
 
 		public bool IsMatched => (this.flags & Flags.Matched) != 0;
 
-		public void Execute(Invocation invocation)
+		public void Execute(IInvocation invocation)
 		{
 			// update this setup:
 			this.flags |= Flags.Matched;
@@ -86,7 +86,7 @@ namespace Moq
 			}
 		}
 
-		protected abstract void ExecuteCore(Invocation invocation);
+		protected abstract void ExecuteCore(IInvocation invocation);
 
 		/// <summary>
 		///   Attempts to get this setup's return value without invoking user code
@@ -110,12 +110,12 @@ namespace Moq
 			this.flags |= Flags.Verifiable;
 		}
 
-		public bool Matches(Invocation invocation)
+		public bool Matches(IInvocation invocation)
 		{
 			return this.expectation.IsMatch(invocation) && (this.Condition == null || this.Condition.IsTrue);
 		}
 
-		public virtual void SetOutParameters(Invocation invocation)
+		public virtual void SetOutParameters(IInvocation invocation)
 		{
 		}
 

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -109,7 +109,7 @@ namespace Moq
 			}
 		}
 
-		public Setup FindMatchFor(Invocation invocation)
+		public Setup FindMatchFor(IInvocation invocation)
 		{
 			// Fast path (no `lock`) when there are no setups:
 			if (this.setups.Count == 0)

--- a/src/Moq/SetupWithOutParameterSupport.cs
+++ b/src/Moq/SetupWithOutParameterSupport.cs
@@ -23,7 +23,7 @@ namespace Moq
 			this.outValues = GetOutValues(expectation.Arguments, expectation.Method.GetParameters());
 		}
 
-		public sealed override void SetOutParameters(Invocation invocation)
+		public sealed override void SetOutParameters(IInvocation invocation)
 		{
 			if (this.outValues != null)
 			{

--- a/tests/Moq.Tests/InterceptorFixture.cs
+++ b/tests/Moq.Tests/InterceptorFixture.cs
@@ -63,7 +63,7 @@ namespace Moq.Tests
 				this.returnValue = returnValue;
 			}
 
-			public void Intercept(Invocation invocation)
+			public void Intercept(IInvocation invocation)
 			{
 				invocation.ReturnValue = this.returnValue;
 			}


### PR DESCRIPTION
This is a draft for the changes as per our discussion in issue #1083.

I am aware that it might need cleaning up, documentation, and so on. In this first stage, I mainly want feedback on this approach, if it's the right way to go at all.

I opted to make `ProxyFactory` public, which I assume is desirable if we want external projects to provide their own implementations. That in turn cascaded a bit, and required me to make some more types public.

In order to not leak too much implementation, I decided to expose the interface types instead of the abstract base classes. This might require some more boilerplate for alternative proxy factory implementations, but I would argue that it's worth it.

I can also confirm that with these rather crude changes, we are now able to plug in our own proxy generator, and by utilizing Cecil, we have managed to cut our test execution times nearly 2 hours down to 15 minutes.