### PR TITLE
Create dedicated setup type for `SetupAllProperties`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
+## Unreleased
+
+#### Fixed
+
+* Property setups are ignored on mocks instantiated using `Mock.Of` (@stakx, #1066)
+* `SetupAllProperties` causes mocks to become race-prone (@estrizhok, #1231)
+
+
 ## 4.17.0 (2022-02-13)
 
 #### Added

--- a/src/Moq/AsInterface.cs
+++ b/src/Moq/AsInterface.cs
@@ -43,12 +43,6 @@ namespace Moq
 			set => this.owner.DefaultValueProvider = value;
 		}
 
-		internal override DefaultValueProvider AutoSetupPropertiesDefaultValueProvider
-		{
-			get => this.owner.AutoSetupPropertiesDefaultValueProvider;
-			set => this.owner.AutoSetupPropertiesDefaultValueProvider = value;
-		}
-
 		internal override EventHandlerCollection EventHandlers => this.owner.EventHandlers;
 
 		internal override Type[] InheritedInterfaces => this.owner.InheritedInterfaces;

--- a/src/Moq/Interception/Mock.cs
+++ b/src/Moq/Interception/Mock.cs
@@ -19,11 +19,6 @@ namespace Moq
 				return;
 			}
 			
-			if (HandleAutoSetupProperties.Handle(invocation, this))
-			{
-				return;
-			}
-
 			if (HandleEventSubscription.Handle(invocation, this))
 			{
 				return;

--- a/src/Moq/Linq/MockSetupsBuilder.cs
+++ b/src/Moq/Linq/MockSetupsBuilder.cs
@@ -132,7 +132,7 @@ namespace Moq.Linq
 			var rewrittenLeft = v.Visit(left);
 
 			return Expression.Call(
-				Mocks.SetupReturnsMethod,
+				Mock.SetupReturnsMethod,
 				// mock:
 				Expression.Call(
 					Mock.GetMethod.MakeGenericMethod(v.MockObject.Type),

--- a/src/Moq/Linq/Mocks.cs
+++ b/src/Moq/Linq/Mocks.cs
@@ -123,27 +123,5 @@ namespace Moq
 			}
 			while (true);
 		}
-
-		internal static readonly MethodInfo SetupReturnsMethod =
-			typeof(Mocks).GetMethod(nameof(SetupReturns), BindingFlags.NonPublic | BindingFlags.Static);
-
-		internal static bool SetupReturns(Mock mock, LambdaExpression expression, object value)
-		{
-			if (expression.Body is MemberExpression me
-				&& me.Member is PropertyInfo pi
-				&& !(pi.CanRead(out var getter) && getter.CanOverride() && ProxyFactory.Instance.IsMethodVisible(getter, out _))
-				&& pi.CanWrite(out _))
-			{
-				// LINQ to Mocks allows setting non-interceptable properties, which is handy e.g. when initializing DTOs.
-				Mock.SetupSet(mock, expression, propertyToSet: pi, value);
-			}
-			else
-			{
-				var setup = Mock.Setup(mock, expression, condition: null);
-				setup.SetReturnValueBehavior(value);
-			}
-
-			return true;
-		}
 	}
 }

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -209,13 +209,6 @@ namespace Moq
 		/// </summary>
 		public abstract DefaultValueProvider DefaultValueProvider { get; set; }
 
-		/// <summary>
-		/// The <see cref="Moq.DefaultValueProvider"/> used to initialize automatically stubbed properties.
-		/// It is equal to the value of <see cref="DefaultValueProvider"/> at the time when
-		/// <see cref="SetupAllProperties"/> was last called.
-		/// </summary>
-		internal abstract DefaultValueProvider AutoSetupPropertiesDefaultValueProvider { get; set; } 
-
 		internal abstract SetupCollection MutableSetups { get; }
 
 		/// <summary>
@@ -539,26 +532,7 @@ namespace Moq
 
 			Mock.SetupRecursive<MethodCall>(mock, expression, setupLast: (targetMock, _, __) =>
 			{
-				// Setting a mock's property through reflection will only work (i.e. the property will only remember the value
-				// it's being set to) if it is being stubbed. In order to ensure it's stubbed, we temporarily enable
-				// auto-stubbing (if that isn't already switched on).
-
-				var temporaryAutoSetupProperties = targetMock.AutoSetupPropertiesDefaultValueProvider == null;
-				if (temporaryAutoSetupProperties)
-				{
-					targetMock.AutoSetupPropertiesDefaultValueProvider = targetMock.DefaultValueProvider;
-				}
-				try
-				{
-					propertyToSet.SetValue(targetMock.Object, value, null);
-				}
-				finally
-				{
-					if (temporaryAutoSetupProperties)
-					{
-						targetMock.AutoSetupPropertiesDefaultValueProvider = null;
-					}
-				}
+				propertyToSet.SetValue(targetMock.Object, value, null);
 				return null;
 			}, allowNonOverridableLastProperty: true);
 		}
