### PR TITLE
Account for by-ref params in `MethodExpectation.CreateFrom(Invocation)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 #### Fixed
 
 * Regression: Property stubs not working on sub mock (@aaronburro, #1240)
+* Failure when invoking a method with by-ref parameter & mockable return type on a mock with `CallBase` and `DefaultValue.Mock` configured (@IanKemp, #1249)
 
 
 ## 4.17.1 (2022-02-26)

--- a/src/Moq/MethodExpectation.cs
+++ b/src/Moq/MethodExpectation.cs
@@ -37,7 +37,9 @@ namespace Moq
 				arguments = new Expression[n];
 				for (int i = 0; i < n; ++i)
 				{
-					arguments[i] = E.Constant(invocation.Arguments[i], parameterTypes[i]);
+					var parameterType = parameterTypes[i];
+					if (parameterType.IsByRef) parameterType = parameterType.GetElementType();
+					arguments[i] = E.Constant(invocation.Arguments[i], parameterType);
 				}
 			}
 

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -3782,6 +3782,27 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 1249
+
+		public class Issue1249
+		{
+			public class NonSealedType { }
+
+			public interface IFoo
+			{
+				NonSealedType Method(in int arg);
+			}
+
+			[Fact]
+			public void No_ArgumentException_due_to_parameter_refness()
+			{
+				var mock = new Mock<IFoo>() { CallBase = true, DefaultValue = DefaultValue.Mock };
+				_ = mock.Object.Method(default);
+			}
+		}
+
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47


### PR DESCRIPTION
Fixes #1249.