### PR TITLE
Enable nullable references in Moq.csproj

### DIFF
--- a/src/Moq/ActionObserver.cs
+++ b/src/Moq/ActionObserver.cs
@@ -27,7 +27,7 @@ namespace Moq
     /// </summary>
     sealed class ActionObserver : ExpressionReconstructor
     {
-        public override Expression<Action<T>> ReconstructExpression<T>(Action<T> action, object[] ctorArgs = null)
+        public override Expression<Action<T>> ReconstructExpression<T>(Action<T> action, object[]? ctorArgs = null)
         {
             using (var matcherObserver = MatcherObserver.Activate())
             {
@@ -228,7 +228,7 @@ namespace Moq
         }
 
         // Creates a proxy (way more light-weight than a `Mock<T>`!) with an invocation `Recorder` attached to it.
-        static IProxy CreateProxy(Type type, object[] ctorArgs, MatcherObserver matcherObserver, out Recorder recorder)
+        static IProxy CreateProxy(Type type, object[]? ctorArgs, MatcherObserver matcherObserver, out Recorder recorder)
         {
             recorder = new Recorder(matcherObserver);
             return (IProxy)ProxyFactory.Instance.CreateProxy(type, recorder, Type.EmptyTypes, ctorArgs ?? new object[0]);

--- a/src/Moq/ActionObserver.cs
+++ b/src/Moq/ActionObserver.cs
@@ -178,7 +178,7 @@ namespace Moq
                                 CultureInfo.CurrentCulture,
                                 Resources.MatcherAssignmentFailedDuringExpressionReconstruction,
                                 matches.Length,
-                                $"{invocation.Method.DeclaringType.GetFormattedName()}.{invocation.Method.Name}"));
+                                $"{invocation.Method.DeclaringType!.GetFormattedName()}.{invocation.Method.Name}"));
                     }
 
                     bool CanDistribute(int msi, int asi)

--- a/src/Moq/ActionObserver.cs
+++ b/src/Moq/ActionObserver.cs
@@ -34,7 +34,7 @@ namespace Moq
                 // Create the root recording proxy:
                 var root = (T)CreateProxy(typeof(T), ctorArgs, matcherObserver, out var rootRecorder);
 