@@ -637,21 +611,7 @@ namespace Moq
 
 		internal static void SetupAllProperties(Mock mock)
 		{
-			SetupAllProperties(mock, mock.DefaultValueProvider);
-		}
-
-		internal static void SetupAllProperties(Mock mock, DefaultValueProvider defaultValueProvider)
-		{
-			mock.MutableSetups.RemoveAllPropertyAccessorSetups();
-			// Removing all the previous properties setups to keep the behaviour of overriding
-			// existing setups in `SetupAllProperties`.
-			
-			mock.AutoSetupPropertiesDefaultValueProvider = defaultValueProvider;
-			// `SetupAllProperties` no longer performs properties setup like in previous versions.
-			// Instead it just enables a switch to setup properties on-demand at the moment of first access.
-			// In order for `SetupAllProperties`'s new mode of operation to be indistinguishable
-			// from how it worked previously, it's important to capture the default value provider at this precise
-			// moment, since it might be changed later (before queries to properties).
+			// TODO: implement!
 		}
 
 		#endregion

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -611,7 +611,7 @@ namespace Moq
 
 		internal static void SetupAllProperties(Mock mock)
 		{
-			// TODO: implement!
+			mock.MutableSetups.Add(new StubbedPropertiesSetup(mock));
 		}
 
 		#endregion

--- a/src/Moq/MockDefaultValueProvider.cs
+++ b/src/Moq/MockDefaultValueProvider.cs
@@ -36,7 +36,6 @@ namespace Moq
 				var mockType = typeof(Mock<>).MakeGenericType(type);
 				Mock newMock = (Mock)Activator.CreateInstance(mockType, mock.Behavior);
 				newMock.DefaultValueProvider = mock.DefaultValueProvider;
-				newMock.AutoSetupPropertiesDefaultValueProvider = mock.AutoSetupPropertiesDefaultValueProvider;
 				if(!type.IsDelegateType())
 				{
 					newMock.CallBase = mock.CallBase;

--- a/src/Moq/MockDefaultValueProvider.cs
+++ b/src/Moq/MockDefaultValueProvider.cs
@@ -36,6 +36,10 @@ namespace Moq
 				var mockType = typeof(Mock<>).MakeGenericType(type);
 				Mock newMock = (Mock)Activator.CreateInstance(mockType, mock.Behavior);
 				newMock.DefaultValueProvider = mock.DefaultValueProvider;
+				if (mock.MutableSetups.FindLast(s => s is StubbedPropertiesSetup) is StubbedPropertiesSetup sts)
+				{
+					newMock.MutableSetups.Add(new StubbedPropertiesSetup(newMock, sts.DefaultValueProvider));
+				}
 				if(!type.IsDelegateType())
 				{
 					newMock.CallBase = mock.CallBase;

--- a/src/Moq/Mock`1.cs
+++ b/src/Moq/Mock`1.cs
@@ -265,8 +265,6 @@ namespace Moq
 			set => this.defaultValueProvider = value ?? throw new ArgumentNullException(nameof(value));
 		}
 
-		internal override DefaultValueProvider AutoSetupPropertiesDefaultValueProvider { get; set; }
-
 		internal override EventHandlerCollection EventHandlers => this.eventHandlers;
 
 		internal override List<Type> AdditionalInterfaces => this.additionalInterfaces;

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Moq
 {
@@ -69,26 +68,6 @@ namespace Moq
 					// meaning that this older setup is an overridden one.
 					setup.MarkAsOverridden();
 				}
-			}
-		}
-
-		public void RemoveAllPropertyAccessorSetups()
-		{
-			// Fast path (no `lock`) when there are no setups:
-			if (this.setups.Count == 0)
-			{
-				return;
-			}
-
-			lock (this.setups)
-			{
-				this.setups.RemoveAll(s => s is StubbedPropertySetup || (s is MethodSetup ms && ms.Method.IsPropertyAccessor()));
-
-				// NOTE: In the general case, removing a setup means that some overridden setups might no longer
-				// be shadowed, and their `IsOverridden` flag should go back from `true` to `false`.
-				//
-				// In this particular case however, we don't need to worry about this because we are categorically
-				// removing all property accessors, and they could only have overridden other property accessors.
 			}
 		}
 

