### PR TITLE
Don't throw away generic type arguments in one `mock.Protected().Verify<T>()` method overload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ The format is loosely based on [Keep a Changelog](http://keepachangelog.com/en/1
 * `setup.Verifiable(Times times, [string failMessage])` method to specify the expected number of calls upfront. `mock.Verify[All]` can then be used to check whether the setup was called that many times. The upper bound (maximum allowed number of calls) will be checked right away, i.e. whenever a setup gets called. (@stakx, #1319)
 * Add `ThrowsAsync` methods for non-generic `ValueTask` (@johnthcall, #1235)
 
+#### Fixed
+
+* Verifying a protected generic method that returns a value is broken (@nthornton2010, #1314)
+
+
 ## 4.18.4 (2022-12-30)
 
 #### Changed

--- a/src/Moq/Protected/ProtectedMock.cs
+++ b/src/Moq/Protected/ProtectedMock.cs
@@ -253,7 +253,7 @@ namespace Moq.Protected
 		public void Verify<TResult>(string methodName, Type[] genericTypeArguments, Times times, bool exactParameterMatch, params object[] args)
 		{
 			Guard.NotNull(genericTypeArguments, nameof(genericTypeArguments));
-			this.InternalVerify<TResult>(methodName, null, times, exactParameterMatch, args);
+			this.InternalVerify<TResult>(methodName, genericTypeArguments, times, exactParameterMatch, args);
 		}
 
 		private void InternalVerify<TResult>(string methodName, Type[] genericTypeArguments, Times times, bool exactParameterMatch, params object[] args)

--- a/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
+++ b/tests/Moq.Tests/Regressions/IssueReportsFixture.cs
@@ -4026,6 +4026,34 @@ namespace Moq.Tests.Regressions
 
 #endregion
 
+#region #1314
+
+		public class Issue1314
+		{
+			[Fact]
+			public void Verify_protected_generic_non_void_method_using_exactParameterMatch_overload_uses_provided_generic_type_arguments()
+			{
+				var mock = new Mock<C>();
+
+				_ = mock.Object.InvokeMethod<int>();
+				_ = mock.Object.InvokeMethod<bool>();
+				_ = mock.Object.InvokeMethod<int>();
+
+				mock.Protected().Verify<string>("Method", new Type[] { typeof(float) }, Times.Never(), true);
+				mock.Protected().Verify<string>("Method", new Type[] { typeof(bool) }, Times.Once(), true);
+				mock.Protected().Verify<string>("Method", new Type[] { typeof(int) }, Times.Exactly(2), true);
+			}
+
+			public abstract class C
+			{
+				protected abstract string Method<T>();
+
+				public string InvokeMethod<T>() => Method<T>();
+			}
+		}
+
+#endregion
+
 		// Old @ Google Code
 
 #region #47


### PR DESCRIPTION
Fixes #1314.