### PR TITLE
Fix typo in the documentation of Mock`1.cs #1

### DIFF
--- a/src/Moq/Mock`1.cs
+++ b/src/Moq/Mock`1.cs
@@ -22,7 +22,7 @@ namespace Moq
 	///   Any interface type can be used for mocking, but for classes, only abstract and virtual members can be mocked.
 	///   <para>
 	///     The behavior of the mock with regards to the setups and the actual calls is determined by the optional
-	///     <see cref = "MockBehavior" /> that can be passed to the<see cref="Mock{T}(MockBehavior)"/> constructor.
+	///     <see cref = "MockBehavior" /> that can be passed to the <see cref="Mock{T}(MockBehavior)"/> constructor.
 	///   </para>
 	/// </remarks>
 	/// <example group="overview">


### PR DESCRIPTION
Fix a space typo in the dicumentation in the Mock.cs file.