### PR TITLE
Add `Mock<T>.RaiseAsync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
+## Unreleased
+
+#### Added
+
+* `Mock<T>.RaiseAsync` method for raising "async" events, i.e. events that use a `Func<..., Task>` or `Func<..., ValueTask>` delegate. (@stakx, #1313)
+
+
 ## 4.18.4 (2022-12-30)
 
 #### Changed

--- a/src/Moq/Mock`1.cs
+++ b/src/Moq/Mock`1.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 using Moq.Language;
 using Moq.Language.Flow;
@@ -1386,6 +1387,33 @@ namespace Moq
 			Mock.RaiseEvent(this, eventExpression, args);
 		}
 
-#endregion
+		/// <summary>
+		///   Raises the event referenced in <paramref name="eventExpression"/> using the given arguments
+		///   for an event with a <c>Func&lt;..., Task&gt;</c> or <c>Func&lt;..., ValueTask&gt;</c> signature.
+		///   The returned <see cref="Task"/> completes when all of the <see cref="Task"/>s / <see cref="ValueTask"/>s
+		///   returned by the event handlers have completed.
+		/// </summary>
+		/// <exception cref="ArgumentException">
+		///   The <paramref name="args"/> arguments are invalid for the target event invocation,
+		///   or the <paramref name="eventExpression"/> is not an event attach or detach expression.
+		/// </exception>
+		/// <example>
+		///   The following example shows how to raise an event with async event handlers:
+		///   <code>
+		///     interface IViewModel
+		///     {
+		///         event Func&lt;InitializationData, Task&gt; Initialized;
+		///     }
+		///     var mock = new Mock&lt;IViewModel&gt;();
+		///     mock.Object.Initialized += async initializationData => ...;
+		///     await mock.RaiseAsync(x => x.Initialized += null, new InitializationData { ... });
+		///   </code>
+		/// </example>
+		public Task RaiseAsync(Action<T> eventExpression, params object[] args)
+		{
+			return Mock.RaiseEventAsync(this, eventExpression, args);
+		}
+
+		#endregion
 	}
 }

--- a/tests/Moq.Tests/EventHandlersFixture.cs
+++ b/tests/Moq.Tests/EventHandlersFixture.cs
@@ -2,6 +2,7 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
+using System.Threading.Tasks;
 
 using Xunit;
 
@@ -148,6 +149,40 @@ namespace Moq.Tests
 			public virtual event Action Event;
 
 			public void RaiseEvent() => this.Event?.Invoke();
+		}
+
+		[Fact]
+		public async Task Can_raise_async_event_using_RaiseAsync()
+		{
+			var handled = false;
+			var mock = new Mock<HasAsyncEvent>();
+			mock.Object.Event += async () =>
+			{
+				await Task.Delay(50);
+				handled = true;
+			};
+			await mock.RaiseAsync(m => m.Event += null);
+			Assert.True(handled);
+		}
+
+		[Fact]
+		public async Task Can_raise_parameterized_async_event_using_RaiseAsync()
+		{
+			var received = 0;
+			var mock = new Mock<HasAsyncEvent>();
+			mock.Object.ParameterizedEvent += async incoming =>
+			{
+				await Task.Delay(50);
+				received = incoming;
+			};
+			await mock.RaiseAsync(m => m.ParameterizedEvent += null, 42);
+			Assert.Equal(42, received);
+		}
+
+		public class HasAsyncEvent
+		{
+			public virtual event Func<Task> Event;
+			public virtual event Func<int, Task> ParameterizedEvent;
 		}
 	}
 }


### PR DESCRIPTION
Closes #1310.

### Usage summary:

```csharp
public interface IFoo
{
    Func<TArg1, ..., TArgN, Task> Bar;  // Func<..., ValueTask> is supported too
}

var mock = new Mock<IFoo>();

// subscribe an async event handler to the event:
mock.Object.Bar += async (arg1, ..., argN) => ...;

// raise the event and await completion of all async event handlers:
await mock.RaiseAsync(m => m.Bar += null, arg1, ..., argN);
```