### PR TITLE
Update link to documentation website

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The most popular and friendly mocking library for .NET
 
 [![Version](https://img.shields.io/nuget/vpre/Moq.svg)](https://www.nuget.org/packages/Moq)
 [![Downloads](https://img.shields.io/nuget/dt/Moq.svg)](https://www.nuget.org/packages/Moq)
-[![Documentation](https://img.shields.io/badge/docs-website-%23fc0)](https://www.moqthis.com/moq4/)
+[![Documentation](https://img.shields.io/badge/docs-website-%23fc0)](http://moq.github.io/moq4/)
 [![Discord Chat](https://img.shields.io/badge/chat-on%20discord-7289DA.svg)](https://discord.gg/8PtpGdu)
 [![Gitter chat](https://img.shields.io/badge/chat-on%20gitter-753A88.svg)](https://gitter.im/moq/moq)
 
@@ -70,7 +70,7 @@ See our [Quickstart](https://github.com/Moq/moq4/wiki/Quickstart) examples to ge
 
 Read about the announcement at [kzu's blog](https://web.archive.org/web/20201130233544/http://blogs.clariusconsulting.net/kzu/linq-to-mock-moq-is-born/). Get some background on [the state of mock libraries from Scott Hanselman](http://www.hanselman.com/blog/MoqLinqLambdasAndPredicatesAppliedToMockObjects.aspx).
 
-In-depth documentation is being added to the [documentation website](https://www.moqthis.com/moq4/).
+In-depth documentation is being added to the [documentation website](http://moq.github.io/moq4/).
 
 
 ## Who?


### PR DESCRIPTION
It is now officially at http://moq.github.io/moq4/

Supports #1244.