--- a/src/Moq/StubbedPropertiesSetup.cs
+++ b/src/Moq/StubbedPropertiesSetup.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors.
+// All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq.Expressions;
+
+using E = System.Linq.Expressions.Expression;
+
+namespace Moq
+{
+	internal sealed class StubbedPropertiesSetup : Setup
+	{
+		private readonly Dictionary<string, object> values;
+		private readonly DefaultValueProvider defaultValueProvider;
+
+		public StubbedPropertiesSetup(Mock mock, DefaultValueProvider defaultValueProvider = null)
+			: base(originalExpression: null, mock, new PropertyAccessorExpectation(mock))
+		{
+			this.values = new Dictionary<string, object>();
+			this.defaultValueProvider = defaultValueProvider ?? mock.DefaultValueProvider;
+
+			this.MarkAsVerifiable();
+		}
+
+		public DefaultValueProvider DefaultValueProvider => this.defaultValueProvider;
+
+		public override IEnumerable<Mock> InnerMocks
+		{
+			get
+			{
+				foreach (var value in this.values.Values)
+				{
+					var innerMock = TryGetInnerMockFrom(value);
+					if (innerMock != null)
+					{
+						yield return innerMock;
+					}
+				}
+			}
+		}
+
+		public void SetProperty(string propertyName, object value)
+		{
+			this.values[propertyName] = value;
+		}
+
+		protected override void ExecuteCore(Invocation invocation)
+		{
+			if (invocation.Method.ReturnType == typeof(void))
+			{
+				Debug.Assert(invocation.Method.IsSetAccessor());
+				Debug.Assert(invocation.Arguments.Length == 1);
+
+				var propertyName = invocation.Method.Name.Substring(4);
+				this.values[propertyName] = invocation.Arguments[0];
+			}
+			else
+			{
+				Debug.Assert(invocation.Method.IsGetAccessor());
+
+				var propertyName = invocation.Method.Name.Substring(4);
+				if (!this.values.TryGetValue(propertyName, out var value))
+				{
+					value = this.values[propertyName] = this.Mock.GetDefaultValue(invocation.Method, out _, this.defaultValueProvider);
+				}
+
+				invocation.ReturnValue = value;
+			}
+		}
+
+		protected override void VerifySelf()
+		{
+		}
+
+		private sealed class PropertyAccessorExpectation : Expectation
+		{
+			private readonly LambdaExpression expression;
+
+			public PropertyAccessorExpectation(Mock mock)
+			{
+				Debug.Assert(mock != null);
+
+				var mockType = mock.GetType();
+				var mockedType = mockType.GetGenericArguments()[0];
+				var mockGetMethod = Mock.GetMethod.MakeGenericMethod(mockedType);
+				var setupAllPropertiesMethod = mockType.GetMethod(nameof(Mock<object>.SetupAllProperties));
+				var mockParam = E.Parameter(mockedType, "m");
+				this.expression = E.Lambda(E.Call(E.Call(mockGetMethod, mockParam), setupAllPropertiesMethod), mockParam);
+			}
+
+			public override LambdaExpression Expression => this.expression;
+
+			public override bool Equals(Expectation other)
+			{
+				return other is PropertyAccessorExpectation pae && ExpressionComparer.Default.Equals(this.expression, pae.expression);
+			}
+
+			public override int GetHashCode()
+			{
+				return typeof(PropertyAccessorExpectation).GetHashCode();
+			}
+
+			public override bool IsMatch(Invocation invocation)
+			{
+				return invocation.Method.IsPropertyAccessor();
+			}
+		}
+	}
+}

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -3549,6 +3549,36 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 1066
+
+		public class Issue1066
+		{
+			public interface IX
+			{
+				int Property { get; set; }
+			}
+
+			[Fact]
+			public void Stubbed_property_set_before_SetupGet()
+			{
+				var mock = Mock.Get(Mock.Of<IX>());
+				mock.Object.Property = 4;
+				mock.SetupGet(m => m.Property).Returns(3);
+				Assert.Equal(3, mock.Object.Property);
+			}
+
+			[Fact]
+			public void Stubbed_property_set_after_SetupGet()
+			{
+				var mock = Mock.Get(Mock.Of<IX>());
+				mock.SetupGet(m => m.Property).Returns(3);
+				mock.Object.Property = 4;
+				Assert.Equal(3, mock.Object.Property);
+			}
+		}
+
+		#endregion
+
 		#region 1071
 
 		public class Issue1071

