### PR TITLE
Update caste.core from 4.4.1 to 5.0.0 therefore net45 to net462.

### DIFF
--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -6,7 +6,7 @@
 	<Import Project="$(BuildDirectory)SourceLink.props" />
 
 	<PropertyGroup>
-		<TargetFrameworks>net45;netstandard2.0;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>net462;netstandard2.0;netstandard2.1</TargetFrameworks>
 		<AssemblyName>Moq</AssemblyName>
 		<DebugSymbols>True</DebugSymbols>
 		<DebugType>embedded</DebugType>
@@ -43,7 +43,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Castle.Core" Version="4.4.1" />
+		<PackageReference Include="Castle.Core" Version="5.0.0" />
 		<PackageReference Include="IFluentInterface" Version="2.1.0" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />

--- a/tests/Moq.Tests/Moq.Tests.csproj
+++ b/tests/Moq.Tests/Moq.Tests.csproj
@@ -22,7 +22,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Castle.Core" Version="4.4.1" />
+		<PackageReference Include="Castle.Core" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.9" />
 		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />


### PR DESCRIPTION
This change resolved the next vulnerability:
https://security.snyk.io/vuln/SNYK-DOTNET-SYSTEMTEXTREGULAREXPRESSIONS-174708