### PR TITLE
Let `StubbedPropertiesSetup` figure out type parameter in a less fragile way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
+## Unreleased
+
+#### Fixed
+
+* `SetupAllProperties` crashes when invoked on a `Mock<T>` subclass (@mo-russo, #1278)
+
+
 ## 4.18.2 (2022-08-02)
 
 #### Changed

--- a/src/Moq/StubbedPropertiesSetup.cs
+++ b/src/Moq/StubbedPropertiesSetup.cs
@@ -79,9 +79,9 @@ namespace Moq
 				Debug.Assert(mock != null);
 
 				var mockType = mock.GetType();
-				var mockedType = mockType.GetGenericArguments()[0];
-				var mockGetMethod = Mock.GetMethod.MakeGenericMethod(mockedType);
 				var setupAllPropertiesMethod = mockType.GetMethod(nameof(Mock<object>.SetupAllProperties));
+				var mockedType = setupAllPropertiesMethod.ReturnType.GetGenericArguments()[0];
+				var mockGetMethod = Mock.GetMethod.MakeGenericMethod(mockedType);
 				var mockParam = E.Parameter(mockedType, "m");
 				this.expression = E.Lambda(E.Call(E.Call(mockGetMethod, mockParam), setupAllPropertiesMethod), mockParam);
 			}

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -4003,6 +4003,29 @@ namespace Moq.Tests.Regressions
 
 #endregion
 
+#region 1278
+
+		public class Issue1278
+		{
+			[Fact]
+			public void Can_call_SetupAllProperties_on_instance_of_Mock_T_subclass()
+			{
+				var mock = new MockOfX();
+				mock.SetupAllProperties();
+			}
+
+			public class MockOfX : Mock<IX>
+			{
+			}
+
+			public interface IX
+			{
+				object P { get; set; }
+			}
+		}
+
+#endregion
+
 		// Old @ Google Code
 
 #region #47


### PR DESCRIPTION
Fixes #1278.