### PR TITLE
Avoid Castle's default trace logging

### DIFF
--- a/src/Moq/Interception/CastleProxyFactory.cs
+++ b/src/Moq/Interception/CastleProxyFactory.cs
@@ -14,6 +14,7 @@ using System.Runtime;
 using System.Text;
 #endif
 
+using Castle.Core.Logging;
 using Castle.DynamicProxy;
 
 using Moq.Internals;
@@ -33,7 +34,11 @@ namespace Moq
         public CastleProxyFactory()
         {
             this.generationOptions = new ProxyGenerationOptions { Hook = new IncludeObjectMethodsHook(), BaseTypeForInterfaceProxy = typeof(InterfaceProxy) };
-            this.generator = new ProxyGenerator();
+            this.generator = new ProxyGenerator()
+            {
+                Logger = NullLogger.Instance,
+            };
+
             this.classGenerators = new ConcurrentDictionary<string, ProxyGenerator>();
         }
 

--- a/src/Moq/Interception/CastleProxyFactory.cs
+++ b/src/Moq/Interception/CastleProxyFactory.cs
@@ -34,10 +34,8 @@ namespace Moq
         public CastleProxyFactory()
         {
             this.generationOptions = new ProxyGenerationOptions { Hook = new IncludeObjectMethodsHook(), BaseTypeForInterfaceProxy = typeof(InterfaceProxy) };
-            this.generator = new ProxyGenerator()
-            {
-                Logger = NullLogger.Instance,
-            };
+            this.generator = new ProxyGenerator();
+            (this.generator.Logger as TraceLogger)?.Level = LoggerLevel.Warn;
 
             this.classGenerators = new ConcurrentDictionary<string, ProxyGenerator>();
         }


### PR DESCRIPTION
Castle's trace logging can have severe perf impact as the log operations are all locking, so it can slow down significantly test runs that are parallelized.