### PR TITLE
Use PackageLicenseExpression instead of PackageLicenseUrl

### DIFF
--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -31,6 +31,7 @@
 		<Description>Moq is the most popular and friendly mocking framework for .NET.</Description>
 		<PackageReleaseNotes>A changelog is available at https://github.com/moq/moq4/blob/main/CHANGELOG.md.</PackageReleaseNotes>
 		<Authors>Daniel Cazzulino, kzu</Authors>
+		<Copyright>Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD, and Contributors. All rights reserved.</Copyright>
 		<PackageIcon>moq.png</PackageIcon>
 		<PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>

--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -32,7 +32,7 @@
 		<PackageReleaseNotes>A changelog is available at https://github.com/moq/moq4/blob/main/CHANGELOG.md.</PackageReleaseNotes>
 		<Authors>Daniel Cazzulino, kzu</Authors>
 		<PackageIcon>moq.png</PackageIcon>
-		<PackageLicenseUrl>https://raw.githubusercontent.com/moq/moq4/main/License.txt</PackageLicenseUrl>
+		<PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
 		<PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
 		<NoPackageAnalysis>True</NoPackageAnalysis>
 		<PackageOutputPath>$(OutputDirectory)</PackageOutputPath>


### PR DESCRIPTION
It is recommended to use the SPDX license identifier for NuGet packages (if applicable) instead of license URLs or license files.

This PR removes *LicenseUrl* and adds *LicenseExpression* from the package-related properties in *Moq.csproj* to follow this recommendation.
In order to keep the list of copyright holders linked to the NuGet package, the 'Copyright' property is added with the copyright holders as listed in current *License.txt*.

References:
https://docs.microsoft.com/en-us/nuget/reference/nuspec#license
https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/nuget#important-nuget-package-metadata
https://github.com/NuGet/Home/wiki/Packaging-License-within-the-nupkg-(Technical-Spec)#license-expression-pack