### PR TITLE
Make `StubbedPropertySetup.IsMatch` less picky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ New major version of DynamicProxy (you may get better performance!), so please u
 
 * Can't set up "private protected" properties (@RobSiklos, #1170)
 * Using [...] an old version of `System.Net.Http` which is vulnerable to "DoS", "Spoofing", "Privilege Escalation", "Authentication Bypass" and "Information Exposure"  (@sidseter, #1219)
+* Regression with `SetupProperty` where Moq fails to match a property accessor implementation against its definition in an interface (@Naxemar, #1248)
 * Failure when invoking a method with by-ref parameter & mockable return type on a mock with `CallBase` and `DefaultValue.Mock` configured (@IanKemp, #1249)
 
 

--- a/src/Moq/StubbedPropertySetup.cs
+++ b/src/Moq/StubbedPropertySetup.cs
@@ -100,8 +100,8 @@ namespace Moq
 
 			public override bool IsMatch(Invocation invocation)
 			{
-				var method = invocation.Method;
-				return method == this.getter || method == this.setter;
+				var methodName = invocation.Method.Name;
+				return methodName == this.getter.Name || methodName == this.setter.Name;
 			}
 		}
 	}

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -3781,6 +3781,42 @@ namespace Moq.Tests.Regressions
 
 		#endregion
 
+		#region 1248
+
+		public class Issue1248
+		{
+			public interface IBase
+			{
+				bool Property { get; set; }
+			}
+
+			public interface IDerived : IBase
+			{
+			}
+
+			public class Base : IBase
+			{
+				public virtual bool Property { get; set; }
+			}
+
+			[Fact]
+			public void Test()
+			{
+				var mock = new Mock<Base>();
+				var mockAsDerived = mock.As<IDerived>();
+				mockAsDerived.SetupProperty(x => x.Property, false);
+
+				mockAsDerived.Object.Property = true;
+
+				mock.VerifySet(x => x.Property = true, Times.Once());
+				mockAsDerived.VerifySet(x => x.Property = true, Times.Once());
+				Assert.True(mockAsDerived.Object.Property);
+				Assert.True(mock.Object.Property);
+			}
+		}
+
+		#endregion
+
 		#region 1249
 
 		public class Issue1249


### PR DESCRIPTION
Fixes #1248.