### PR TITLE
add STTE for older target frameworks only

### DIFF
--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -46,8 +46,10 @@
 		<PackageReference Include="Castle.Core" Version="5.0.0" />
 		<PackageReference Include="IFluentInterface" Version="2.1.0" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
 		<PackageReference Include="TypeNameFormatter.Sources" Version="1.0.0" PrivateAssets="All" />
+	</ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'netstandard2.0' ">
+		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Add System.Threading.Tasks.Extensions reference conditionally to reduce dependencies on newer frameworks.