-                Exception error = null;
+                Exception? error = null;
                 try
                 {
                     // Execute the delegate. The root recorder will automatically "mock" return values
@@ -61,7 +61,7 @@ namespace Moq
                     var invocation = recorder.Invocation;
                     if (invocation != null)
                     {
-                        var resultType = invocation.Method.DeclaringType;
+                        var resultType = invocation.Method.DeclaringType!;
                         if (resultType.IsAssignableFrom(body.Type) == false)
                         {
                             if (AwaitableFactory.TryGet(body.Type) is { } awaitableHandler
@@ -128,7 +128,7 @@ namespace Moq
                         // it will have left behind a `default(T)` argument, possibly coerced to the parameter type.
                         // Therefore, we attempt to reproduce such coercions using `Convert.ChangeType`:
                         Type defaultValueType = matches[matchIndex].RenderExpression.Type;
-                        object defaultValue = defaultValueType.GetDefaultValue();
+                        object? defaultValue = defaultValueType.GetDefaultValue();
                         try
                         {
                             defaultValue = Convert.ChangeType(defaultValue, parameterTypes[argumentIndex]);
@@ -241,9 +241,9 @@ namespace Moq
         {
             readonly MatcherObserver matcherObserver;
             int creationTimestamp;
-            Invocation invocation;
-            int invocationTimestamp;
-            object returnValue;
+            Invocation? invocation;
+            int? invocationTimestamp;
+            object? returnValue;
 
             public Recorder(MatcherObserver matcherObserver)
             {
@@ -253,18 +253,18 @@ namespace Moq
                 this.creationTimestamp = this.matcherObserver.GetNextTimestamp();
             }
 
-            public Invocation Invocation => this.invocation;
+            public Invocation? Invocation => this.invocation;
 
             public IEnumerable<Match> Matches
             {
                 get
                 {
                     Debug.Assert(this.invocationTimestamp != default);
-                    return this.matcherObserver.GetMatchesBetween(this.creationTimestamp, this.invocationTimestamp);
+                    return this.matcherObserver.GetMatchesBetween(this.creationTimestamp, this.invocationTimestamp!.Value);
                 }
             }
 
-            public Recorder Next => (Awaitable.TryGetResultRecursive(this.returnValue) as IProxy)?.Interceptor as Recorder;
+            public Recorder? Next => (Awaitable.TryGetResultRecursive(this.returnValue) as IProxy)?.Interceptor as Recorder;
 
             public void Intercept(Invocation invocation)
             {

--- a/src/Moq/ActionObserver.cs
+++ b/src/Moq/ActionObserver.cs
@@ -242,7 +242,7 @@ namespace Moq
             readonly MatcherObserver matcherObserver;
             int creationTimestamp;
             Invocation? invocation;
-            int? invocationTimestamp;
+            int invocationTimestamp;
             object? returnValue;
 
             public Recorder(MatcherObserver matcherObserver)
@@ -260,7 +260,7 @@ namespace Moq
                 get
                 {
                     Debug.Assert(this.invocationTimestamp != default);
-                    return this.matcherObserver.GetMatchesBetween(this.creationTimestamp, this.invocationTimestamp!.Value);
+                    return this.matcherObserver.GetMatchesBetween(this.creationTimestamp, this.invocationTimestamp);
                 }
             }
 

--- a/src/Moq/ActionObserver.cs
+++ b/src/Moq/ActionObserver.cs
@@ -27,7 +27,7 @@ namespace Moq
     /// </summary>
     sealed class ActionObserver : ExpressionReconstructor
     {
-        public override Expression<Action<T>> ReconstructExpression<T>(Action<T> action, object[]? ctorArgs = null)
+        public override Expression<Action<T>> ReconstructExpression<T>(Action<T> action, object?[]? ctorArgs = null)
         {
             using (var matcherObserver = MatcherObserver.Activate())
             {
@@ -228,10 +228,10 @@ namespace Moq
         }
 
         // Creates a proxy (way more light-weight than a `Mock<T>`!) with an invocation `Recorder` attached to it.
-        static IProxy CreateProxy(Type type, object[]? ctorArgs, MatcherObserver matcherObserver, out Recorder recorder)
+        static IProxy CreateProxy(Type type, object?[]? ctorArgs, MatcherObserver matcherObserver, out Recorder recorder)
         {
             recorder = new Recorder(matcherObserver);
-            return (IProxy)ProxyFactory.Instance.CreateProxy(type, recorder, Type.EmptyTypes, ctorArgs ?? new object[0]);
+            return (IProxy)ProxyFactory.Instance.CreateProxy(type, recorder, Type.EmptyTypes, ctorArgs ?? new object?[0]);
 
         }
 

--- a/src/Moq/AsInterface.cs
+++ b/src/Moq/AsInterface.cs
@@ -49,7 +49,7 @@ namespace Moq
 
         public override TInterface Object
         {
-            get { return (TInterface) this.owner.Object; }
+            get { return (TInterface)this.owner.Object; }
         }
 
         internal override SetupCollection MutableSetups => this.owner.MutableSetups;

--- a/src/Moq/AsInterface.cs
+++ b/src/Moq/AsInterface.cs
@@ -19,9 +19,9 @@ namespace Moq
 
         internal override List<Type> AdditionalInterfaces => this.owner.AdditionalInterfaces;
 
-        internal override Dictionary<Type, object> ConfiguredDefaultValues => this.owner.ConfiguredDefaultValues;
+        internal override Dictionary<Type, object?> ConfiguredDefaultValues => this.owner.ConfiguredDefaultValues;
 
-        internal override object[] ConstructorArguments => this.owner.ConstructorArguments;
+        internal override object?[] ConstructorArguments => this.owner.ConstructorArguments;
 
         internal override InvocationCollection MutableInvocations => this.owner.MutableInvocations;
 

--- a/src/Moq/AsInterface.cs
+++ b/src/Moq/AsInterface.cs
@@ -49,7 +49,7 @@ namespace Moq
 
         public override TInterface Object
         {
-            get { return this.owner.Object as TInterface; }
+            get { return (TInterface) this.owner.Object; }
         }
 
         internal override SetupCollection MutableSetups => this.owner.MutableSetups;
@@ -72,7 +72,7 @@ namespace Moq
 
         public override string ToString()
         {
-            return this.owner.ToString();
+            return this.owner.ToString()!;
         }
     }
 }

--- a/src/Moq/Async/Awaitable.cs
+++ b/src/Moq/Async/Awaitable.cs
@@ -14,7 +14,7 @@ namespace Moq.Async
         ///   this method will return <c>42</c>.
         /// </remarks>
         /// <param name="obj">The (possibly awaitable) object to be "unwrapped".</param>
-        public static object TryGetResultRecursive(object obj)
+        public static object? TryGetResultRecursive(object? obj)
         {
             if (obj != null
                 && AwaitableFactory.TryGet(obj.GetType()) is { } awaitableFactory

--- a/src/Moq/Async/AwaitableFactory.cs
+++ b/src/Moq/Async/AwaitableFactory.cs
@@ -27,7 +27,7 @@ namespace Moq.Async
         {
             return (IAwaitableFactory)Activator.CreateInstance(
                 awaitableFactoryType.MakeGenericType(
-                    awaitableType.GetGenericArguments()));
+                    awaitableType.GetGenericArguments()))!;
         }
 
         public static IAwaitableFactory? TryGet(Type type)

--- a/src/Moq/Async/AwaitableFactory`1.cs
+++ b/src/Moq/Async/AwaitableFactory`1.cs
@@ -14,12 +14,13 @@ namespace Moq.Async
     ///   for awaitables that do not produce a result when awaited.
     /// </summary>
     abstract class AwaitableFactory<TAwaitable> : IAwaitableFactory
+        where TAwaitable : notnull
     {
         Type IAwaitableFactory.ResultType => typeof(void);
 
         public abstract TAwaitable CreateCompleted();
 
-        object IAwaitableFactory.CreateCompleted(object result)
+        object IAwaitableFactory.CreateCompleted(object? result)
         {
             Debug.Assert(result == null);
 
@@ -50,7 +51,7 @@ namespace Moq.Async
             return new AwaitExpression(awaitableExpression, this);
         }
 
-        bool IAwaitableFactory.TryGetResult(object awaitable, out object result)
+        bool IAwaitableFactory.TryGetResult(object awaitable, out object? result)
         {
             Debug.Assert(awaitable is TAwaitable);
 

--- a/src/Moq/Async/AwaitableFactory`2.cs
+++ b/src/Moq/Async/AwaitableFactory`2.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 
@@ -47,7 +48,11 @@ namespace Moq.Async
             return this.CreateFaulted(exceptions);
         }
 
+#if NULLABLE_REFERENCE_TYPES
+        public abstract bool TryGetResult(TAwaitable awaitable, [MaybeNullWhen(false)] out TResult result);
+#else
         public abstract bool TryGetResult(TAwaitable awaitable, out TResult result);
+#endif
 
         public abstract Expression CreateResultExpression(Expression awaitableExpression);
 

--- a/src/Moq/Async/AwaitableFactory`2.cs
+++ b/src/Moq/Async/AwaitableFactory`2.cs
@@ -14,16 +14,17 @@ namespace Moq.Async
     ///   for awaitables that produce a result when awaited.
     /// </summary>
     abstract class AwaitableFactory<TAwaitable, TResult> : IAwaitableFactory
+        where TAwaitable : notnull
     {
         public Type ResultType => typeof(TResult);
 
-        public abstract TAwaitable CreateCompleted(TResult result);
+        public abstract TAwaitable CreateCompleted(TResult? result);
 
-        object IAwaitableFactory.CreateCompleted(object result)
+        object IAwaitableFactory.CreateCompleted(object? result)
         {
             Debug.Assert(result is TResult || result == null);
 
-            return this.CreateCompleted((TResult)result);
+            return this.CreateCompleted((TResult?)result);
         }
 
         public abstract TAwaitable CreateFaulted(Exception exception);
@@ -49,7 +50,7 @@ namespace Moq.Async
 
         public abstract Expression CreateResultExpression(Expression awaitableExpression);
 
-        bool IAwaitableFactory.TryGetResult(object awaitable, out object result)
+        bool IAwaitableFactory.TryGetResult(object awaitable, out object? result)
         {
             Debug.Assert(awaitable is TAwaitable);
 

--- a/src/Moq/Async/AwaitableFactory`2.cs
+++ b/src/Moq/Async/AwaitableFactory`2.cs
@@ -18,13 +18,14 @@ namespace Moq.Async
     {
         public Type ResultType => typeof(TResult);
 
-        public abstract TAwaitable CreateCompleted(TResult? result);
+        public abstract TAwaitable CreateCompleted(TResult result);
 
         object IAwaitableFactory.CreateCompleted(object? result)
         {
+            // TODO: result should only be null if TResult is a nullable type.
             Debug.Assert(result is TResult || result == null);
 
-            return this.CreateCompleted((TResult?)result);
+            return this.CreateCompleted((TResult)result!);
         }
 
         public abstract TAwaitable CreateFaulted(Exception exception);

--- a/src/Moq/Async/IAwaitableFactory.cs
+++ b/src/Moq/Async/IAwaitableFactory.cs
@@ -11,7 +11,7 @@ namespace Moq.Async
     {
         Type ResultType { get; }
 
-        object CreateCompleted(object result = null);
+        object CreateCompleted(object? result = null);
 
         object CreateFaulted(Exception exception);
 
@@ -19,6 +19,6 @@ namespace Moq.Async
 
         Expression CreateResultExpression(Expression awaitableExpression);
 
-        bool TryGetResult(object awaitable, out object result);
+        bool TryGetResult(object awaitable, out object? result);
     }
 }

--- a/src/Moq/Async/TaskFactory.cs
+++ b/src/Moq/Async/TaskFactory.cs
@@ -19,7 +19,7 @@ namespace Moq.Async
 
         public override Task CreateCompleted()
         {
-            return Task.FromResult<object>(default);
+            return Task.CompletedTask;
         }
 
         public override Task CreateFaulted(Exception exception)

--- a/src/Moq/Async/TaskFactory`1.cs
+++ b/src/Moq/Async/TaskFactory`1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 
@@ -33,10 +34,14 @@ namespace Moq.Async
         {
             return Expression.MakeMemberAccess(
                 awaitableExpression,
-                typeof(Task<TResult>).GetProperty(nameof(Task<TResult>.Result)));
+                typeof(Task<TResult>).GetProperty(nameof(Task<TResult>.Result))!);
         }
 
-        public override bool TryGetResult(Task<TResult> task, out TResult result)
+#if NULLABLE_REFERENCE_TYPES
+        public override bool TryGetResult(Task<TResult> task, [MaybeNullWhen(false)] out TResult result)
+#else
+        public override bool TryGetResult(Task<TResult> task, out TResult? result)
+#endif
         {
             if (task.Status == TaskStatus.RanToCompletion)
             {

--- a/src/Moq/Async/ValueTaskFactory`1.cs
+++ b/src/Moq/Async/ValueTaskFactory`1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
 
@@ -33,10 +34,14 @@ namespace Moq.Async
         {
             return Expression.MakeMemberAccess(
                 awaitableExpression,
-                typeof(ValueTask<TResult>).GetProperty(nameof(ValueTask<TResult>.Result)));
+                typeof(ValueTask<TResult>).GetProperty(nameof(ValueTask<TResult>.Result))!);
         }
 
+#if NULLABLE_REFERENCE_TYPES
+        public override bool TryGetResult(ValueTask<TResult> valueTask, [MaybeNullWhen(false)] out TResult result)
+#else
         public override bool TryGetResult(ValueTask<TResult> valueTask, out TResult result)
+#endif
         {
             if (valueTask.IsCompletedSuccessfully)
             {

--- a/src/Moq/Behaviors/RaiseEvent.cs
+++ b/src/Moq/Behaviors/RaiseEvent.cs
@@ -12,9 +12,9 @@ namespace Moq.Behaviors
         Mock mock;
         LambdaExpression expression;
         Delegate? eventArgsFunc;
-        object[]? eventArgsParams;
+        object?[]? eventArgsParams;
 
-        public RaiseEvent(Mock mock, LambdaExpression expression, Delegate? eventArgsFunc, object[]? eventArgsParams)
+        public RaiseEvent(Mock mock, LambdaExpression expression, Delegate? eventArgsFunc, object?[]? eventArgsParams)
         {
             Debug.Assert(mock != null);
             Debug.Assert(expression != null);
@@ -28,7 +28,7 @@ namespace Moq.Behaviors
 
         public override void Execute(Invocation invocation)
         {
-            object[] args;
+            object?[] args;
 
             if (this.eventArgsParams != null)
             {
@@ -39,11 +39,11 @@ namespace Moq.Behaviors
                 var argsFuncType = this.eventArgsFunc!.GetType();
                 if (argsFuncType.IsGenericType && argsFuncType.GetGenericArguments().Length == 1)
                 {
-                    args = new object[] { this.mock.Object, this.eventArgsFunc.InvokePreserveStack() };
+                    args = new object?[] { this.mock.Object, this.eventArgsFunc.InvokePreserveStack() };
                 }
                 else
                 {
-                    args = new object[] { this.mock.Object, this.eventArgsFunc.InvokePreserveStack(invocation.Arguments) };
+                    args = new object?[] { this.mock.Object, this.eventArgsFunc.InvokePreserveStack(invocation.Arguments) };
                 }
             }
 

--- a/src/Moq/Behaviors/RaiseEvent.cs
+++ b/src/Moq/Behaviors/RaiseEvent.cs
@@ -11,10 +11,10 @@ namespace Moq.Behaviors
     {
         Mock mock;
         LambdaExpression expression;
-        Delegate eventArgsFunc;
-        object[] eventArgsParams;
+        Delegate? eventArgsFunc;
+        object[]? eventArgsParams;
 
-        public RaiseEvent(Mock mock, LambdaExpression expression, Delegate eventArgsFunc, object[] eventArgsParams)
+        public RaiseEvent(Mock mock, LambdaExpression expression, Delegate? eventArgsFunc, object[]? eventArgsParams)
         {
             Debug.Assert(mock != null);
             Debug.Assert(expression != null);
@@ -36,7 +36,7 @@ namespace Moq.Behaviors
             }
             else
             {
-                var argsFuncType = this.eventArgsFunc.GetType();
+                var argsFuncType = this.eventArgsFunc!.GetType();
                 if (argsFuncType.IsGenericType && argsFuncType.GetGenericArguments().Length == 1)
                 {
                     args = new object[] { this.mock.Object, this.eventArgsFunc.InvokePreserveStack() };

--- a/src/Moq/Behaviors/ReturnBaseOrDefaultValue.cs
+++ b/src/Moq/Behaviors/ReturnBaseOrDefaultValue.cs
@@ -31,7 +31,7 @@ namespace Moq.Behaviors
 				var tryCallDefaultInterfaceImplementation = false;
 #endif
 
-                var declaringType = method.DeclaringType;
+                var declaringType = method.DeclaringType!;
                 if (declaringType.IsInterface)
                 {
                     if (this.mock.MockedType.IsInterface)

--- a/src/Moq/Behaviors/ReturnComputedValue.cs
+++ b/src/Moq/Behaviors/ReturnComputedValue.cs
@@ -8,9 +8,9 @@ namespace Moq.Behaviors
 {
     sealed class ReturnComputedValue : Behavior
     {
-        readonly Func<IInvocation, object> valueFactory;
+        readonly Func<IInvocation, object?> valueFactory;
 
-        public ReturnComputedValue(Func<IInvocation, object> valueFactory)
+        public ReturnComputedValue(Func<IInvocation, object?> valueFactory)
         {
             Debug.Assert(valueFactory != null);
 

--- a/src/Moq/Behaviors/ReturnValue.cs
+++ b/src/Moq/Behaviors/ReturnValue.cs
@@ -5,14 +5,14 @@ namespace Moq.Behaviors
 {
     sealed class ReturnValue : Behavior
     {
-        readonly object value;
+        readonly object? value;
 
-        public ReturnValue(object value)
+        public ReturnValue(object? value)
         {
             this.value = value;
         }
 
-        public object Value => this.value;
+        public object? Value => this.value;
 
         public override void Execute(Invocation invocation)
         {

--- a/src/Moq/Behaviors/ThrowComputedException.cs
+++ b/src/Moq/Behaviors/ThrowComputedException.cs
@@ -8,9 +8,9 @@ namespace Moq.Behaviors
 {
     sealed class ThrowComputedException : Behavior
     {
-        readonly Func<IInvocation, Exception> exceptionFactory;
+        readonly Func<IInvocation, Exception?> exceptionFactory;
 
-        public ThrowComputedException(Func<IInvocation, Exception> exceptionFactory)
+        public ThrowComputedException(Func<IInvocation, Exception?> exceptionFactory)
         {
             Debug.Assert(exceptionFactory != null);
 
@@ -19,6 +19,7 @@ namespace Moq.Behaviors
 
         public override void Execute(Invocation invocation)
         {
+            // TODO: Technically this permits `throw null` here.
             throw this.exceptionFactory.Invoke(invocation);
         }
     }

--- a/src/Moq/Capture.cs
+++ b/src/Moq/Capture.cs
@@ -76,7 +76,7 @@ namespace Moq
         public static T With<T>(CaptureMatch<T> match)
         {
             Match.Register(match);
-            return default(T);
+            return default(T)!;
         }
     }
 }

--- a/src/Moq/Condition.cs
+++ b/src/Moq/Condition.cs
@@ -8,15 +8,15 @@ namespace Moq
     sealed class Condition
     {
         Func<bool> condition;
-        Action success;
+        Action? success;
 
-        public Condition(Func<bool> condition, Action success = null)
+        public Condition(Func<bool> condition, Action? success = null)
         {
             this.condition = condition;
             this.success = success;
         }
 
-        public bool IsTrue => this.condition?.Invoke() == true;
+        public bool IsTrue => this.condition.Invoke();
 
         public void SetupEvaluatedSuccessfully() => this.success?.Invoke();
     }

--- a/src/Moq/DefaultValueProvider.cs
+++ b/src/Moq/DefaultValueProvider.cs
@@ -49,7 +49,7 @@ namespace Moq
         /// <remarks>
         /// Implementations may assume that all parameters have valid, non-<see langword="null"/>, non-<see langword="void"/> values.
         /// </remarks>
-        protected internal abstract object GetDefaultValue(Type type, Mock mock);
+        protected internal abstract object? GetDefaultValue(Type type, Mock mock);
 
         /// <summary>
         ///   <para>
@@ -65,7 +65,7 @@ namespace Moq
         /// <remarks>
         /// Implementations may assume that all parameters have valid, non-<see langword="null"/>, non-<see langword="void"/> values.
         /// </remarks>
-        protected internal virtual object GetDefaultParameterValue(ParameterInfo parameter, Mock mock)
+        protected internal virtual object? GetDefaultParameterValue(ParameterInfo parameter, Mock mock)
         {
             Debug.Assert(parameter != null);
             Debug.Assert(parameter.ParameterType != typeof(void));
@@ -88,7 +88,7 @@ namespace Moq
         /// <remarks>
         /// Implementations may assume that all parameters have valid, non-<see langword="null"/>, non-<see langword="void"/> values.
         /// </remarks>
-        protected internal virtual object GetDefaultReturnValue(MethodInfo method, Mock mock)
+        protected internal virtual object? GetDefaultReturnValue(MethodInfo method, Mock mock)
         {
             Debug.Assert(method != null);
             Debug.Assert(method.ReturnType != typeof(void));

--- a/src/Moq/EmptyDefaultValueProvider.cs
+++ b/src/Moq/EmptyDefaultValueProvider.cs
@@ -57,7 +57,7 @@ namespace Moq
             return typeof(Queryable).GetMethods("AsQueryable")
                 .Single(x => x.IsGenericMethod)
                 .MakeGenericMethod(elementType)
-                .Invoke(null, new[] { array });
+                .Invoke(null, new[] { array })!;
         }
     }
 }

--- a/src/Moq/EmptyDefaultValueProvider.cs
+++ b/src/Moq/EmptyDefaultValueProvider.cs
@@ -28,7 +28,7 @@ namespace Moq
 
         static object CreateArray(Type type, Mock mock)
         {
-            var elementType = type.GetElementType();
+            var elementType = type.GetElementType()!;
             var lengths = new int[type.GetArrayRank()];
             return Array.CreateInstance(elementType, lengths);
         }

--- a/src/Moq/Evaluator.cs
+++ b/src/Moq/Evaluator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 
 namespace Moq
@@ -53,7 +54,10 @@ namespace Moq
                 return this.Visit(exp);
             }
 
-            public override Expression Visit(Expression exp)
+#if NULLABLE_REFERENCE_TYPES
+            [return: NotNullIfNotNull("exp")]
+#endif
+            public override Expression? Visit(Expression? exp)
             {
                 if (exp == null)
                 {
@@ -85,7 +89,7 @@ namespace Moq
         class Nominator : ExpressionVisitor
         {
             Func<Expression, bool> fnCanBeEvaluated;
-            HashSet<Expression> candidates;
+            HashSet<Expression> candidates = null!;
             bool cannotBeEvaluated;
 
             internal Nominator(Func<Expression, bool> fnCanBeEvaluated)
@@ -100,7 +104,7 @@ namespace Moq
                 return this.candidates;
             }
 
-            public override Expression Visit(Expression expression)
+            public override Expression? Visit(Expression? expression)
             {
                 if (expression != null && expression.NodeType != ExpressionType.Quote)
                 {

--- a/src/Moq/Expectation.cs
+++ b/src/Moq/Expectation.cs
@@ -2,6 +2,7 @@
 // All rights reserved. Licensed under the BSD 3-Clause License; see License.txt.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq.Expressions;
 
 using Moq.Async;
@@ -16,18 +17,23 @@ namespace Moq
     {
         public abstract LambdaExpression Expression { get; }
 
-        public virtual bool HasResultExpression(out IAwaitableFactory awaitableFactory)
+#if NULLABLE_REFERENCE_TYPES
+        
+        public virtual bool HasResultExpression([NotNullWhen(true)] out IAwaitableFactory? awaitableFactory)
+#else
+        public virtual bool HasResultExpression(out IAwaitableFactory? awaitableFactory)
+#endif
         {
             awaitableFactory = null;
             return false;
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is Expectation other && this.Equals(other);
         }
 
-        public abstract bool Equals(Expectation other);
+        public abstract bool Equals(Expectation? other);
 
         public abstract override int GetHashCode();
 

--- a/src/Moq/ExpressionComparer.cs
+++ b/src/Moq/ExpressionComparer.cs
@@ -21,7 +21,7 @@ namespace Moq
         {
         }
 
-        public bool Equals(Expression x, Expression y)
+        public bool Equals(Expression? x, Expression? y)
         {
             if (object.ReferenceEquals(x, y))
             {
@@ -137,7 +137,7 @@ namespace Moq
 
         public int GetHashCode(Expression obj)
         {
-            return obj == null ? 0 : obj.GetHashCode();
+            return obj.GetHashCode();
         }
 
         static bool Equals<T>(ReadOnlyCollection<T> x, ReadOnlyCollection<T> y, Func<T, T, bool> comparer)

--- a/src/Moq/ExpressionReconstructor.cs
+++ b/src/Moq/ExpressionReconstructor.cs
@@ -29,6 +29,6 @@ namespace Moq
         /// </summary>
         /// <param name="action">The <see cref="Action"/> delegate for which to reconstruct a LINQ expression tree.</param>
         /// <param name="ctorArgs">Arguments to pass to a parameterized constructor of <typeparamref name="T"/>. (Optional.)</param>
-        public abstract Expression<Action<T>> ReconstructExpression<T>(Action<T> action, object[]? ctorArgs = null);
+        public abstract Expression<Action<T>> ReconstructExpression<T>(Action<T> action, object?[]? ctorArgs = null);
     }
 }

--- a/src/Moq/ExpressionReconstructor.cs
+++ b/src/Moq/ExpressionReconstructor.cs
@@ -29,6 +29,6 @@ namespace Moq
         /// </summary>
         /// <param name="action">The <see cref="Action"/> delegate for which to reconstruct a LINQ expression tree.</param>
         /// <param name="ctorArgs">Arguments to pass to a parameterized constructor of <typeparamref name="T"/>. (Optional.)</param>
-        public abstract Expression<Action<T>> ReconstructExpression<T>(Action<T> action, object[] ctorArgs = null);
+        public abstract Expression<Action<T>> ReconstructExpression<T>(Action<T> action, object[]? ctorArgs = null);
     }
 }

--- a/src/Moq/Expressions/Visitors/EvaluateCaptures.cs
+++ b/src/Moq/Expressions/Visitors/EvaluateCaptures.cs
@@ -22,7 +22,7 @@ namespace Moq.Expressions.Visitors
         {
             if (node.Member is FieldInfo fi
                 && node.Expression is ConstantExpression ce
-                && node.Member.DeclaringType.IsDefined(typeof(CompilerGeneratedAttribute)))
+                && fi.DeclaringType!.IsDefined(typeof(CompilerGeneratedAttribute)))
             {
                 return Expression.Constant(fi.GetValue(ce.Value), node.Type);
             }

--- a/src/Moq/Expressions/Visitors/UpgradePropertyAccessorMethods.cs
+++ b/src/Moq/Expressions/Visitors/UpgradePropertyAccessorMethods.cs
@@ -48,7 +48,7 @@ namespace Moq.Expressions.Visitors
                     if (argumentCount == 0)
                     {
                         // getter:
-                        var property = node.Method.DeclaringType.GetProperty(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                        var property = node.Method.DeclaringType!.GetProperty(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
                         Debug.Assert(property != null && property.GetGetMethod(true) == node.Method);
 
                         return Expression.MakeMemberAccess(instance, property);
@@ -58,10 +58,10 @@ namespace Moq.Expressions.Visitors
                         // indexer getter:
                         var parameterTypes = node.Method.GetParameterTypes();
                         var argumentTypes = parameterTypes.ToArray();
-                        var indexer = node.Method.DeclaringType.GetProperty(name, node.Method.ReturnType, argumentTypes);
+                        var indexer = node.Method.DeclaringType!.GetProperty(name, node.Method.ReturnType, argumentTypes);
                         Debug.Assert(indexer != null && indexer.GetGetMethod(true) == node.Method);
 
-                        return Expression.MakeIndex(instance, indexer, arguments);
+                        return Expression.MakeIndex(instance!, indexer, arguments);
                     }
                 }
                 else if (node.Method.IsSetAccessor())
@@ -72,7 +72,7 @@ namespace Moq.Expressions.Visitors
                     if (argumentCount == 1)
                     {
                         // setter:
-                        var property = node.Method.DeclaringType.GetProperty(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                        var property = node.Method.DeclaringType!.GetProperty(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
                         Debug.Assert(property != null && property.GetSetMethod(true) == node.Method);
 
                         var value = node.Arguments[0];
@@ -83,12 +83,12 @@ namespace Moq.Expressions.Visitors
                         // indexer setter:
                         var parameterTypes = node.Method.GetParameterTypes();
                         var argumentTypes = parameterTypes.Take(parameterTypes.Count - 1).ToArray();
-                        var indexer = node.Method.DeclaringType.GetProperty(name, parameterTypes.Last(), argumentTypes);
+                        var indexer = node.Method.DeclaringType!.GetProperty(name, parameterTypes.Last(), argumentTypes);
                         Debug.Assert(indexer != null && indexer.GetSetMethod(true) == node.Method);
 
                         var indices = arguments.Take(argumentCount - 1);
                         var value = arguments.Last();
-                        return Expression.Assign(Expression.MakeIndex(instance, indexer, indices), value);
+                        return Expression.Assign(Expression.MakeIndex(instance!, indexer, indices), value);
                     }
                 }
             }

--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -20,7 +20,7 @@ namespace Moq
         {
             return type.IsValueType || type.GetConstructor(Type.EmptyTypes) != null;
         }
-        
+
 #if NULLABLE_REFERENCE_TYPES
         public static bool CanRead(this PropertyInfo property, [NotNullWhen(true)] out MethodInfo? getter)
 #else

--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -170,11 +170,11 @@ namespace Moq
             }
         }
 
-        public static object InvokePreserveStack(this Delegate del, IReadOnlyList<object>? args = null)
+        public static object? InvokePreserveStack(this Delegate del, IReadOnlyList<object?>? args = null)
         {
             try
             {
-                return del.DynamicInvoke((args as object[]) ?? args?.ToArray());
+                return del.DynamicInvoke((args as object?[]) ?? args?.ToArray());
             }
             catch (TargetInvocationException ex)
             {
@@ -428,7 +428,7 @@ namespace Moq
 
             if (type.IsTypeMatcher(out var typeMatcherType))
             {
-                var typeMatcher = (ITypeMatcher)Activator.CreateInstance(typeMatcherType);
+                var typeMatcher = (ITypeMatcher)Activator.CreateInstance(typeMatcherType)!;
 
                 if (typeMatcher.Matches(other))
                 {
@@ -509,8 +509,7 @@ namespace Moq
         public static IEnumerable<Mock> FindAllInnerMocks(this SetupCollection setups)
         {
             return setups.FindAll(setup => !setup.IsConditional)
-                         .SelectMany(setup => setup.InnerMocks)
-                         .Where(innerMock => innerMock != null);
+                         .SelectMany(setup => setup.InnerMocks);
         }
 
         public static Mock? FindLastInnerMock(this SetupCollection setups, Func<Setup, bool> predicate)

--- a/src/Moq/Extensions.cs
+++ b/src/Moq/Extensions.cs
@@ -60,7 +60,7 @@ namespace Moq
                     var baseProperty =
                         baseSetter
                         .DeclaringType
-                        .GetMember(property.Name, MemberTypes.Property, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                        !.GetMember(property.Name, MemberTypes.Property, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
                         .Cast<PropertyInfo>()
                         .First(p => p.GetSetMethod(nonPublic: true) == baseSetter);
                     return baseProperty.CanRead(out getter, out getterProperty);
@@ -513,7 +513,7 @@ namespace Moq
                          .Where(innerMock => innerMock != null);
         }
 
-        public static Mock FindLastInnerMock(this SetupCollection setups, Func<Setup, bool> predicate)
+        public static Mock? FindLastInnerMock(this SetupCollection setups, Func<Setup, bool> predicate)
         {
             return setups.FindLast(setup => !setup.IsConditional && predicate(setup))?.InnerMocks.SingleOrDefault();
         }

--- a/src/Moq/Guard.cs
+++ b/src/Moq/Guard.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -165,7 +166,11 @@ namespace Moq
         /// Ensures the given <paramref name="value"/> is not null.
         /// Throws <see cref="ArgumentNullException"/> otherwise.
         /// </summary>
-        public static void NotNull(object value, string paramName)
+#if NULLABLE_REFERENCE_TYPES
+        public static void NotNull([NotNull] object? value, string paramName)
+#else
+        public static void NotNull(object? value, string paramName)
+#endif
         {
             if (value == null)
             {

--- a/src/Moq/Guard.cs
+++ b/src/Moq/Guard.cs
@@ -28,7 +28,7 @@ namespace Moq
             }
         }
 
-        public static void ImplementsInterface(Type interfaceType, Type type, string paramName = null)
+        public static void ImplementsInterface(Type interfaceType, Type type, string? paramName = null)
         {
             Debug.Assert(interfaceType != null);
             Debug.Assert(interfaceType.IsInterface);
@@ -92,7 +92,7 @@ namespace Moq
                         string.Format(
                             CultureInfo.CurrentCulture,
                             method.IsExtensionMethod() ? Resources.UnsupportedExtensionMethod : Resources.UnsupportedStaticMember,
-                            $"{method.DeclaringType.GetFormattedName()}.{method.Name}")));
+                            $"{method.DeclaringType!.GetFormattedName()}.{method.Name}")));
             }
             else if (!method.CanOverride())
             {
@@ -104,18 +104,18 @@ namespace Moq
                         string.Format(
                             CultureInfo.CurrentCulture,
                             Resources.UnsupportedNonOverridableMember,
-                            $"{method.DeclaringType.GetFormattedName()}.{method.Name}")));
+                            $"{method.DeclaringType!.GetFormattedName()}.{method.Name}")));
             }
         }
 
         public static void IsVisibleToProxyFactory(MethodInfo method)
         {
-            if (ProxyFactory.Instance.IsMethodVisible(method, out string messageIfNotVisible) == false)
+            if (ProxyFactory.Instance.IsMethodVisible(method, out string? messageIfNotVisible) == false)
             {
                 throw new ArgumentException(string.Format(
                     CultureInfo.CurrentCulture,
                     Resources.MethodNotVisibleToProxyFactory,
-                    method.DeclaringType.Name,
+                    method.DeclaringType!.Name,
                     method.Name,
                     messageIfNotVisible));
             }
@@ -226,7 +226,7 @@ namespace Moq
                 throw new ArgumentException(string.Format(
                     CultureInfo.CurrentCulture,
                     Resources.PropertyGetNotFound,
-                    property.DeclaringType.Name, property.Name));
+                    property.DeclaringType!.Name, property.Name));
             }
         }
 
@@ -237,7 +237,7 @@ namespace Moq
                 throw new ArgumentException(string.Format(
                     CultureInfo.CurrentCulture,
                     Resources.PropertySetNotFound,
-                    property.DeclaringType.Name, property.Name));
+                    property.DeclaringType!.Name, property.Name));
             }
         }
     }

--- a/src/Moq/IInvocation.cs
+++ b/src/Moq/IInvocation.cs
@@ -20,7 +20,7 @@ namespace Moq
         /// <summary>
         /// Gets the arguments of the invocation.
         /// </summary>
-        IReadOnlyList<object> Arguments { get; }
+        IReadOnlyList<object?> Arguments { get; }
 
         /// <summary>
         ///   Gets the setup that matched this invocation (or <see langword="null"/> if there was no matching setup).

--- a/src/Moq/IInvocation.cs
+++ b/src/Moq/IInvocation.cs
@@ -25,7 +25,7 @@ namespace Moq
         /// <summary>
         ///   Gets the setup that matched this invocation (or <see langword="null"/> if there was no matching setup).
         /// </summary>
-        ISetup MatchingSetup { get; }
+        ISetup? MatchingSetup { get; }
 
         /// <summary>
         ///   Gets whether this invocation was successfully verified by any of the various <c>`Verify`</c> methods.
@@ -35,11 +35,11 @@ namespace Moq
         /// <summary>
         /// The value being returned for a non-void method if no exception was thrown.
         /// </summary>
-        object ReturnValue { get; }
+        object? ReturnValue { get; }
 
         /// <summary>
         /// Optional exception if the method invocation results in an exception being thrown.
         /// </summary>
-        Exception Exception { get; }
+        Exception? Exception { get; }
     }
 }

--- a/src/Moq/IMatcher.cs
+++ b/src/Moq/IMatcher.cs
@@ -7,8 +7,8 @@ namespace Moq
 {
     interface IMatcher
     {
-        bool Matches(object argument, Type parameterType);
+        bool Matches(object? argument, Type parameterType);
 
-        void SetupEvaluatedSuccessfully(object argument, Type parameterType);
+        void SetupEvaluatedSuccessfully(object? argument, Type parameterType);
     }
 }

--- a/src/Moq/ISetup.cs
+++ b/src/Moq/ISetup.cs
@@ -49,7 +49,7 @@ namespace Moq
         // /// <exception cref="InvalidOperationException">The setup has more than one inner mock.</exception>
         // [Obsolete("Use 'InnerMocks' instead.")]
         // [EditorBrowsable(EditorBrowsableState.Never)]
-        Mock InnerMock { get; }
+        Mock? InnerMock { get; }
 
         // /// <summary>
         // ///   Gets the inner mocks of this setup (if present and known).

--- a/src/Moq/ISetup.cs
+++ b/src/Moq/ISetup.cs
@@ -126,7 +126,7 @@ namespace Moq
         ///     e.g. by <see cref="Mock{T}.SetupAllProperties"/> or by <see cref="DefaultValue.Mock"/>.
         ///   </para>
         /// </summary>
-        Expression OriginalExpression { get; }
+        Expression? OriginalExpression { get; }
 
         /// <summary>
         ///   Verifies this setup and optionally all verifiable setups of its inner mock (if present and known).

--- a/src/Moq/InnerMockSetup.cs
+++ b/src/Moq/InnerMockSetup.cs
@@ -13,7 +13,7 @@ namespace Moq
     {
         readonly object? returnValue;
 
-        public InnerMockSetup(Expression originalExpression, Mock mock, MethodExpectation expectation, object? returnValue)
+        public InnerMockSetup(Expression? originalExpression, Mock mock, MethodExpectation expectation, object? returnValue)
             : base(originalExpression, mock, expectation)
         {
             Debug.Assert(Awaitable.TryGetResultRecursive(returnValue) is IMocked);

--- a/src/Moq/InnerMockSetup.cs
+++ b/src/Moq/InnerMockSetup.cs
@@ -11,9 +11,9 @@ namespace Moq
 {
     sealed class InnerMockSetup : SetupWithOutParameterSupport
     {
-        readonly object returnValue;
+        readonly object? returnValue;
 
-        public InnerMockSetup(Expression originalExpression, Mock mock, MethodExpectation expectation, object returnValue)
+        public InnerMockSetup(Expression originalExpression, Mock mock, MethodExpectation expectation, object? returnValue)
             : base(originalExpression, mock, expectation)
         {
             Debug.Assert(Awaitable.TryGetResultRecursive(returnValue) is IMocked);

--- a/src/Moq/Interception/CastleProxyFactory.cs
+++ b/src/Moq/Interception/CastleProxyFactory.cs
@@ -44,7 +44,7 @@ namespace Moq
         }
 
         /// <inheritdoc />
-        public override object CreateProxy(Type mockType, Moq.IInterceptor interceptor, Type[] interfaces, object[] arguments)
+        public override object CreateProxy(Type mockType, Moq.IInterceptor interceptor, Type[] interfaces, object?[] arguments)
         {
             // All generated proxies need to implement `IProxy`:
             var additionalInterfaces = new Type[1 + interfaces.Length];

--- a/src/Moq/Interception/InterceptionAspects.cs
+++ b/src/Moq/Interception/InterceptionAspects.cs
@@ -117,7 +117,7 @@ namespace Moq
                 if (methodName[0] == 'a' && methodName[3] == '_' && invocation.Method.IsEventAddAccessor())
                 {
                     var implementingMethod = invocation.Method.GetImplementingMethod(invocation.ProxyType);
-                    var @event = implementingMethod.DeclaringType.GetEvents(bindingFlags).SingleOrDefault(e => e.GetAddMethod(true) == implementingMethod);
+                    var @event = implementingMethod.DeclaringType!.GetEvents(bindingFlags).SingleOrDefault(e => e.GetAddMethod(true) == implementingMethod);
                     if (@event != null)
                     {
                         if (mock.CallBase && !invocation.Method.IsAbstract)
@@ -135,7 +135,7 @@ namespace Moq
                 else if (methodName[0] == 'r' && methodName.Length > 7 && methodName[6] == '_' && invocation.Method.IsEventRemoveAccessor())
                 {
                     var implementingMethod = invocation.Method.GetImplementingMethod(invocation.ProxyType);
-                    var @event = implementingMethod.DeclaringType.GetEvents(bindingFlags).SingleOrDefault(e => e.GetRemoveMethod(true) == implementingMethod);
+                    var @event = implementingMethod.DeclaringType!.GetEvents(bindingFlags).SingleOrDefault(e => e.GetRemoveMethod(true) == implementingMethod);
                     if (@event != null)
                     {
                         if (mock.CallBase && !invocation.Method.IsAbstract)

--- a/src/Moq/Interception/InterfaceProxy.cs
+++ b/src/Moq/Interception/InterfaceProxy.cs
@@ -17,19 +17,19 @@ namespace Moq.Internals
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class InterfaceProxy
     {
-        static MethodInfo equalsMethod = typeof(object).GetMethod("Equals", BindingFlags.Public | BindingFlags.Instance);
-        static MethodInfo getHashCodeMethod = typeof(object).GetMethod("GetHashCode", BindingFlags.Public | BindingFlags.Instance);
-        static MethodInfo toStringMethod = typeof(object).GetMethod("ToString", BindingFlags.Public | BindingFlags.Instance);
+        static MethodInfo equalsMethod = typeof(object).GetMethod("Equals", BindingFlags.Public | BindingFlags.Instance)!;
+        static MethodInfo getHashCodeMethod = typeof(object).GetMethod("GetHashCode", BindingFlags.Public | BindingFlags.Instance)!;
+        static MethodInfo toStringMethod = typeof(object).GetMethod("ToString", BindingFlags.Public | BindingFlags.Instance)!;
 
         /// <summary/>
         [DebuggerHidden]
-        public sealed override bool Equals(object obj)
+        public sealed override bool Equals(object? obj)
         {
             // Forward this call to the interceptor, so that `object.Equals` can be set up.
             var interceptor = (IInterceptor)((IProxy)this).Interceptor;
             var invocation = new Invocation(this.GetType(), equalsMethod, obj);
             interceptor.Intercept(invocation);
-            return (bool)invocation.ReturnValue;
+            return (bool)invocation.ReturnValue!;
         }
 
         /// <summary/>
@@ -40,25 +40,25 @@ namespace Moq.Internals
             var interceptor = (IInterceptor)((IProxy)this).Interceptor;
             var invocation = new Invocation(this.GetType(), getHashCodeMethod);
             interceptor.Intercept(invocation);
-            return (int)invocation.ReturnValue;
+            return (int)invocation.ReturnValue!;
         }
 
         /// <summary/>
         [DebuggerHidden]
-        public sealed override string ToString()
+        public sealed override string? ToString()
         {
             // Forward this call to the interceptor, so that `object.ToString` can be set up.
             var interceptor = (IInterceptor)((IProxy)this).Interceptor;
             var invocation = new Invocation(this.GetType(), toStringMethod);
             interceptor.Intercept(invocation);
-            return (string)invocation.ReturnValue;
+            return (string?)invocation.ReturnValue;
         }
 
         sealed class Invocation : Moq.Invocation
         {
-            static object[] noArguments = new object[0];
+            static object?[] noArguments = new object?[0];
 
-            public Invocation(Type proxyType, MethodInfo method, params object[] arguments)
+            public Invocation(Type proxyType, MethodInfo method, params object?[] arguments)
                 : base(proxyType, method, arguments)
             {
             }

--- a/src/Moq/Interception/ProxyFactory.cs
+++ b/src/Moq/Interception/ProxyFactory.cs
@@ -13,7 +13,7 @@ namespace Moq
         /// </summary>
         public static ProxyFactory Instance { get; } = new CastleProxyFactory();
 
-        public abstract object CreateProxy(Type mockType, IInterceptor interceptor, Type[] interfaces, object[] arguments);
+        public abstract object CreateProxy(Type mockType, IInterceptor interceptor, Type[] interfaces, object?[] arguments);
 
         public abstract bool IsMethodVisible(MethodInfo method, out string messageIfNotVisible);
 

--- a/src/Moq/Invocation.cs
+++ b/src/Moq/Invocation.cs
@@ -14,7 +14,7 @@ namespace Moq
 {
     abstract class Invocation : IInvocation
     {
-        object[] arguments;
+        object?[] arguments;
         MethodInfo method;
         MethodInfo? methodImplementation;
         readonly Type proxyType;
@@ -28,7 +28,7 @@ namespace Moq
         /// <param name="proxyType">The <see cref="Type"/> of the concrete proxy object on which a method is being invoked.</param>
         /// <param name="method">The method being invoked.</param>
         /// <param name="arguments">The arguments with which the specified <paramref name="method"/> is being invoked.</param>
-        protected Invocation(Type proxyType, MethodInfo method, params object[] arguments)
+        protected Invocation(Type proxyType, MethodInfo method, params object?[] arguments)
         {
             Debug.Assert(proxyType != null);
             Debug.Assert(arguments != null);
@@ -64,9 +64,9 @@ namespace Moq
         /// Arguments may be modified. Derived classes must ensure that by-reference parameters are written back
         /// when the invocation is ended by a call to any of the three <c>Returns</c> methods.
         /// </remarks>
-        public object[] Arguments => this.arguments;
+        public object?[] Arguments => this.arguments;
 
-        IReadOnlyList<object> IInvocation.Arguments => this.arguments;
+        IReadOnlyList<object?> IInvocation.Arguments => this.arguments;
 
         public ISetup? MatchingSetup => this.matchingSetup;
 

--- a/src/Moq/Invocation.cs
+++ b/src/Moq/Invocation.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text;
 
@@ -15,10 +16,10 @@ namespace Moq
     {
         object[] arguments;
         MethodInfo method;
-        MethodInfo methodImplementation;
+        MethodInfo? methodImplementation;
         readonly Type proxyType;
-        object result;
-        Setup matchingSetup;
+        object? result;
+        Setup? matchingSetup;
         bool verified;
 
         /// <summary>
@@ -67,11 +68,11 @@ namespace Moq
 
         IReadOnlyList<object> IInvocation.Arguments => this.arguments;
 
-        public ISetup MatchingSetup => this.matchingSetup;
+        public ISetup? MatchingSetup => this.matchingSetup;
 
         public Type ProxyType => this.proxyType;
 
-        public object ReturnValue
+        public object? ReturnValue
         {
             get => this.result is ExceptionResult ? null : this.result;
             set
@@ -80,8 +81,10 @@ namespace Moq
                 this.result = value;
             }
         }
-
-        public Exception Exception
+#if NULLABLE_REFERENCE_TYPES  
+        [DisallowNull]
+#endif
+        public Exception? Exception
         {
             get => this.result is ExceptionResult r ? r.Exception : null;
             set
@@ -134,7 +137,7 @@ namespace Moq
             var method = this.Method;
 
             var builder = new StringBuilder();
-            builder.AppendNameOf(method.DeclaringType);
+            builder.AppendNameOf(method.DeclaringType!);
             builder.Append('.');
 
             if (method.IsGetAccessor())

--- a/src/Moq/InvocationCollection.cs
+++ b/src/Moq/InvocationCollection.cs
@@ -10,7 +10,7 @@ namespace Moq
 {
     sealed class InvocationCollection : IInvocationList
     {
-        Invocation[] invocations;
+        Invocation[] invocations = new Invocation[0];
         int capacity = 0;
         int count = 0;
 
@@ -72,7 +72,7 @@ namespace Moq
             lock (this.invocationsLock)
             {
                 // Replace the collection so readers with a reference to the old collection aren't interrupted
-                this.invocations = null;
+                this.invocations = new Invocation[0];
                 this.count = 0;
                 this.capacity = 0;
 

--- a/src/Moq/It.cs
+++ b/src/Moq/It.cs
@@ -32,7 +32,7 @@ namespace Moq
             /// <summary>
             /// Matches any value that is assignment-compatible with type <typeparamref name="TValue"/>.
             /// </summary>
-            public static TValue IsAny;
+            public static TValue IsAny = default(TValue)!;
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace Moq
             }
         }
 
-        static readonly MethodInfo isAnyMethod = typeof(It).GetMethod(nameof(It.IsAny), BindingFlags.Public | BindingFlags.Static);
+        static readonly MethodInfo isAnyMethod = typeof(It).GetMethod(nameof(It.IsAny), BindingFlags.Public | BindingFlags.Static)!;
 
         internal static MethodCallExpression IsAny(Type genericArgument)
         {
@@ -143,7 +143,7 @@ namespace Moq
                 throw new ArgumentException(Resources.UseItIsOtherOverload, nameof(match));
             }
 
-            var thisMethod = (MethodInfo)MethodBase.GetCurrentMethod();
+            var thisMethod = (MethodInfo)MethodBase.GetCurrentMethod()!;
             var compiledMatchMethod = match.CompileUsingExpressionCompiler();
 
             return Match.Create<TValue>(
@@ -165,9 +165,9 @@ namespace Moq
         ///   Allows the specification of a predicate to perform matching of method call arguments.
         /// </remarks>
         [EditorBrowsable(EditorBrowsableState.Advanced)]
-        public static TValue Is<TValue>(Expression<Func<object, Type, bool>> match)
+        public static TValue Is<TValue>(Expression<Func<object?, Type, bool>> match)
         {
-            var thisMethod = (MethodInfo)MethodBase.GetCurrentMethod();
+            var thisMethod = (MethodInfo)MethodBase.GetCurrentMethod()!;
             var compiledMatchMethod = match.CompileUsingExpressionCompiler();
 
             return Match.Create<TValue>(

--- a/src/Moq/Language/Flow/SetupPhrase.cs
+++ b/src/Moq/Language/Flow/SetupPhrase.cs
@@ -286,9 +286,9 @@ namespace Moq.Language.Flow
 
         public void Verifiable(Times times) => this.Verifiable(times, null);
 
-        public void Verifiable(Func<Times> times, string failMessage) => this.Verifiable(times(), failMessage);
+        public void Verifiable(Func<Times> times, string? failMessage) => this.Verifiable(times(), failMessage);
 
-        public void Verifiable(Times times, string failMessage)
+        public void Verifiable(Times times, string? failMessage)
         {
             this.setup.MarkAsVerifiable();
             this.setup.SetExpectedInvocationCount(times);

--- a/src/Moq/Linq/MockSetupsBuilder.cs
+++ b/src/Moq/Linq/MockSetupsBuilder.cs
@@ -103,7 +103,7 @@ namespace Moq.Linq
             return base.VisitUnary(node);
         }
 
-        static Expression ConvertToSetup(Expression left, Expression right)
+        static Expression? ConvertToSetup(Expression left, Expression right)
         {
             switch (left.NodeType)
             {

--- a/src/Moq/Match.cs
+++ b/src/Moq/Match.cs
@@ -78,7 +78,7 @@ namespace Moq
         bool IMatcher.Matches(object? argument, Type parameterType) => this.Matches(argument, parameterType);
 
         void IMatcher.SetupEvaluatedSuccessfully(object? value, Type parameterType) => this.SetupEvaluatedSuccessfully(value, parameterType);
-        
+
         // TODO: Consider making the constructor set this to avoid the nullable reference warning.
         internal Expression RenderExpression { get; set; }
 

--- a/src/Moq/Match.cs
+++ b/src/Moq/Match.cs
@@ -163,9 +163,9 @@ namespace Moq
     public class Match<T> : Match, IEquatable<Match<T>>
     {
         internal Predicate<T> Condition { get; set; }
-        internal Action<T> Success { get; set; }
+        internal Action<T>? Success { get; set; }
 
-        internal Match(Predicate<T> condition, Expression<Func<T>> renderExpression, Action<T> success = null)
+        internal Match(Predicate<T> condition, Expression<Func<T>> renderExpression, Action<T>? success = null)
         {
             this.Condition = condition;
             this.RenderExpression = renderExpression.Body.Apply(EvaluateCaptures.Rewriter);

--- a/src/Moq/Match.cs
+++ b/src/Moq/Match.cs
@@ -199,15 +199,19 @@ namespace Moq
         }
 
         /// <inheritdoc/>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is Match<T> other && this.Equals(other);
         }
 
         /// <inheritdoc/>
-        public bool Equals(Match<T> other)
+        public bool Equals(Match<T>? other)
         {
-            if (this.Condition == other.Condition)
+            if (other == null)
+            {
+                return false;
+            }
+            else if (this.Condition == other.Condition)
             {
                 return true;
             }

--- a/src/Moq/Match.cs
+++ b/src/Moq/Match.cs
@@ -68,7 +68,7 @@ namespace Moq
         /// </devdoc>
         internal static TValue Matcher<TValue>()
         {
-            return default(TValue);
+            return default(TValue)!;
         }
 
         internal abstract bool Matches(object argument, Type parameterType);
@@ -104,7 +104,7 @@ namespace Moq
         public static T Create<T>(Predicate<T> condition, Expression<Func<T>> renderExpression)
         {
             Match.Register(new Match<T>(condition, renderExpression));
-            return default(T);
+            return default(T)!;
         }
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace Moq
             Guard.NotNull(renderExpression, nameof(renderExpression));
 
             Match.Register(new MatchFactory(condition, renderExpression));
-            return default(T);
+            return default(T)!;
         }
 
         internal static void Register(Match match)
@@ -185,7 +185,7 @@ namespace Moq
             this.Success?.Invoke((T)argument);
         }
 
-        static bool CanCast(object value)
+        static bool CanCast(object? value)
         {
             if (value != null)
             {
@@ -260,7 +260,7 @@ namespace Moq
             Debug.Assert(this.Matches(argument, parameterType));
         }
 
-        static bool CanCast<T>(object value)
+        static bool CanCast<T>(object? value)
         {
             if (value != null)
             {
@@ -273,7 +273,7 @@ namespace Moq
             }
         }
 
-        static readonly MethodInfo canCastMethod = typeof(MatchFactory).GetMethod("CanCast", BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
+        static readonly MethodInfo canCastMethod = typeof(MatchFactory).GetMethod(nameof(CanCast), BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly)!;
 
         // TODO: Check whether we need to implement `IEquatable<>` to make this work with delegate-based
         // setup & verification methods such as `SetupSet`!

--- a/src/Moq/MatcherFactory.cs
+++ b/src/Moq/MatcherFactory.cs
@@ -52,7 +52,7 @@ namespace Moq
                         var member = memberExpression.Member;
                         if (member.Name == nameof(It.Ref<object>.IsAny))
                         {
-                            var memberDeclaringType = member.DeclaringType;
+                            var memberDeclaringType = member.DeclaringType!;
                             if (memberDeclaringType.IsGenericType)
                             {
                                 var memberDeclaringTypeDefinition = memberDeclaringType.GetGenericTypeDefinition();
@@ -77,7 +77,7 @@ namespace Moq
                 var newArrayExpression = (NewArrayExpression)argument;
 
                 Debug.Assert(newArrayExpression.Type.IsArray);
-                var elementType = newArrayExpression.Type.GetElementType();
+                var elementType = newArrayExpression.Type.GetElementType()!;
 
                 var n = newArrayExpression.Expressions.Count;
                 var matchers = new IMatcher[n];

--- a/src/Moq/MatcherObserver.cs
+++ b/src/Moq/MatcherObserver.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Moq
@@ -21,7 +22,7 @@ namespace Moq
     sealed class MatcherObserver : IDisposable
     {
         [ThreadStatic]
-        static Stack<MatcherObserver> activations;
+        static Stack<MatcherObserver>? activations;
 
         public static MatcherObserver Activate()
         {
@@ -37,7 +38,11 @@ namespace Moq
             return activation;
         }
 
-        public static bool IsActive(out MatcherObserver observer)
+#if NULLABLE_REFERENCE_TYPES
+        public static bool IsActive([NotNullWhen(true)] out MatcherObserver? observer)
+#else
+        public static bool IsActive(out MatcherObserver? observer)
+#endif
         {
             var activations = MatcherObserver.activations;
 
@@ -54,7 +59,7 @@ namespace Moq
         }
 
         int timestamp;
-        List<Observation> observations;
+        List<Observation>? observations;
 
         MatcherObserver()
         {
@@ -94,7 +99,11 @@ namespace Moq
         ///   and if so, returns the last one.
         /// </summary>
         /// <param name="match">The observed <see cref="Match"/> matcher observed last.</param>
-        public bool TryGetLastMatch(out Match match)
+#if NULLABLE_REFERENCE_TYPES
+        public bool TryGetLastMatch([NotNullWhen(true)] out Match? match)
+#else
+        public bool TryGetLastMatch(out Match? match)
+#endif
         {
             if (this.observations != null && this.observations.Count > 0)
             {

--- a/src/Moq/Matchers/AnyMatcher.cs
+++ b/src/Moq/Matchers/AnyMatcher.cs
@@ -14,9 +14,9 @@ namespace Moq.Matchers
         {
         }
 
-        public bool Matches(object argument, Type parameterType) => true;
+        public bool Matches(object? argument, Type parameterType) => true;
 
-        public void SetupEvaluatedSuccessfully(object argument, Type parameterType)
+        public void SetupEvaluatedSuccessfully(object? argument, Type parameterType)
         {
             Debug.Assert(this.Matches(argument, parameterType));
         }

--- a/src/Moq/Matchers/ConstantMatcher.cs
+++ b/src/Moq/Matchers/ConstantMatcher.cs
@@ -10,14 +10,14 @@ namespace Moq.Matchers
 {
     class ConstantMatcher : IMatcher
     {
-        object constantValue;
+        object? constantValue;
 
-        public ConstantMatcher(object constantValue)
+        public ConstantMatcher(object? constantValue)
         {
             this.constantValue = constantValue;
         }
 
-        public bool Matches(object argument, Type parameterType)
+        public bool Matches(object? argument, Type parameterType)
         {
             if (object.Equals(argument, constantValue))
             {
@@ -36,14 +36,14 @@ namespace Moq.Matchers
             return false;
         }
 
-        public void SetupEvaluatedSuccessfully(object argument, Type parameterType)
+        public void SetupEvaluatedSuccessfully(object? argument, Type parameterType)
         {
             Debug.Assert(this.Matches(argument, parameterType));
         }
 
         bool MatchesEnumerable(IEnumerable enumerable)
         {
-            var constValues = (IEnumerable)constantValue;
+            var constValues = (IEnumerable)constantValue!;
             return constValues.Cast<object>().SequenceEqual(enumerable.Cast<object>());
         }
     }

--- a/src/Moq/Matchers/ExpressionMatcher.cs
+++ b/src/Moq/Matchers/ExpressionMatcher.cs
@@ -16,13 +16,13 @@ namespace Moq.Matchers
             this.expression = expression;
         }
 
-        public bool Matches(object argument, Type parameterType)
+        public bool Matches(object? argument, Type parameterType)
         {
             return argument is Expression valueExpression
                 && ExpressionComparer.Default.Equals(this.expression, valueExpression);
         }
 
-        public void SetupEvaluatedSuccessfully(object argument, Type parameterType)
+        public void SetupEvaluatedSuccessfully(object? argument, Type parameterType)
         {
             Debug.Assert(this.Matches(argument, parameterType));
         }

--- a/src/Moq/Matchers/LazyEvalMatcher.cs
+++ b/src/Moq/Matchers/LazyEvalMatcher.cs
@@ -16,13 +16,13 @@ namespace Moq.Matchers
             this.expression = expression;
         }
 
-        public bool Matches(object argument, Type parameterType)
+        public bool Matches(object? argument, Type parameterType)
         {
             var eval = Evaluator.PartialEval(this.expression);
             return eval is ConstantExpression ce && new ConstantMatcher(ce.Value).Matches(argument, parameterType);
         }
 
-        public void SetupEvaluatedSuccessfully(object argument, Type parameterType)
+        public void SetupEvaluatedSuccessfully(object? argument, Type parameterType)
         {
             Debug.Assert(this.Matches(argument, parameterType));
         }

--- a/src/Moq/Matchers/MatcherAttributeMatcher.cs
+++ b/src/Moq/Matchers/MatcherAttributeMatcher.cs
@@ -43,7 +43,7 @@ namespace Moq.Matchers
         {
             var expectedParametersTypes = new[] { call.Method.ReturnType }.Concat(call.Method.GetParameters().Select(p => p.ParameterType)).ToArray();
 
-            MethodInfo method = null;
+            MethodInfo? method;
 
             if (call.Method.IsGenericMethod)
             {
@@ -51,7 +51,7 @@ namespace Moq.Matchers
                 // passing generic type arguments for the query.
                 var genericArgs = call.Method.GetGenericArguments();
 
-                method = call.Method.DeclaringType.GetMethods(call.Method.Name)
+                method = call.Method.DeclaringType!.GetMethods(call.Method.Name)
                     .Where(m =>
                         m.IsGenericMethodDefinition &&
                         m.GetGenericArguments().Length ==
@@ -63,7 +63,7 @@ namespace Moq.Matchers
             }
             else
             {
-                method = call.Method.DeclaringType.GetMethod(call.Method.Name, expectedParametersTypes);
+                method = call.Method.DeclaringType!.GetMethod(call.Method.Name, expectedParametersTypes);
             }
 
             // throw if validatorMethod doesn't exists			
@@ -74,22 +74,22 @@ namespace Moq.Matchers
                     call.Method.IsStatic ? "static " : String.Empty,
                     call.Method.Name,
                     String.Join(", ", expectedParametersTypes.Select(x => x.Name).ToArray()),
-                    call.Method.DeclaringType.ToString()));
+                    call.Method.DeclaringType!.ToString()));
             }
             return method;
         }
 
-        public bool Matches(object argument, Type parameterType)
+        public bool Matches(object? argument, Type parameterType)
         {
             // use matcher Expression to get extra arguments
             var extraArgs = this.expression.Arguments.Select(ae => ((ConstantExpression)ae.PartialEval()).Value);
             var args = new[] { argument }.Concat(extraArgs).ToArray();
             // for static and non-static method
             var instance = this.expression.Object == null ? null : (this.expression.Object.PartialEval() as ConstantExpression).Value;
-            return (bool)validatorMethod.Invoke(instance, args);
+            return (bool)validatorMethod.Invoke(instance, args)!;
         }
 
-        public void SetupEvaluatedSuccessfully(object argument, Type parameterType)
+        public void SetupEvaluatedSuccessfully(object? argument, Type parameterType)
         {
             Debug.Assert(this.Matches(argument, parameterType));
         }

--- a/src/Moq/Matchers/MatcherAttributeMatcher.cs
+++ b/src/Moq/Matchers/MatcherAttributeMatcher.cs
@@ -85,7 +85,7 @@ namespace Moq.Matchers
             var extraArgs = this.expression.Arguments.Select(ae => ((ConstantExpression)ae.PartialEval()).Value);
             var args = new[] { argument }.Concat(extraArgs).ToArray();
             // for static and non-static method
-            var instance = this.expression.Object == null ? null : (this.expression.Object.PartialEval() as ConstantExpression).Value;
+            var instance = this.expression.Object == null ? null : ((ConstantExpression)this.expression.Object.PartialEval()).Value;
             return (bool)validatorMethod.Invoke(instance, args)!;
         }
 

--- a/src/Moq/Matchers/ParamArrayMatcher.cs
+++ b/src/Moq/Matchers/ParamArrayMatcher.cs
@@ -24,7 +24,7 @@ namespace Moq.Matchers
                 return false;
             }
 
-            var elementType = parameterType.GetElementType();
+            var elementType = parameterType.GetElementType()!;
 
             for (int index = 0; index < values.Length; index++)
             {

--- a/src/Moq/Matchers/ParamArrayMatcher.cs
+++ b/src/Moq/Matchers/ParamArrayMatcher.cs
@@ -17,7 +17,7 @@ namespace Moq.Matchers
             this.matchers = matchers;
         }
 
-        public bool Matches(object argument, Type parameterType)
+        public bool Matches(object? argument, Type parameterType)
         {
             if (argument is not Array values || this.matchers.Length != values.Length)
             {
@@ -37,13 +37,13 @@ namespace Moq.Matchers
             return true;
         }
 
-        public void SetupEvaluatedSuccessfully(object argument, Type parameterType)
+        public void SetupEvaluatedSuccessfully(object? argument, Type parameterType)
         {
             Debug.Assert(this.Matches(argument, parameterType));
             Debug.Assert(argument is Array array && array.Length == this.matchers.Length);
 
             var values = (Array)argument;
-            var elementType = parameterType.GetElementType();
+            var elementType = parameterType.GetElementType()!;
             for (int i = 0, n = this.matchers.Length; i < n; ++i)
             {
                 this.matchers[i].SetupEvaluatedSuccessfully(values.GetValue(i), elementType);

--- a/src/Moq/Matchers/RefMatcher.cs
+++ b/src/Moq/Matchers/RefMatcher.cs
@@ -8,10 +8,10 @@ namespace Moq.Matchers
 {
     class RefMatcher : IMatcher
     {
-        readonly object reference;
+        readonly object? reference;
         readonly bool referenceIsValueType;
 
-        public RefMatcher(object reference)
+        public RefMatcher(object? reference)
         {
             this.reference = reference;
             this.referenceIsValueType = reference?.GetType().IsValueType ?? false;

--- a/src/Moq/Matchers/RefMatcher.cs
+++ b/src/Moq/Matchers/RefMatcher.cs
@@ -17,13 +17,13 @@ namespace Moq.Matchers
             this.referenceIsValueType = reference?.GetType().IsValueType ?? false;
         }
 
-        public bool Matches(object argument, Type parameterType)
+        public bool Matches(object? argument, Type parameterType)
         {
             return this.referenceIsValueType ? object.Equals(this.reference, argument)
                                              : object.ReferenceEquals(this.reference, argument);
         }
 
-        public void SetupEvaluatedSuccessfully(object value, Type parameterType)
+        public void SetupEvaluatedSuccessfully(object? value, Type parameterType)
         {
             Debug.Assert(this.Matches(value, parameterType));
         }

--- a/src/Moq/MethodCall.cs
+++ b/src/Moq/MethodCall.cs
@@ -20,16 +20,16 @@ namespace Moq
 {
     sealed partial class MethodCall : SetupWithOutParameterSupport
     {
-        VerifyInvocationCount verifyInvocationCount;
-        Behavior callback;
-        Behavior raiseEvent;
-        Behavior returnOrThrow;
-        Behavior afterReturnCallback;
-        Condition condition;
-        string failMessage;
-        string declarationSite;
+        VerifyInvocationCount? verifyInvocationCount;
+        Behavior? callback;
+        Behavior? raiseEvent;
+        Behavior? returnOrThrow;
+        Behavior? afterReturnCallback;
+        Condition? condition;
+        string? failMessage;
+        string? declarationSite;
 
-        public MethodCall(Expression originalExpression, Mock mock, Condition condition, MethodExpectation expectation)
+        public MethodCall(Expression originalExpression, Mock mock, Condition? condition, MethodExpectation expectation)
             : base(originalExpression, mock, expectation)
         {
             this.condition = condition;
@@ -40,12 +40,12 @@ namespace Moq
             }
         }
 
-        public string FailMessage
+        public string? FailMessage
         {
             get => this.failMessage;
         }
 
-        public override Condition Condition => this.condition;
+        public override Condition? Condition => this.condition;
 
         public override IEnumerable<Mock> InnerMocks
         {
@@ -59,7 +59,7 @@ namespace Moq
             }
         }
 
-        static string GetUserCodeCallSite()
+        static string? GetUserCodeCallSite()
         {
             try
             {
@@ -68,14 +68,14 @@ namespace Moq
                 var frame = new StackTrace(true)
                     .GetFrames()
                     .SkipWhile(f => f.GetMethod() != thisMethod)
-                    .SkipWhile(f => f.GetMethod().DeclaringType == null || f.GetMethod().DeclaringType.Assembly == mockAssembly)
+                    .SkipWhile(f => f.GetMethod()!.DeclaringType == null || f.GetMethod()!.DeclaringType!.Assembly == mockAssembly)
                     .FirstOrDefault();
                 var member = frame?.GetMethod();
                 if (member != null)
                 {
                     var declaredAt = new StringBuilder();
-                    declaredAt.AppendNameOf(member.DeclaringType).Append('.').AppendNameOf(member, false);
-                    var fileName = Path.GetFileName(frame.GetFileName());
+                    declaredAt.AppendNameOf(member.DeclaringType!).Append('.').AppendNameOf(member, false);
+                    var fileName = Path.GetFileName(frame!.GetFileName());
                     if (fileName != null)
                     {
                         declaredAt.Append(" in ").Append(fileName);
@@ -144,7 +144,7 @@ namespace Moq
                 throw new ArgumentNullException(nameof(callback));
             }
 
-            ref Behavior behavior = ref (this.returnOrThrow == null) ? ref this.callback
+            ref Behavior? behavior = ref (this.returnOrThrow == null) ? ref this.callback
                                                                      : ref this.afterReturnCallback;
 
             if (callback is Action callbackWithoutArguments)
@@ -224,7 +224,7 @@ namespace Moq
             this.returnOrThrow = new ReturnValue(value);
         }
 
-        public void SetReturnComputedValueBehavior(Delegate valueFactory)
+        public void SetReturnComputedValueBehavior(Delegate? valueFactory)
         {
             Debug.Assert(this.Method.ReturnType != typeof(void));
             Debug.Assert(this.returnOrThrow == null);
@@ -302,7 +302,7 @@ namespace Moq
             this.returnOrThrow = new ThrowException(exception);
         }
 
-        public void SetThrowComputedExceptionBehavior(Delegate exceptionFactory)
+        public void SetThrowComputedExceptionBehavior(Delegate? exceptionFactory)
         {
             Debug.Assert(this.returnOrThrow == null);
 
@@ -314,6 +314,7 @@ namespace Moq
                 // and instead of in `Throws(TException)`, we ended up in `Throws(Delegate)` or `Throws(Func)`,
                 // which likely isn't what the user intended.
                 // So here we do what we would've done in `Throws(TException)`:
+                // TODO: ThrowException expects non-null argument.
                 this.returnOrThrow = new ThrowException(default);
             }
             else

--- a/src/Moq/MethodExpectation.cs
+++ b/src/Moq/MethodExpectation.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -38,14 +39,14 @@ namespace Moq
                 for (int i = 0; i < n; ++i)
                 {
                     var parameterType = parameterTypes[i];
-                    if (parameterType.IsByRef) parameterType = parameterType.GetElementType();
+                    if (parameterType.IsByRef) parameterType = parameterType.GetElementType()!;
                     arguments[i] = E.Constant(invocation.Arguments[i], parameterType);
                 }
             }
 
             LambdaExpression expression;
             {
-                var mock = E.Parameter(method.DeclaringType, "mock");
+                var mock = E.Parameter(method.DeclaringType!, "mock");
                 expression = E.Lambda(E.Call(mock, method, arguments).Apply(UpgradePropertyAccessorMethods.Rewriter), mock);
             }
 
@@ -111,7 +112,11 @@ namespace Moq
             this.awaitableFactory = awaitableFactory;
         }
 
-        public override bool HasResultExpression(out IAwaitableFactory awaitableFactory)
+#if NULLABLE_REFERENCE_TYPES
+        public override bool HasResultExpression([NotNullWhen(true)] out IAwaitableFactory? awaitableFactory)
+#else
+        public override bool HasResultExpression(out IAwaitableFactory? awaitableFactory)
+#endif
         {
             return (awaitableFactory = this.awaitableFactory) != null;
         }
@@ -199,7 +204,7 @@ namespace Moq
             return true;
         }
 
-        public override bool Equals(Expectation obj)
+        public override bool Equals(Expectation? obj)
         {
             if (obj is not MethodExpectation other) return false;
 

--- a/src/Moq/MethodExpectation.cs
+++ b/src/Moq/MethodExpectation.cs
@@ -68,16 +68,16 @@ namespace Moq
         public readonly IReadOnlyList<Expression> Arguments;
 
         readonly IMatcher[] argumentMatchers;
-        IAwaitableFactory awaitableFactory;
-        MethodInfo methodImplementation;
-        Expression[] partiallyEvaluatedArguments;
+        IAwaitableFactory? awaitableFactory;
+        MethodInfo? methodImplementation;
+        Expression[]? partiallyEvaluatedArguments;
 #if DEBUG
-        Type proxyType;
+        Type? proxyType;
 #endif
 
         readonly bool exactGenericTypeArguments;
 
-        public MethodExpectation(LambdaExpression expression, MethodInfo method, IReadOnlyList<Expression> arguments = null, bool exactGenericTypeArguments = false, bool skipMatcherInitialization = false, bool allowNonOverridable = false)
+        public MethodExpectation(LambdaExpression expression, MethodInfo method, IReadOnlyList<Expression>? arguments = null, bool exactGenericTypeArguments = false, bool skipMatcherInitialization = false, bool allowNonOverridable = false)
         {
             Debug.Assert(expression != null);
             Debug.Assert(method != null);

--- a/src/Moq/MethodSetup.cs
+++ b/src/Moq/MethodSetup.cs
@@ -11,7 +11,7 @@ namespace Moq
     /// </summary>
     abstract class MethodSetup : Setup
     {
-        protected MethodSetup(Expression originalExpression, Mock mock, MethodExpectation expectation)
+        protected MethodSetup(Expression? originalExpression, Mock mock, MethodExpectation expectation)
             : base(originalExpression, mock, expectation)
         {
         }

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -23,7 +23,7 @@ namespace Moq
     public abstract partial class Mock : IFluentInterface
     {
         internal static readonly MethodInfo GetMethod =
-            typeof(Mock).GetMethod(nameof(Get), BindingFlags.Public | BindingFlags.Static);
+            typeof(Mock).GetMethod(nameof(Get), BindingFlags.Public | BindingFlags.Static)!;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="Mock"/> class.
@@ -313,7 +313,7 @@ namespace Moq
             }
         }
 
-        internal static void Verify(Mock mock, LambdaExpression expression, Times times, string failMessage)
+        internal static void Verify(Mock mock, LambdaExpression expression, Times times, string? failMessage)
         {
             Guard.NotNull(times, nameof(times));
 
@@ -333,7 +333,7 @@ namespace Moq
             }
         }
 
-        internal static void VerifyGet(Mock mock, LambdaExpression expression, Times times, string failMessage)
+        internal static void VerifyGet(Mock mock, LambdaExpression expression, Times times, string? failMessage)
         {
             Guard.NotNull(expression, nameof(expression));
 
@@ -346,7 +346,7 @@ namespace Moq
             Mock.Verify(mock, expression, times, failMessage);
         }
 
-        internal static void VerifySet(Mock mock, LambdaExpression expression, Times times, string failMessage)
+        internal static void VerifySet(Mock mock, LambdaExpression expression, Times times, string? failMessage)
         {
             Guard.NotNull(expression, nameof(expression));
             Guard.IsAssignmentToPropertyOrIndexer(expression, nameof(expression));
@@ -354,7 +354,7 @@ namespace Moq
             Mock.Verify(mock, expression, times, failMessage);
         }
 
-        internal static void VerifyAdd(Mock mock, LambdaExpression expression, Times times, string failMessage)
+        internal static void VerifyAdd(Mock mock, LambdaExpression expression, Times times, string? failMessage)
         {
             Guard.NotNull(expression, nameof(expression));
             Guard.IsEventAdd(expression, nameof(expression));
@@ -362,7 +362,7 @@ namespace Moq
             Mock.Verify(mock, expression, times, failMessage);
         }
 
-        internal static void VerifyRemove(Mock mock, LambdaExpression expression, Times times, string failMessage)
+        internal static void VerifyRemove(Mock mock, LambdaExpression expression, Times times, string? failMessage)
         {
             Guard.NotNull(expression, nameof(expression));
             Guard.IsEventRemove(expression, nameof(expression));
@@ -379,7 +379,7 @@ namespace Moq
         {
             if (!verifiedMocks.Add(mock)) return;
 
-            var unverifiedInvocations = mock.MutableInvocations.ToArray(invocation => !invocation.IsVerified);
+            Invocation?[] unverifiedInvocations = mock.MutableInvocations.ToArray(invocation => !invocation.IsVerified);
 
             var innerMocks = mock.MutableSetups.FindAllInnerMocks();
 
@@ -410,7 +410,7 @@ namespace Moq
                 var remainingUnverifiedInvocations = unverifiedInvocations.Where(i => i != null);
                 if (remainingUnverifiedInvocations.Any())
                 {
-                    throw MockException.UnverifiedInvocations(mock, remainingUnverifiedInvocations);
+                    throw MockException.UnverifiedInvocations(mock, remainingUnverifiedInvocations!);
                 }
             }
 
@@ -493,7 +493,7 @@ namespace Moq
 
         #region Setup
 
-        internal static MethodCall Setup(Mock mock, LambdaExpression expression, Condition condition)
+        internal static MethodCall Setup(Mock mock, LambdaExpression expression, Condition? condition)
         {
             Guard.NotNull(expression, nameof(expression));
 
@@ -505,7 +505,7 @@ namespace Moq
             });
         }
 
-        internal static MethodCall SetupGet(Mock mock, LambdaExpression expression, Condition condition)
+        internal static MethodCall SetupGet(Mock mock, LambdaExpression expression, Condition? condition)
         {
             Guard.NotNull(expression, nameof(expression));
 
@@ -527,7 +527,7 @@ namespace Moq
         }
 
         internal static readonly MethodInfo SetupReturnsMethod =
-            typeof(Mock).GetMethod(nameof(SetupReturns), BindingFlags.NonPublic | BindingFlags.Static);
+            typeof(Mock).GetMethod(nameof(SetupReturns), BindingFlags.NonPublic | BindingFlags.Static)!;
 
         // This specialized setup method is used to set up a single `Mock.Of` predicate.
         // Unlike other setup methods, LINQ to Mocks can set non-interceptable properties, which is handy when initializing DTOs.
@@ -535,7 +535,7 @@ namespace Moq
         {
             Guard.NotNull(expression, nameof(expression));
 
-            Mock.SetupRecursive<MethodCall>(mock, expression, setupLast: (targetMock, oe, part) =>
+            Mock.SetupRecursive<MethodCall?>(mock, expression, setupLast: (targetMock, oe, part) =>
             {
                 var originalExpression = (LambdaExpression)oe;
 
@@ -636,7 +636,7 @@ namespace Moq
         }
 
         static TSetup SetupRecursive<TSetup>(Mock mock, LambdaExpression expression, Func<Mock, Expression, MethodExpectation, TSetup> setupLast, bool allowNonOverridableLastProperty = false)
-            where TSetup : ISetup
+            where TSetup : ISetup?
         {
             Debug.Assert(mock != null);
             Debug.Assert(expression != null);
@@ -647,7 +647,7 @@ namespace Moq
         }
 
         static TSetup SetupRecursive<TSetup>(Mock mock, LambdaExpression originalExpression, Stack<MethodExpectation> parts, Func<Mock, Expression, MethodExpectation, TSetup> setupLast)
-            where TSetup : ISetup
+            where TSetup : ISetup?
         {
             var part = parts.Pop();
             var (expr, method, arguments) = part;
@@ -658,7 +658,7 @@ namespace Moq
             }
             else
             {
-                Mock innerMock = mock.MutableSetups.FindLastInnerMock(setup => setup.Matches(part));
+                Mock? innerMock = mock.MutableSetups.FindLastInnerMock(setup => setup.Matches(part));
                 if (innerMock == null)
                 {
                     var returnValue = mock.GetDefaultValue(method, out innerMock, useAlternateProvider: DefaultValueProvider.Mock);
@@ -697,16 +697,18 @@ namespace Moq
             Mock.RaiseEvent(mock, expression, parts, arguments);
         }
 
-        internal static Task RaiseEventAsync<T>(Mock mock, Action<T> action, object[] arguments)
+        internal static Task RaiseEventAsync<T>(Mock mock, Action<T> action, object?[] arguments)
         {
             Guard.NotNull(action, nameof(action));
 
             var expression = ExpressionReconstructor.Instance.ReconstructExpression(action, mock.ConstructorArguments);
             var parts = expression.Split();
+            
+            // TODO: Will this code never return null?
             return (Task)Mock.RaiseEvent(mock, expression, parts, arguments);
         }
 
-        internal static object RaiseEvent(Mock mock, LambdaExpression expression, Stack<MethodExpectation> parts, object[] arguments)
+        internal static object? RaiseEvent(Mock mock, LambdaExpression expression, Stack<MethodExpectation> parts, object?[] arguments)
         {
             const BindingFlags bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly;
 
@@ -719,28 +721,22 @@ namespace Moq
                 if (method.IsEventAddAccessor())
                 {
                     var implementingMethod = method.GetImplementingMethod(mock.Object.GetType());
-                    @event = implementingMethod.DeclaringType.GetEvents(bindingFlags).SingleOrDefault(e => e.GetAddMethod(true) == implementingMethod);
-                    if (@event == null)
-                    {
-                        throw new ArgumentException(
-                            string.Format(
-                                CultureInfo.CurrentCulture,
-                                Resources.SetupNotEventAdd,
-                                part.Expression));
-                    }
+                    @event = implementingMethod.DeclaringType!.GetEvents(bindingFlags)
+                                               .SingleOrDefault(e => e.GetAddMethod(true) == implementingMethod)
+                             ?? throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
+                                                                          Resources.SetupNotEventAdd,
+                                                                          part.Expression));
+
                 }
                 else if (method.IsEventRemoveAccessor())
                 {
                     var implementingMethod = method.GetImplementingMethod(mock.Object.GetType());
-                    @event = implementingMethod.DeclaringType.GetEvents(bindingFlags).SingleOrDefault(e => e.GetRemoveMethod(true) == implementingMethod);
-                    if (@event == null)
-                    {
-                        throw new ArgumentException(
-                            string.Format(
-                                CultureInfo.CurrentCulture,
-                                Resources.SetupNotEventRemove,
-                                part.Expression));
-                    }
+                    @event = implementingMethod.DeclaringType!.GetEvents(bindingFlags)
+                                               .SingleOrDefault(e => e.GetRemoveMethod(true) == implementingMethod)
+                             ?? throw new ArgumentException(string.Format(CultureInfo.CurrentCulture,
+                                                                          Resources.SetupNotEventRemove,
+                                                                          part.Expression));
+
                 }
                 else
                 {
@@ -820,7 +816,7 @@ namespace Moq
 
         #region Default Values
 
-        internal abstract Dictionary<Type, object> ConfiguredDefaultValues { get; }
+        internal abstract Dictionary<Type, object?> ConfiguredDefaultValues { get; }
 
         /// <summary>
         /// Defines the default return value for all mocked methods or properties with return type <typeparamref name= "TReturn" />.
@@ -835,13 +831,13 @@ namespace Moq
             this.ConfiguredDefaultValues[typeof(TReturn)] = value;
         }
 
-        internal object GetDefaultValue(MethodInfo method, out Mock candidateInnerMock, DefaultValueProvider useAlternateProvider = null)
+        internal object? GetDefaultValue(MethodInfo method, out Mock? candidateInnerMock, DefaultValueProvider? useAlternateProvider = null)
         {
             Debug.Assert(method != null);
             Debug.Assert(method.ReturnType != null);
             Debug.Assert(method.ReturnType != typeof(void));
 
-            if (this.ConfiguredDefaultValues.TryGetValue(method.ReturnType, out object configuredDefaultValue))
+            if (this.ConfiguredDefaultValues.TryGetValue(method.ReturnType, out object? configuredDefaultValue))
             {
                 candidateInnerMock = null;
                 return configuredDefaultValue;

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -151,7 +151,7 @@ namespace Moq
         /// </summary>
         public abstract bool CallBase { get; set; }
 
-        internal abstract object[] ConstructorArguments { get; }
+        internal abstract object?[] ConstructorArguments { get; }
 
         /// <summary>
         ///   Specifies the behavior to use when returning default values for unexpected invocations on loose mocks.
@@ -397,7 +397,7 @@ namespace Moq
                         // In order for an invocation to be "transitive", its return value has to be a
                         // sub-object (inner mock); and that sub-object has to have received at least
                         // one call:
-                        var wasTransitiveInvocation = mock.MutableSetups.FindLastInnerMock(setup => setup.Matches(unverifiedInvocations[i])) is Mock innerMock
+                        var wasTransitiveInvocation = mock.MutableSetups.FindLastInnerMock(setup => setup.Matches(unverifiedInvocations[i]!)) is Mock innerMock
                                                       && innerMock.MutableInvocations.Any();
                         if (wasTransitiveInvocation)
                         {
@@ -518,7 +518,7 @@ namespace Moq
             return Mock.Setup(mock, expression, condition);
         }
 
-        internal static MethodCall SetupSet(Mock mock, LambdaExpression expression, Condition condition)
+        internal static MethodCall SetupSet(Mock mock, LambdaExpression expression, Condition? condition)
         {
             Guard.NotNull(expression, nameof(expression));
             Guard.IsAssignmentToPropertyOrIndexer(expression, nameof(expression));
@@ -583,7 +583,7 @@ namespace Moq
             return true;
         }
 
-        internal static MethodCall SetupAdd(Mock mock, LambdaExpression expression, Condition condition)
+        internal static MethodCall SetupAdd(Mock mock, LambdaExpression expression, Condition? condition)
         {
             Guard.NotNull(expression, nameof(expression));
             Guard.IsEventAdd(expression, nameof(expression));
@@ -591,7 +591,7 @@ namespace Moq
             return Mock.Setup(mock, expression, condition);
         }
 
-        internal static MethodCall SetupRemove(Mock mock, LambdaExpression expression, Condition condition)
+        internal static MethodCall SetupRemove(Mock mock, LambdaExpression expression, Condition? condition)
         {
             Guard.NotNull(expression, nameof(expression));
             Guard.IsEventRemove(expression, nameof(expression));
@@ -611,7 +611,7 @@ namespace Moq
             });
         }
 
-        internal static StubbedPropertySetup SetupProperty(Mock mock, LambdaExpression expression, object initialValue)
+        internal static StubbedPropertySetup SetupProperty(Mock mock, LambdaExpression expression, object? initialValue)
         {
             Guard.NotNull(expression, nameof(expression));
 

--- a/src/Moq/Mock.cs
+++ b/src/Moq/Mock.cs
@@ -703,7 +703,7 @@ namespace Moq
 
             var expression = ExpressionReconstructor.Instance.ReconstructExpression(action, mock.ConstructorArguments);
             var parts = expression.Split();
-            
+
             // TODO: Will this code never return null?
             return (Task)Mock.RaiseEvent(mock, expression, parts, arguments);
         }

--- a/src/Moq/MockDefaultValueProvider.cs
+++ b/src/Moq/MockDefaultValueProvider.cs
@@ -19,7 +19,7 @@ namespace Moq
 
         internal override DefaultValue Kind => DefaultValue.Mock;
 
-        protected override object GetFallbackDefaultValue(Type type, Mock mock)
+        protected override object? GetFallbackDefaultValue(Type type, Mock mock)
         {
             Debug.Assert(type != null);
             Debug.Assert(type != typeof(void));
@@ -34,7 +34,7 @@ namespace Moq
             {
                 // Create a new mock to be placed to InnerMocks dictionary if it's missing there
                 var mockType = typeof(Mock<>).MakeGenericType(type);
-                Mock newMock = (Mock)Activator.CreateInstance(mockType, mock.Behavior);
+                Mock newMock = (Mock)Activator.CreateInstance(mockType, mock.Behavior)!;
                 newMock.DefaultValueProvider = mock.DefaultValueProvider;
                 if (mock.MutableSetups.FindLast(s => s is StubbedPropertiesSetup) is StubbedPropertiesSetup sts)
                 {

--- a/src/Moq/MockException.cs
+++ b/src/Moq/MockException.cs
@@ -56,7 +56,7 @@ namespace Moq
         internal static MockException NoMatchingCalls(
             Mock rootMock,
             LambdaExpression expression,
-            string failMessage,
+            string? failMessage,
             Times times,
             int callCount)
         {
@@ -172,7 +172,7 @@ namespace Moq
         ///   and whose reason(s) is the combination of the given <paramref name="errors"/>' reason(s).
         ///   Used by <see cref="MockFactory.VerifyMocks(Action{Mock})"/> when it finds one or more mocks with verification errors.
         /// </summary>
-        internal static MockException Combined(IEnumerable<MockException> errors, string preamble)
+        internal static MockException Combined(IEnumerable<MockException> errors, string? preamble)
         {
             Debug.Assert(errors != null);
             Debug.Assert(errors.Any());

--- a/src/Moq/MockException.cs
+++ b/src/Moq/MockException.cs
@@ -248,7 +248,7 @@ namespace Moq
           System.Runtime.Serialization.StreamingContext context)
             : base(info, context)
         {
-            this.reasons = (MockExceptionReasons)info.GetValue(nameof(this.reasons), typeof(MockExceptionReasons));
+            this.reasons = (MockExceptionReasons)info.GetValue(nameof(this.reasons), typeof(MockExceptionReasons))!;
         }
 
         /// <summary>

--- a/src/Moq/Mock`1.cs
+++ b/src/Moq/Mock`1.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
@@ -84,10 +85,10 @@ namespace Moq
             serialNumberCounter = 0;
         }
 
-        T instance;
+        T? instance;
         List<Type> additionalInterfaces;
-        Dictionary<Type, object> configuredDefaultValues;
-        object[] constructorArguments;
+        Dictionary<Type, object?> configuredDefaultValues;
+        object?[] constructorArguments;
         DefaultValueProvider defaultValueProvider;
         EventHandlerCollection eventHandlers;
         InvocationCollection invocations;
@@ -110,6 +111,7 @@ namespace Moq
             // The skipInitialize parameter is not used at all, and it's 
             // just to differentiate this ctor that should do nothing 
             // from the regular ones which initializes the proxy, etc.
+            // TODO: How should nullable references be handled here?
         }
 
         /// <summary>
@@ -176,7 +178,7 @@ namespace Moq
 
             this.additionalInterfaces = new List<Type>();
             this.behavior = behavior;
-            this.configuredDefaultValues = new Dictionary<Type, object>();
+            this.configuredDefaultValues = new Dictionary<Type, object?>();
             this.constructorArguments = args;
             this.defaultValueProvider = DefaultValueProvider.Empty;
             this.eventHandlers = new EventHandlerCollection();
@@ -248,9 +250,9 @@ namespace Moq
             }
         }
 
-        internal override object[] ConstructorArguments => this.constructorArguments;
+        internal override object?[] ConstructorArguments => this.constructorArguments;
 
-        internal override Dictionary<Type, object> ConfiguredDefaultValues => this.configuredDefaultValues;
+        internal override Dictionary<Type, object?> ConfiguredDefaultValues => this.configuredDefaultValues;
 
         /// <summary>
         /// Gets or sets the <see cref="DefaultValueProvider"/> instance that will be used
@@ -295,6 +297,9 @@ namespace Moq
             return this.Name;
         }
 
+#if NET
+        [MemberNotNull(nameof(instance))]
+#endif
         void InitializeInstance()
         {
             // Determine the set of interfaces that the proxy object should additionally implement.
@@ -623,7 +628,7 @@ namespace Moq
         ///     Assert.Equal(6, v.Value);
         ///   </code>
         /// </example>
-        public Mock<T> SetupProperty<TProperty>(Expression<Func<T, TProperty>> property, TProperty initialValue)
+        public Mock<T> SetupProperty<TProperty>(Expression<Func<T, TProperty>> property, TProperty? initialValue)
         {
             Mock.SetupProperty(this, property, initialValue);
             return this;

--- a/src/Moq/Mock`1.cs
+++ b/src/Moq/Mock`1.cs
@@ -680,6 +680,11 @@ namespace Moq
         /// </param>
         public ISetupConditionResult<T> When(Func<bool> condition)
         {
+            if (condition == null)
+            {
+                throw new ArgumentNullException(nameof(condition));
+            }
+
             return new WhenPhrase<T>(this, new Condition(condition));
         }
 

--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -10,7 +10,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'net6.0' ">
-		<DefineConstants>$(DefineConstants);FEATURE_DEFAULT_INTERFACE_IMPLEMENTATIONS</DefineConstants>
+		<DefineConstants>$(DefineConstants);NULLABLE_REFERENCE_TYPES;FEATURE_DEFAULT_INTERFACE_IMPLEMENTATIONS</DefineConstants>
     <Nullable>enable</Nullable>
     <WarningsNotAsErrors>nullable</WarningsNotAsErrors>
 	</PropertyGroup>

--- a/src/Moq/Moq.csproj
+++ b/src/Moq/Moq.csproj
@@ -11,6 +11,8 @@
 
 	<PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'net6.0' ">
 		<DefineConstants>$(DefineConstants);FEATURE_DEFAULT_INTERFACE_IMPLEMENTATIONS</DefineConstants>
+    <Nullable>enable</Nullable>
+    <WarningsNotAsErrors>nullable</WarningsNotAsErrors>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Moq/Obsolete/MockFactory.cs
+++ b/src/Moq/Obsolete/MockFactory.cs
@@ -222,7 +222,7 @@ namespace Moq
         /// factory.Verify();
         /// </code>
         /// </example>
-        public Mock<T> Create<T>(params object[] args)
+        public Mock<T> Create<T>(params object[]? args)
             where T : class
         {
             // "fix" compiler picking this overload instead of 
@@ -314,7 +314,7 @@ namespace Moq
         /// <typeparam name="T">Type to mock.</typeparam>
         /// <param name="behavior">The behavior for the new mock.</param>
         /// <param name="args">Optional arguments for the construction of the mock.</param>
-        protected virtual Mock<T> CreateMock<T>(MockBehavior behavior, object[] args)
+        protected virtual Mock<T> CreateMock<T>(MockBehavior behavior, object[]? args)
             where T : class
         {
             var mock = new Mock<T>(behavior, args);

--- a/src/Moq/Pair.cs
+++ b/src/Moq/Pair.cs
@@ -28,7 +28,7 @@ namespace Moq
                 && object.Equals(this.Item2, other.Item2);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is Pair<T1, T2> other && this.Equals(other);
         }

--- a/src/Moq/Protected/IProtectedAsMock.cs
+++ b/src/Moq/Protected/IProtectedAsMock.cs
@@ -111,11 +111,11 @@ namespace Moq.Protected
         /// <param name="expression">Lambda expression that specifies the method invocation.</param>
         /// <param name="times">
         /// Number of times that the invocation is expected to have occurred.
-        /// If omitted, assumed to be <see cref="Times.AtLeastOnce"/>.
         /// </param>
+        /// If omitted, assumed to be <see cref="Times.AtLeastOnce"/>.
         /// <param name="failMessage">Message to include in the thrown <see cref="MockException"/> if verification fails.</param>
         /// <exception cref="MockException">The specified invocation did not occur (or did not occur the specified number of times).</exception>
-        void Verify(Expression<Action<TAnalog>> expression, Times? times = null, string failMessage = null);
+        void Verify(Expression<Action<TAnalog>> expression, Times? times = null, string? failMessage = null);
 
         /// <summary>
         /// Verifies that a specific invocation matching the given expression was performed on the mock.
@@ -129,7 +129,7 @@ namespace Moq.Protected
         /// </param>
         /// <param name="failMessage">Message to include in the thrown <see cref="MockException"/> if verification fails.</param>
         /// <exception cref="MockException">The specified invocation did not occur (or did not occur the specified number of times).</exception>
-        void Verify<TResult>(Expression<Func<TAnalog, TResult>> expression, Times? times = null, string failMessage = null);
+        void Verify<TResult>(Expression<Func<TAnalog, TResult>> expression, Times? times = null, string? failMessage = null);
 
         /// <summary>
         ///   Verifies that a property was set on the mock.
@@ -143,7 +143,7 @@ namespace Moq.Protected
         /// <exception cref="MockException">
         ///   The invocation was not called the number of times specified by <paramref name="times"/>.
         /// </exception>
-        void VerifySet(Action<TAnalog> setterExpression, Times? times = null, string failMessage = null);
+        void VerifySet(Action<TAnalog> setterExpression, Times? times = null, string? failMessage = null);
 
         /// <summary>
         /// Verifies that a property was read on the mock.
@@ -156,6 +156,6 @@ namespace Moq.Protected
         /// </param>
         /// <param name="failMessage">Message to include in the thrown <see cref="MockException"/> if verification fails.</param>
         /// <exception cref="MockException">The specified invocation did not occur (or did not occur the specified number of times).</exception>
-        void VerifyGet<TProperty>(Expression<Func<TAnalog, TProperty>> expression, Times? times = null, string failMessage = null);
+        void VerifyGet<TProperty>(Expression<Func<TAnalog, TProperty>> expression, Times? times = null, string? failMessage = null);
     }
 }

--- a/src/Moq/Protected/IProtectedAsMock.cs
+++ b/src/Moq/Protected/IProtectedAsMock.cs
@@ -89,7 +89,7 @@ namespace Moq.Protected
         /// <typeparam name="TProperty">Type of the property. Typically omitted as it can be inferred from the expression.</typeparam>
         /// <param name="expression">Lambda expression that specifies the property.</param>
         /// <param name="initialValue">Initial value for the property.</param>
-        Mock<T> SetupProperty<TProperty>(Expression<Func<TAnalog, TProperty>> expression, TProperty initialValue = default(TProperty));
+        Mock<T> SetupProperty<TProperty>(Expression<Func<TAnalog, TProperty>> expression, TProperty? initialValue = default(TProperty));
 
         /// <summary>
         /// Return a sequence of values, once per call.

--- a/src/Moq/Protected/ItExpr.cs
+++ b/src/Moq/Protected/ItExpr.cs
@@ -113,7 +113,7 @@ namespace Moq.Protected
         /// </example>
         public static Expression Is<TValue>(Expression<Func<TValue, bool>> match)
         {
-            Expression<Func<TValue>> expr = () => It.Is((Expression<Func<TValue, bool>>)null);
+            Expression<Func<TValue>> expr = () => It.Is((Expression<Func<TValue, bool>>)null!);
             return Expression.Call(((MethodCallExpression)expr.Body).Method, match);
         }
 

--- a/src/Moq/Protected/ProtectedAsMock.cs
+++ b/src/Moq/Protected/ProtectedAsMock.cs
@@ -100,7 +100,7 @@ namespace Moq.Protected
             return new NonVoidSetupPhrase<T, TProperty>(setup);
         }
 
-        public Mock<T> SetupProperty<TProperty>(Expression<Func<TAnalog, TProperty>> expression, TProperty initialValue = default(TProperty))
+        public Mock<T> SetupProperty<TProperty>(Expression<Func<TAnalog, TProperty>> expression, TProperty? initialValue = default(TProperty))
         {
             Guard.NotNull(expression, nameof(expression));
 

--- a/src/Moq/Protected/ProtectedAsMock.cs
+++ b/src/Moq/Protected/ProtectedAsMock.cs
@@ -153,7 +153,7 @@ namespace Moq.Protected
             return new SetupSequencePhrase(setup);
         }
 
-        public void Verify(Expression<Action<TAnalog>> expression, Times? times = null, string failMessage = null)
+        public void Verify(Expression<Action<TAnalog>> expression, Times? times = null, string? failMessage = null)
         {
             Guard.NotNull(expression, nameof(expression));
 
@@ -170,7 +170,7 @@ namespace Moq.Protected
             Mock.Verify(this.mock, rewrittenExpression, times ?? Times.AtLeastOnce(), failMessage);
         }
 
-        public void Verify<TResult>(Expression<Func<TAnalog, TResult>> expression, Times? times = null, string failMessage = null)
+        public void Verify<TResult>(Expression<Func<TAnalog, TResult>> expression, Times? times = null, string? failMessage = null)
         {
             Guard.NotNull(expression, nameof(expression));
 
@@ -187,7 +187,7 @@ namespace Moq.Protected
             Mock.Verify(this.mock, rewrittenExpression, times ?? Times.AtLeastOnce(), failMessage);
         }
 
-        public void VerifySet(Action<TAnalog> setterExpression, Times? times = null, string failMessage = null)
+        public void VerifySet(Action<TAnalog> setterExpression, Times? times = null, string? failMessage = null)
         {
             Guard.NotNull(setterExpression, nameof(setterExpression));
 
@@ -195,7 +195,7 @@ namespace Moq.Protected
             Mock.VerifySet(mock, rewrittenExpression, times.HasValue ? times.Value : Times.AtLeastOnce(), failMessage);
         }
 
-        public void VerifyGet<TProperty>(Expression<Func<TAnalog, TProperty>> expression, Times? times = null, string failMessage = null)
+        public void VerifyGet<TProperty>(Expression<Func<TAnalog, TProperty>> expression, Times? times = null, string? failMessage = null)
         {
             Guard.NotNull(expression, nameof(expression));
 

--- a/src/Moq/Protected/ProtectedMock.cs
+++ b/src/Moq/Protected/ProtectedMock.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
@@ -51,7 +52,7 @@ namespace Moq.Protected
             return this.InternalSetup(methodName, genericTypeArguments, exactParameterMatch, args);
         }
 
-        ISetup<T> InternalSetup(string methodName, Type[] genericTypeArguments, bool exactParameterMatch, params object[] args)
+        ISetup<T> InternalSetup(string methodName, Type[]? genericTypeArguments, bool exactParameterMatch, params object[] args)
         {
             Guard.NotNull(methodName, nameof(methodName));
 
@@ -80,7 +81,7 @@ namespace Moq.Protected
             return this.InternalSetup<TResult>(methodName, genericTypeArguments, exactParameterMatch, args);
         }
 
-        ISetup<T, TResult> InternalSetup<TResult>(string methodName, Type[] genericTypeArguments,
+        ISetup<T, TResult> InternalSetup<TResult>(string methodName, Type[]? genericTypeArguments,
             bool exactParameterMatch, params object[] args)
         {
             Guard.NotNullOrEmpty(methodName, nameof(methodName));
@@ -147,7 +148,7 @@ namespace Moq.Protected
             return this.InternalSetupSequence(methodOrPropertyName, genericTypeArguments, exactParameterMatch, args);
         }
 
-        ISetupSequentialAction InternalSetupSequence(string methodOrPropertyName, Type[] genericTypeArguments, bool exactParameterMatch, params object[] args)
+        ISetupSequentialAction InternalSetupSequence(string methodOrPropertyName, Type[]? genericTypeArguments, bool exactParameterMatch, params object[] args)
         {
             Guard.NotNullOrEmpty(methodOrPropertyName, nameof(methodOrPropertyName));
 
@@ -175,7 +176,7 @@ namespace Moq.Protected
             return this.InternalSetupSequence<TResult>(methodOrPropertyName, genericTypeArguments, exactParameterMatch, args);
         }
 
-        ISetupSequentialResult<TResult> InternalSetupSequence<TResult>(string methodOrPropertyName, Type[] genericTypeArguments, bool exactParameterMatch, params object[] args)
+        ISetupSequentialResult<TResult> InternalSetupSequence<TResult>(string methodOrPropertyName, Type[]? genericTypeArguments, bool exactParameterMatch, params object[] args)
         {
             Guard.NotNullOrEmpty(methodOrPropertyName, nameof(methodOrPropertyName));
 
@@ -223,7 +224,7 @@ namespace Moq.Protected
             this.InternalVerify(methodName, genericTypeArguments, times, exactParameterMatch, args);
         }
 
-        void InternalVerify(string methodName, Type[] genericTypeArguments, Times times, bool exactParameterMatch, params object[] args)
+        void InternalVerify(string methodName, Type[]? genericTypeArguments, Times times, bool exactParameterMatch, params object[] args)
         {
             Guard.NotNullOrEmpty(methodName, nameof(methodName));
 
@@ -256,7 +257,7 @@ namespace Moq.Protected
             this.InternalVerify<TResult>(methodName, genericTypeArguments, times, exactParameterMatch, args);
         }
 
-        void InternalVerify<TResult>(string methodName, Type[] genericTypeArguments, Times times, bool exactParameterMatch, params object[] args)
+        void InternalVerify<TResult>(string methodName, Type[]? genericTypeArguments, Times times, bool exactParameterMatch, params object[] args)
         {
             Guard.NotNullOrEmpty(methodName, nameof(methodName));
 
@@ -359,7 +360,11 @@ namespace Moq.Protected
                 param);
         }
 
-        static void ThrowIfMemberMissing(string memberName, MemberInfo member)
+#if NULLABLE_REFERENCE_TYPES
+        static void ThrowIfMemberMissing(string memberName, [NotNull] MemberInfo? member)
+#else
+        static void ThrowIfMemberMissing(string memberName, MemberInfo? member)
+#endif
         {
             if (member == null)
             {
@@ -371,7 +376,11 @@ namespace Moq.Protected
             }
         }
 
-        static void ThrowIfMethodMissing(string methodName, MethodInfo method, object[] args)
+#if NULLABLE_REFERENCE_TYPES
+        static void ThrowIfMethodMissing(string methodName, [NotNull] MethodInfo? method, object[] args)
+#else
+        static void ThrowIfMethodMissing(string methodName, MethodInfo? method, object[] args)
+#endif
         {
             if (method == null)
             {
@@ -443,14 +452,14 @@ namespace Moq.Protected
             }
         }
 
-        static Type[] ToArgTypes(object[] args)
+        static Type?[] ToArgTypes(object[] args)
         {
             if (args == null)
             {
                 throw new ArgumentException(Resources.UseItExprIsNullRatherThanNullArgumentValue);
             }
 
-            var types = new Type[args.Length];
+            var types = new Type?[args.Length];
             for (int index = 0; index < args.Length; index++)
             {
                 if (args[index] == null)
@@ -503,9 +512,9 @@ namespace Moq.Protected
             return ItRefAnyField(expression) != null;
         }
 
-        static FieldInfo ItRefAnyField(Expression expr)
+        static FieldInfo? ItRefAnyField(Expression expr)
         {
-            FieldInfo itRefAnyField = null;
+            FieldInfo? itRefAnyField = null;
 
             if (expr.NodeType == ExpressionType.MemberAccess)
             {
@@ -514,7 +523,7 @@ namespace Moq.Protected
                 {
                     if (field.Name == nameof(It.Ref<object>.IsAny))
                     {
-                        var fieldDeclaringType = field.DeclaringType;
+                        var fieldDeclaringType = field.DeclaringType!;
                         if (fieldDeclaringType.IsGenericType)
                         {
                             var fieldDeclaringTypeDefinition = fieldDeclaringType.GetGenericTypeDefinition();

--- a/src/Moq/Protected/ProtectedMock.cs
+++ b/src/Moq/Protected/ProtectedMock.cs
@@ -314,7 +314,7 @@ namespace Moq.Protected
             return Expression.Lambda<Func<T, TResult>>(Expression.MakeMemberAccess(param, property), param);
         }
 
-        static MethodInfo GetMethod(string methodName, Type[] genericTypeArguments, bool exact, params object[] args)
+        static MethodInfo? GetMethod(string methodName, Type[]? genericTypeArguments, bool exact, params object[] args)
         {
             var argTypes = ToArgTypes(args);
             var methods = typeof(T).GetMethods(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
@@ -343,7 +343,7 @@ namespace Moq.Protected
         }
 
         // TODO should support arguments for property indexers
-        static PropertyInfo GetProperty(string propertyName)
+        static PropertyInfo? GetProperty(string propertyName)
         {
             return typeof(T).GetProperty(
                 propertyName,

--- a/src/Moq/ReturnsExtensions.cs
+++ b/src/Moq/ReturnsExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
 using Moq.Language;
@@ -48,11 +49,11 @@ namespace Moq
         /// <typeparam name="TResult">Type of the return value.</typeparam>
         /// <param name="mock">Returns verb which represents the mocked type and the task of return type</param>
         /// <param name="valueFunction">The function that will calculate the return value.</param>
-        public static IReturnsResult<TMock> ReturnsAsync<TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<TResult> valueFunction) where TMock : class
+        public static IReturnsResult<TMock> ReturnsAsync<TMock, TResult>(this IReturns<TMock, Task<TResult>> mock, Func<TResult>? valueFunction) where TMock : class
         {
             if (IsNullResult(valueFunction, typeof(TResult)))
             {
-                return mock.ReturnsAsync(() => default);
+                return mock.ReturnsAsync(() => default!);
             }
 
             return mock.Returns(() => Task.FromResult(valueFunction()));
@@ -69,7 +70,7 @@ namespace Moq
         {
             if (IsNullResult(valueFunction, typeof(TResult)))
             {
-                return mock.ReturnsAsync(() => default);
+                return mock.ReturnsAsync(() => default!);
             }
 
             return mock.Returns(() => new ValueTask<TResult>(valueFunction()));
@@ -283,7 +284,11 @@ namespace Moq
             return DelayedException(mock, exception, delay);
         }
 
-        internal static bool IsNullResult(Delegate valueFunction, Type resultType)
+#if NULLABLE_REFERENCE_TYPES
+        internal static bool IsNullResult([NotNullWhen(false)] Delegate? valueFunction, Type resultType)
+#else
+        internal static bool IsNullResult(Delegate? valueFunction, Type resultType)
+#endif
         {
             if (valueFunction == null)
             {

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -35,7 +35,7 @@ namespace Moq
 
         public LambdaExpression Expression => this.expectation.Expression;
 
-        Mock ISetup.InnerMock => this.InnerMocks.SingleOrDefault();
+        Mock? ISetup.InnerMock => this.InnerMocks.SingleOrDefault();
 
         public virtual IEnumerable<Mock> InnerMocks => Enumerable.Empty<Mock>();
 
@@ -204,7 +204,7 @@ namespace Moq
             this.Verify(recursive, predicate, verifiedMocks);
         }
 
-        protected static Mock? TryGetInnerMockFrom(object returnValue)
+        protected static Mock? TryGetInnerMockFrom(object? returnValue)
         {
             return (Awaitable.TryGetResultRecursive(returnValue) as IMocked)?.Mock;
         }

--- a/src/Moq/Setup.cs
+++ b/src/Moq/Setup.cs
@@ -15,11 +15,11 @@ namespace Moq
     abstract class Setup : ISetup
     {
         readonly Expectation expectation;
-        readonly Expression originalExpression;
+        readonly Expression? originalExpression;
         readonly Mock mock;
         Flags flags;
 
-        protected Setup(Expression originalExpression, Mock mock, Expectation expectation)
+        protected Setup(Expression? originalExpression, Mock mock, Expectation expectation)
         {
             Debug.Assert(mock != null);
             Debug.Assert(expectation != null);
@@ -29,7 +29,7 @@ namespace Moq
             this.mock = mock;
         }
 
-        public virtual Condition Condition => null;
+        public virtual Condition? Condition => null;
 
         public Expectation Expectation => this.expectation;
 
@@ -47,7 +47,7 @@ namespace Moq
 
         public Mock Mock => this.mock;
 
-        public Expression OriginalExpression => this.originalExpression;
+        public Expression? OriginalExpression => this.originalExpression;
 
         public bool IsMatched => (this.flags & Flags.Matched) != 0;
 
@@ -204,7 +204,7 @@ namespace Moq
             this.Verify(recursive, predicate, verifiedMocks);
         }
 
-        protected static Mock TryGetInnerMockFrom(object returnValue)
+        protected static Mock? TryGetInnerMockFrom(object returnValue)
         {
             return (Awaitable.TryGetResultRecursive(returnValue) as IMocked)?.Mock;
         }

--- a/src/Moq/SetupCollection.cs
+++ b/src/Moq/SetupCollection.cs
@@ -101,7 +101,7 @@ namespace Moq
             return setups;
         }
 
-        public Setup FindLast(Func<Setup, bool> predicate)
+        public Setup? FindLast(Func<Setup, bool> predicate)
         {
             // Fast path (no `lock`) when there are no setups:
             if (this.setups.Count == 0)

--- a/src/Moq/SetupWithOutParameterSupport.cs
+++ b/src/Moq/SetupWithOutParameterSupport.cs
@@ -13,9 +13,9 @@ namespace Moq
 {
     abstract class SetupWithOutParameterSupport : MethodSetup
     {
-        readonly List<KeyValuePair<int, object>> outValues;
+        readonly List<KeyValuePair<int, object?>>? outValues;
 
-        protected SetupWithOutParameterSupport(Expression originalExpression, Mock mock, MethodExpectation expectation)
+        protected SetupWithOutParameterSupport(Expression? originalExpression, Mock mock, MethodExpectation expectation)
             : base(originalExpression, mock, expectation)
         {
             Debug.Assert(expectation != null);
@@ -34,9 +34,9 @@ namespace Moq
             }
         }
 
-        static List<KeyValuePair<int, object>> GetOutValues(IReadOnlyList<Expression> arguments, ParameterInfo[] parameters)
+        static List<KeyValuePair<int, object?>>? GetOutValues(IReadOnlyList<Expression> arguments, ParameterInfo[] parameters)
         {
-            List<KeyValuePair<int, object>> outValues = null;
+            List<KeyValuePair<int, object?>>? outValues = null;
             for (int i = 0, n = parameters.Length; i < n; ++i)
             {
                 var parameter = parameters[i];
@@ -51,10 +51,10 @@ namespace Moq
 
                         if (outValues == null)
                         {
-                            outValues = new List<KeyValuePair<int, object>>();
+                            outValues = new List<KeyValuePair<int, object?>>();
                         }
 
-                        outValues.Add(new KeyValuePair<int, object>(i, constant.Value));
+                        outValues.Add(new KeyValuePair<int, object?>(i, constant.Value));
                     }
                 }
             }

--- a/src/Moq/StringBuilderExtensions.AppendExpression.cs
+++ b/src/Moq/StringBuilderExtensions.AppendExpression.cs
@@ -17,7 +17,7 @@ namespace Moq
     // These methods are intended to create more readable string representations for use in failure messages.
     partial class StringBuilderExtensions
     {
-        public static StringBuilder AppendExpression(this StringBuilder builder, Expression expression)
+        public static StringBuilder AppendExpression(this StringBuilder builder, Expression? expression)
         {
             if (expression == null)
             {
@@ -273,7 +273,7 @@ namespace Moq
             }
             else
             {
-                builder.AppendNameOf(expression.Member.DeclaringType);
+                builder.AppendNameOf(expression.Member.DeclaringType!);
             }
 
             return builder.Append('.')
@@ -300,7 +300,7 @@ namespace Moq
             {
                 Debug.Assert(method.IsStatic);
 
-                builder.AppendNameOf(method.DeclaringType);
+                builder.AppendNameOf(method.DeclaringType!);
             }
 
             if (method.IsGetAccessor())
@@ -380,7 +380,7 @@ namespace Moq
 
         static StringBuilder AppendExpression(this StringBuilder builder, NewExpression expression)
         {
-            Type type = (expression.Constructor == null) ? expression.Type : expression.Constructor.DeclaringType;
+            Type type = (expression.Constructor == null) ? expression.Type : expression.Constructor.DeclaringType!;
             return builder.Append("new ")
                           .AppendNameOf(type)
                           .AppendCommaSeparated("(", expression.Arguments, AppendExpression, ")");
@@ -395,7 +395,7 @@ namespace Moq
 
                 case ExpressionType.NewArrayBounds:
                     return builder.Append("new ")
-                                  .AppendNameOf(expression.Type.GetElementType())
+                                  .AppendNameOf(expression.Type.GetElementType()!)
                                   .AppendCommaSeparated("[", expression.Expressions, AppendExpression, "]");
             }
 

--- a/src/Moq/StringBuilderExtensions.cs
+++ b/src/Moq/StringBuilderExtensions.cs
@@ -95,7 +95,7 @@ namespace Moq
                     _ => "ref ",
                 });
 
-                parameterType = parameterType.GetElementType();
+                parameterType = parameterType.GetElementType()!;
             }
 
             if (parameterType.IsArray && parameter.IsDefined(typeof(ParamArrayAttribute), true))
@@ -106,7 +106,7 @@ namespace Moq
             return stringBuilder.AppendFormattedName(parameterType);
         }
 
-        public static StringBuilder AppendValueOf(this StringBuilder stringBuilder, object obj)
+        public static StringBuilder AppendValueOf(this StringBuilder stringBuilder, object? obj)
         {
             if (obj == null)
             {
@@ -148,6 +148,8 @@ namespace Moq
 
                     stringBuilder.AppendValueOf(enumerator.Current);
                 }
+                
+                (enumerator as IDisposable)?.Dispose();
                 stringBuilder.Append(']');
             }
             else

--- a/src/Moq/StringBuilderExtensions.cs
+++ b/src/Moq/StringBuilderExtensions.cs
@@ -148,7 +148,7 @@ namespace Moq
 
                     stringBuilder.AppendValueOf(enumerator.Current);
                 }
-                
+
                 (enumerator as IDisposable)?.Dispose();
                 stringBuilder.Append(']');
             }

--- a/src/Moq/StringBuilderExtensions.cs
+++ b/src/Moq/StringBuilderExtensions.cs
@@ -128,12 +128,11 @@ namespace Moq
             {
                 stringBuilder.AppendNameOf(obj.GetType()).Append('.').Append(obj);
             }
-            else if (obj.GetType().IsArray || (obj.GetType().IsConstructedGenericType && obj.GetType().GetGenericTypeDefinition() == typeof(List<>)))
+            else if (obj is IReadOnlyList<object> list)
             {
                 stringBuilder.Append('[');
                 const int maxCount = 10;
-                var enumerator = ((IEnumerable)obj).GetEnumerator();
-                for (int i = 0; enumerator.MoveNext() && i < maxCount + 1; ++i)
+                for (var i = 0; i < list.Count; i++)
                 {
                     if (i > 0)
                     {
@@ -146,10 +145,9 @@ namespace Moq
                         break;
                     }
 
-                    stringBuilder.AppendValueOf(enumerator.Current);
+                    stringBuilder.AppendValueOf(list[i]);
                 }
 
-                (enumerator as IDisposable)?.Dispose();
                 stringBuilder.Append(']');
             }
             else

--- a/src/Moq/StubbedPropertiesSetup.cs
+++ b/src/Moq/StubbedPropertiesSetup.cs
@@ -12,13 +12,13 @@ namespace Moq
 {
     sealed class StubbedPropertiesSetup : Setup
     {
-        readonly ConcurrentDictionary<string, object> values;
+        readonly ConcurrentDictionary<string, object?> values;
         readonly DefaultValueProvider defaultValueProvider;
 
         public StubbedPropertiesSetup(Mock mock, DefaultValueProvider? defaultValueProvider = null)
             : base(originalExpression: null, mock, new PropertyAccessorExpectation(mock))
         {
-            this.values = new ConcurrentDictionary<string, object>();
+            this.values = new ConcurrentDictionary<string, object?>();
             this.defaultValueProvider = defaultValueProvider ?? mock.DefaultValueProvider;
 
             this.MarkAsVerifiable();

--- a/src/Moq/StubbedPropertiesSetup.cs
+++ b/src/Moq/StubbedPropertiesSetup.cs
@@ -15,7 +15,7 @@ namespace Moq
         readonly ConcurrentDictionary<string, object> values;
         readonly DefaultValueProvider defaultValueProvider;
 
-        public StubbedPropertiesSetup(Mock mock, DefaultValueProvider defaultValueProvider = null)
+        public StubbedPropertiesSetup(Mock mock, DefaultValueProvider? defaultValueProvider = null)
             : base(originalExpression: null, mock, new PropertyAccessorExpectation(mock))
         {
             this.values = new ConcurrentDictionary<string, object>();
@@ -79,7 +79,7 @@ namespace Moq
                 Debug.Assert(mock != null);
 
                 var mockType = mock.GetType();
-                var setupAllPropertiesMethod = mockType.GetMethod(nameof(Mock<object>.SetupAllProperties));
+                var setupAllPropertiesMethod = mockType.GetMethod(nameof(Mock<object>.SetupAllProperties))!;
                 var mockedType = setupAllPropertiesMethod.ReturnType.GetGenericArguments()[0];
                 var mockGetMethod = Mock.GetMethod.MakeGenericMethod(mockedType);
                 var mockParam = E.Parameter(mockedType, "m");
@@ -88,7 +88,7 @@ namespace Moq
 
             public override LambdaExpression Expression => this.expression;
 
-            public override bool Equals(Expectation other)
+            public override bool Equals(Expectation? other)
             {
                 return other is PropertyAccessorExpectation pae && ExpressionComparer.Default.Equals(this.expression, pae.expression);
             }

--- a/src/Moq/StubbedPropertySetup.cs
+++ b/src/Moq/StubbedPropertySetup.cs
@@ -10,9 +10,9 @@ namespace Moq
 {
     sealed class StubbedPropertySetup : Setup
     {
-        object value;
+        object? value;
 
-        public StubbedPropertySetup(Mock mock, LambdaExpression expression, MethodInfo getter, MethodInfo setter, object initialValue)
+        public StubbedPropertySetup(Mock mock, LambdaExpression expression, MethodInfo? getter, MethodInfo? setter, object? initialValue)
             : base(originalExpression: null, mock, new PropertyAccessorExpectation(expression, getter, setter))
         {
             // NOTE:

--- a/src/Moq/StubbedPropertySetup.cs
+++ b/src/Moq/StubbedPropertySetup.cs
@@ -70,10 +70,10 @@ namespace Moq
         sealed class PropertyAccessorExpectation : Expectation
         {
             readonly LambdaExpression expression;
-            readonly MethodInfo getter;
-            readonly MethodInfo setter;
+            readonly MethodInfo? getter;
+            readonly MethodInfo? setter;
 
-            public PropertyAccessorExpectation(LambdaExpression expression, MethodInfo getter, MethodInfo setter)
+            public PropertyAccessorExpectation(LambdaExpression expression, MethodInfo? getter, MethodInfo? setter)
             {
                 Debug.Assert(expression != null);
                 Debug.Assert(expression.IsProperty());
@@ -86,7 +86,7 @@ namespace Moq
 
             public override LambdaExpression Expression => this.expression;
 
-            public override bool Equals(Expectation obj)
+            public override bool Equals(Expectation? obj)
             {
                 return obj is PropertyAccessorExpectation other
                     && other.getter == this.getter
@@ -101,7 +101,7 @@ namespace Moq
             public override bool IsMatch(Invocation invocation)
             {
                 var methodName = invocation.Method.Name;
-                return methodName == this.getter.Name || methodName == this.setter.Name;
+                return methodName == this.getter?.Name || methodName == this.setter?.Name;
             }
         }
     }

--- a/src/Moq/Times.cs
+++ b/src/Moq/Times.cs
@@ -192,7 +192,7 @@ namespace Moq
         ///   <see langword="true"/> if <paramref name="obj"/> has the same value as this instance;
         ///   otherwise, <see langword="false"/>.
         /// </returns>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is Times other && this.Equals(other);
         }

--- a/src/Moq/TypeMatcherAttribute.cs
+++ b/src/Moq/TypeMatcherAttribute.cs
@@ -16,7 +16,7 @@ namespace Moq
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Delegate | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Struct, AllowMultiple = false, Inherited = true)]
     public class TypeMatcherAttribute : Attribute
     {
-        readonly Type type;
+        readonly Type? type;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="TypeMatcherAttribute"/> class.
@@ -39,14 +39,9 @@ namespace Moq
         /// <param name="type">The <see cref="Type"/> of a type that implements <see cref="ITypeMatcher"/>.</param>
         public TypeMatcherAttribute(Type type)
         {
-            if (type == null)
-            {
-                throw new ArgumentNullException(nameof(type));
-            }
-
-            this.type = type;
+            this.type = type ?? throw new ArgumentNullException(nameof(type));
         }
 
-        internal Type Type => this.type;
+        internal Type? Type => this.type;
     }
 }


### PR DESCRIPTION
Aims to resolve #1418 , #1416 .

Does not extend to Moq.Tests.csproj, etc.

Nullable reference issues are enabled as warnings in Moq.csproj. Several issues have been left unresolved, as I lack the knowledge to resolve them correctly at this time (perhaps maintainers can help here, or else it may be acceptable to put this PR down as is and slowly pick off the remaining nullable reference warnings one at a time).

In general I have tried hard to avoid actually changing the code functionality, except where it seemed clear. So several simplifications could be made in follow up PRs.

See [the docs](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/nullable-analysis) for details of the nullability attributes I have used.