--- a/tests/Moq.Tests/SetupFixture.cs
+++ b/tests/Moq.Tests/SetupFixture.cs
@@ -140,15 +140,6 @@ namespace Moq.Tests
 		}
 
 		[Fact]
-		public void OriginalExpression_equal_to_Expression_for_simple_expression_in_Mock_Of()
-		{
-			var mockObject = Mock.Of<IX>(m => m.Property == null);
-			var setup = Mock.Get(mockObject).Setups.First();
-
-			Assert.Equal(setup.Expression, setup.OriginalExpression, ExpressionComparer.Default);
-		}
-
-		[Fact]
 		public void OriginalExpression_returns_expression_different_from_Expression_for_multi_dot_expression()
 		{
 			var mock = new Mock<IX>();
@@ -176,23 +167,6 @@ namespace Moq.Tests
 			var setup = mock.Setups.First();
 
 			Assert.Equal(originalExpression, setup.OriginalExpression, ExpressionComparer.Default);
-		}
-
-		[Fact]
-		public void OriginalExpression_returns_only_left_hand_side_of_expression_in_Mock_Of()
-		{
-			Expression<Func<IX, string>> originalExpressionLeftHandSide = m => m.Inner[1].ToString();
-			Expression<Func<IX, bool>> mockSpecification =
-				Expression.Lambda<Func<IX, bool>>(
-					Expression.MakeBinary(
-						ExpressionType.Equal,
-						originalExpressionLeftHandSide.Body,
-						Expression.Constant("")),
-					originalExpressionLeftHandSide.Parameters);
-			var mockObject = Mock.Of<IX>(mockSpecification);
-			var setup = Mock.Get(mockObject).Setups.First();
-
-			Assert.Equal(originalExpressionLeftHandSide, setup.OriginalExpression, ExpressionComparer.Default);
 		}
 
 		[Fact]

--- a/tests/Moq.Tests/SetupsFixture.cs
+++ b/tests/Moq.Tests/SetupsFixture.cs
@@ -19,33 +19,12 @@ namespace Moq.Tests
 		}
 
 		[Fact]
-		public void Mock_made_with_Mock_Of_without_an_expression_initially_has_no_setups()
-		{
-			var mockObject = Mock.Of<object>();
-			var mock = Mock.Get(mockObject);
-			Assert.Empty(mock.Setups);
-		}
-
-		[Fact]
 		public void Setup_adds_one_setup_with_same_expression_to_Setups()
 		{
 			Expression<Func<object, string>> setupExpression = m => m.ToString();
 
 			var mock = new Mock<object>();
 			mock.Setup(setupExpression);
-
-			var setup = Assert.Single(mock.Setups);
-			Assert.Equal(setupExpression, setup.Expression, ExpressionComparer.Default);
-		}
-
-		[Fact]
-		public void Mock_Of_with_expression_for_a_single_member_adds_one_setup_with_same_but_only_partial_expression_to_Setups()
-		{
-			Expression<Func<object, bool>> mockSpecification = m => m.ToString() == default(string);
-			Expression<Func<object, string>> setupExpression = m => m.ToString();
-
-			var mockObject = Mock.Of<object>(mockSpecification);
-			var mock = Mock.Get(mockObject);
 
 			var setup = Assert.Single(mock.Setups);
 			Assert.Equal(setupExpression, setup.Expression, ExpressionComparer.Default);


### PR DESCRIPTION
This is a continuation of #1204, where a dedicated setup type was created for single stubbed properties' accessors (i.e. `SetupProperty`). Thanks to #1203, the same can also be done for `SetupAllProperties`.

A few additional notes:

* This gets rid of the `RemoveAllPropertyAccessorSetups` method in `SetupCollection`, restoring it to an add-only collection, which in turn means its use of `lock`-ing could be optimized in a similar fashion as was done for `InvocationCollection`.

* Gets rid of the `AutoSetupPropertiesDefaultValueProvider` hack and simplifies the interception pipeline.

* Moq should become a little more efficient in principle, since there will be fewer setups created overall.

Fixes #1066, likely fixes #1231.