### PR TITLE
Use same comparison logic in `LazyEvalMatcher` as in `ConstantMatcher`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ and `Setup(x => x.GetFooAsync(It.IsAny<string>()).Result).Throws((string s) => n
 * The guard against unmatchable matchers (added in #900) was too strict; relaxed it to enable an alternative user-code shorthand `_` for `It.IsAny<>()` (@adamfk, #1199)
 * mock.Protected() setup methods fail when argument is of type Expression (@tonyhallett, #1189)
 * Parameter is invalid in Protected().SetupSet() ... VerifySet (@tonyhallett, #1186)
-
 * Virtual properties and automocking not working for `mock.Protected().As<>()` (@tonyhallett, #1185)
 * Issue mocking VB.NET class with overloaded property/indexer in base class (@myurashchyk, #1153)
+* Equivalent arrays don't test equal when returned from a method, making `Verify` fail when it should not (@evilc0, #1225)
 
 
 ## 4.16.1 (2021-02-23)

--- a/src/Moq/Matchers/LazyEvalMatcher.cs
+++ b/src/Moq/Matchers/LazyEvalMatcher.cs
@@ -19,12 +19,7 @@ namespace Moq.Matchers
 		public bool Matches(object argument, Type parameterType)
 		{
 			var eval = Evaluator.PartialEval(this.expression);
-			if (eval.NodeType == ExpressionType.Constant)
-			{
-				return object.Equals(((ConstantExpression)eval).Value, argument);
-			}
-
-			return false;
+			return eval is ConstantExpression ce && new ConstantMatcher(ce.Value).Matches(argument, parameterType);
 		}
 
 		public void SetupEvaluatedSuccessfully(object argument, Type parameterType)

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -3659,6 +3659,57 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 1225
+
+		public class Issue1225
+		{
+			public interface IHardware
+			{
+				void Transmit(IntPtr ptr, byte[] send, byte[] recv);
+			}
+
+			public class MyImpl : IHardware
+			{
+				public void Transmit(IntPtr ptr, byte[] send, byte[] recv)
+				{
+					Console.WriteLine(ptr);
+					Console.WriteLine(BitConverter.ToString(send));
+					Console.WriteLine(BitConverter.ToString(recv));
+				}
+			}
+
+			private static void DoWork(IHardware hw, byte[] send)
+			{
+				hw.Transmit((IntPtr)1, send, new byte[8]);
+			}
+
+			[Fact]
+			public void Pass_byte_array_directly()
+			{
+				Mock<IHardware> hwMock = new Mock<IHardware>();
+				hwMock.Setup(m => m.Transmit(It.IsAny<IntPtr>(), It.IsAny<byte[]>(), It.IsAny<byte[]>()));
+
+				DoWork(hwMock.Object, new byte[] { 1, 2, 3 });
+
+				hwMock.Verify(m => m.Transmit((IntPtr)1, new byte[] { 1, 2, 3 }, It.IsAny<byte[]>()));
+			}
+
+			[Fact]
+			public void Pass_byte_array_indirectly_via_method_call()
+			{
+				Mock<IHardware> hwMock = new Mock<IHardware>();
+				hwMock.Setup(m => m.Transmit(It.IsAny<IntPtr>(), It.IsAny<byte[]>(), It.IsAny<byte[]>()));
+
+				DoWork(hwMock.Object, new byte[] { 1, 2, 3 });
+
+				string inputAsString = Convert.ToBase64String(new byte[] { 1, 2, 3 });
+
+				hwMock.Verify(m => m.Transmit((IntPtr)1, Convert.FromBase64String(inputAsString), It.IsAny<byte[]>()));
+			}
+		}
+
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47


### PR DESCRIPTION
Fixes #1225.