### PR TITLE
Allow async `.Result` setups to return `null`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
+## Unreleased
+
+#### Fixed
+
+* Difference in behavior when mocking async method using `.Result` vs without (@cyungmann, #1253)
+
+
 ## 4.18.0 (2022-05-12)
 
 New major version of DynamicProxy (you may get better performance!), so please update with care.

--- a/src/Moq/Invocation.cs
+++ b/src/Moq/Invocation.cs
@@ -97,7 +97,7 @@ namespace Moq
 			{
 				this.result = awaitableFactory.CreateFaulted(r.Exception);
 			}
-			else if (this.result != null && !this.method.ReturnType.IsAssignableFrom(this.result.GetType()))
+			else if (!this.method.ReturnType.IsAssignableFrom(this.result?.GetType()))
 			{
 				this.result = awaitableFactory.CreateCompleted(this.result);
 			}

--- a/tests/Moq.Tests.FSharpTypes/Moq.Tests.FSharpTypes.fsproj
+++ b/tests/Moq.Tests.FSharpTypes/Moq.Tests.FSharpTypes.fsproj
@@ -11,7 +11,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FSharp.Core" Version="4.5.4" />
 		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
 	</ItemGroup>

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -3802,6 +3802,29 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 1253
+
+		public class Issue1253
+		{
+			public interface IFoo
+			{
+				Task<string> Bar();
+			}
+
+			[Fact]
+			public async Task Test()
+			{
+				var mock = new Mock<IFoo>();
+				mock.Setup(x => x.Bar().Result).Returns((string)null);
+
+				var result = await mock.Object.Bar();
+
+				Assert.Null(result);
+			}
+		}
+
+		#endregion
+
 		// Old @ Google Code
 
 		#region #47


### PR DESCRIPTION
Fixes #1253.