### PR TITLE
Fixed missing placeholder in exception message Resources.TypeNotMockable

### DIFF
--- a/src/Moq/Interception/CastleProxyFactory.cs
+++ b/src/Moq/Interception/CastleProxyFactory.cs
@@ -63,7 +63,7 @@ namespace Moq
 			}
 			catch (TypeLoadException e)
 			{
-				throw new ArgumentException(Resources.TypeNotMockable, e);
+				throw new ArgumentException(string.Format(Resources.TypeNotMockable, mockType), e);
 			}
 			catch (MissingMethodException e)
 			{
@@ -257,7 +257,7 @@ namespace Moq
 			//    unfortunately that doesn't work. `DeclaredOnly` does not have the desired effect.
 			//
 			//  * We could get a function pointer via `method.MethodHandle.GetFunctionPointer()`,
-			//    then construct a delegate for it (see ECMA-335 §II.14.4). This does not work
+			//    then construct a delegate for it (see ECMA-335 Â§II.14.4). This does not work
 			//    because the delegate signature would have to have a matching parameter list,
 			//    not just an untyped `object[]`. It also doesn't work because we don't always have
 			//    a suitable delegate type ready (e.g. when a method has by-ref parameters).


### PR DESCRIPTION
Fixes #1246 